### PR TITLE
iterator: don't expose iterator internals

### DIFF
--- a/crud/select/iterator.lua
+++ b/crud/select/iterator.lua
@@ -16,7 +16,7 @@ local DEFAULT_BATCH_SIZE = 100
 local Iterator = {}
 Iterator.__index = Iterator
 
-function Iterator.new(opts)
+local function new(opts)
     checks({
         space_name = 'string',
         space_format = 'table',
@@ -200,4 +200,6 @@ function Iterator:get()
     return object
 end
 
-return Iterator
+return {
+    new = new,
+}


### PR DESCRIPTION
There are no reasons to expose any iterator internals.
So if we provide a module that constructs some objects we don't
need to expose anything except constructor.
