### PR TITLE
introduce internal API for raw tuples

### DIFF
--- a/crud.lua
+++ b/crud.lua
@@ -25,25 +25,25 @@ crud.register = registry.add
 --- CRUD operations.
 -- @section crud
 
--- @refer insert.call
+-- @refer insert.object
 -- @function insert
-crud.insert = insert.call
+crud.insert = insert.object
 
 -- @refer get.call
 -- @function get
 crud.get = get.call
 
--- @refer replace.call
+-- @refer replace.object
 -- @function replace
-crud.replace = replace.call
+crud.replace = replace.object
 
 -- @refer update.call
 -- @function update
 crud.update = update.call
 
--- @refer upsert.call
+-- @refer upsert.object
 -- @function upsert
-crud.upsert = upsert.call
+crud.upsert = upsert.object
 
 -- @refer delete.call
 -- @function delete

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -5,6 +5,7 @@ local dev_checks = require('crud.common.dev_checks')
 local FlattenError = errors.new_class("FlattenError", {capture_stack = false})
 local UnflattenError = errors.new_class("UnflattenError", {capture_stack = false})
 local ParseOperationsError = errors.new_class('ParseOperationsError',  {capture_stack = false})
+local ShardingError = errors.new_class('ShardingError',  {capture_stack = false})
 
 local utils = {}
 
@@ -193,6 +194,16 @@ function utils.reverse_inplace(t)
         t[i], t[#t - i + 1] = t[#t - i + 1], t[i]
     end
     return t
+end
+
+function utils.get_bucket_id_fieldno(space, shard_index_name)
+    shard_index_name = shard_index_name or 'bucket_id'
+    local bucket_id_index = space.index[shard_index_name]
+    if bucket_id_index == nil then
+        return nil, ShardingError:new('%q index is not found', shard_index_name)
+    end
+
+    return bucket_id_index.parts[1].fieldno
 end
 
 return utils


### PR DESCRIPTION
This patch introduces internal API for insert, replace and upsert
raw tuples. To reduce amonut of changes this methods will be
exposed in next patches.
    
Also some kind of optimization is introduced. Before this patch we
call unflatten for object twice. This patch removes one of them.
This way reduce amount of Lua garbage.
    
Part of #6