### PR TITLE
introduce "use_tomap" option for pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Insert/replace/upsert methods now accept tuples.
   To process unflattened objects *_object methods are introduced.
 
+* `pairs` accepts `use_tomap` flag to return tuples or objects
+
 ### Changed
 
 * `checks` is disabled for internal functions by default

--- a/README.md
+++ b/README.md
@@ -304,12 +304,17 @@ crud.select('customers', {{'<=', 'age', 35}})
 You can iterate across a distributed space using the `crud.pairs` function.
 Its arguments are the same as [`crud.select`](#select) arguments,
 but negative `first` values aren't allowed.
+User could pass use_tomap flag (false by default) to iterate over flat tuples or objects.
 
 **Example:**
 
 ```lua
-for _, obj in crud.pairs('customers', {{'<=', 'age', 35}}) do
-    -- do smth with the object
+for _, tuple in crud.pairs('customers', {{'<=', 'age', 35}}, {use_tomap = false}) do
+    print(json.encode(tuple)) -- {5, 1172, 'Jack', 35}
+end
+
+for _, object in crud.pairs('customers', {{'<=', 'age', 35}}, {use_tomap = true}) do
+    print(json.encode(object)) -- {id = 5, name = 'Jack', bucket_id = 1172, age = 35}
 end
 ```
 

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -204,6 +204,7 @@ function select_module.pairs(space_name, user_conditions, opts)
         first = '?number',
         timeout = '?number',
         batch_size = '?number',
+        use_tomap = '?boolean',
     })
 
     opts = opts or {}
@@ -233,12 +234,15 @@ function select_module.pairs(space_name, user_conditions, opts)
             error(string.format("Failed to get next object: %s", err))
         end
 
-        local obj, err = utils.unflatten(tuple, iter.space_format)
-        if err ~= nil then
-            error(string.format("Failed to unflatten next object: %s", err))
+        local result = tuple
+        if opts.use_tomap == true then
+            result, err = utils.unflatten(tuple, iter.space_format)
+            if err ~= nil then
+                error(string.format("Failed to unflatten next object: %s", err))
+            end
         end
 
-        return iter, obj
+        return iter, result
     end
 
     return gen, nil, iter

--- a/test/integration/pairs_test.lua
+++ b/test/integration/pairs_test.lua
@@ -127,8 +127,15 @@ add('test_pairs_no_conditions', function(g)
 
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
-    -- no after
-    local objects, err = g.cluster.main_server.net_box:eval([[
+    local raw_rows = {
+        {1, 477, 'Elizabeth', 'Jackson', 12, 'New York'},
+        {2, 401, 'Mary', 'Brown', 46, 'Los Angeles'},
+        {3, 2804, 'David', 'Smith', 33, 'Los Angeles'},
+        {4, 1161, 'William', 'White', 81, 'Chicago'},
+    }
+
+    -- without conditions and options
+    local objects = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
         local objects = {}
@@ -138,8 +145,33 @@ add('test_pairs_no_conditions', function(g)
 
         return objects
     ]])
+    t.assert_equals(objects, raw_rows)
 
-    t.assert_equals(err, nil)
+    -- with use_tomap=false (the raw tuples returned)
+    local objects = g.cluster.main_server.net_box:eval([[
+        local crud = require('crud')
+
+        local objects = {}
+        for _, object in crud.pairs('customers', nil, {use_tomap = false}) do
+            table.insert(objects, object)
+        end
+
+        return objects
+    ]])
+    t.assert_equals(objects, raw_rows)
+
+    -- no after
+    local objects = g.cluster.main_server.net_box:eval([[
+        local crud = require('crud')
+
+        local objects = {}
+        for _, object in crud.pairs('customers', nil, {use_tomap = true}) do
+            table.insert(objects, object)
+        end
+
+        return objects
+    ]])
+
     t.assert_equals(objects, customers)
 
     -- after obj 2
@@ -150,7 +182,7 @@ add('test_pairs_no_conditions', function(g)
         local after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {after = after}) do
+        for _, object in crud.pairs('customers', nil, {after = after, use_tomap = true}) do
             table.insert(objects, object)
         end
 
@@ -168,7 +200,7 @@ add('test_pairs_no_conditions', function(g)
         local after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {after = after}) do
+        for _, object in crud.pairs('customers', nil, {after = after, use_tomap = true}) do
             table.insert(objects, object)
         end
 
@@ -209,7 +241,7 @@ add('test_ge_condition_with_index', function(g)
         local conditions = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true}) do
             table.insert(objects, object)
         end
 
@@ -227,7 +259,7 @@ add('test_ge_condition_with_index', function(g)
         local conditions, after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = after}) do
+        for _, object in crud.pairs('customers', conditions, {after = after, use_tomap = true}) do
             table.insert(objects, object)
         end
 
@@ -268,7 +300,7 @@ add('test_le_condition_with_index', function(g)
         local conditions = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true}) do
             table.insert(objects, object)
         end
 
@@ -286,7 +318,7 @@ add('test_le_condition_with_index', function(g)
         local conditions, after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = after}) do
+        for _, object in crud.pairs('customers', conditions, {after = after, use_tomap = true}) do
             table.insert(objects, object)
         end
 


### PR DESCRIPTION
This patch introduces "use_tomap" (`false` by default) option to
    convert raw selected tuples to objects.
    
 Usage:
```lua
-- returns raw tuples
crud.pairs('customers', {{'=', 'id', 1}}, {use_tomap = false})
    
-- returns objects
crud.pairs('customers', {{'=', 'id', 1}}, {use_tomap = true})
```

Part of #6