### PR TITLE
fix typos in error messages and comments

### DIFF
--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -18,7 +18,7 @@ local function call_delete_on_storage(space_name, key)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, DeleteError:new("Space %q doesn't exists", space_name)
+        return nil, DeleteError:new("Space %q doesn't exist", space_name)
     end
 
     local tuple = space:delete(key)
@@ -58,7 +58,7 @@ function delete.call(space_name, key, opts)
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then
-        return nil, DeleteError:new("Space %q doesn't exists", space_name)
+        return nil, DeleteError:new("Space %q doesn't exist", space_name)
     end
 
     if box.tuple.is(key) then

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -18,7 +18,7 @@ local function call_get_on_storage(space_name, key)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, GetError:new("Space %q doesn't exists", space_name)
+        return nil, GetError:new("Space %q doesn't exist", space_name)
     end
 
     local tuple = space:get(key)
@@ -31,7 +31,7 @@ function get.init()
     })
 end
 
---- Get tuple from the specifed space by key
+--- Get tuple from the specified space by key
 --
 -- @function call
 --
@@ -57,7 +57,7 @@ function get.call(space_name, key, opts)
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then
-        return nil, GetError:new("Space %q doesn't exists", space_name)
+        return nil, GetError:new("Space %q doesn't exist", space_name)
     end
 
     if box.tuple.is(key) then

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -18,7 +18,7 @@ local function call_insert_on_storage(space_name, tuple)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, InsertError:new("Space %q doesn't exists", space_name)
+        return nil, InsertError:new("Space %q doesn't exist", space_name)
     end
 
     return space:insert(tuple)
@@ -30,7 +30,7 @@ function insert.init()
     })
 end
 
---- Inserts tuple to the specifed space
+--- Inserts tuple to the specified space
 --
 -- @function call
 --
@@ -59,7 +59,7 @@ function insert.call(space_name, obj, opts)
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then
-        return nil, InsertError:new("Space %q doesn't exists", space_name)
+        return nil, InsertError:new("Space %q doesn't exist", space_name)
     end
     local space_format = space:format()
 

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -18,7 +18,7 @@ local function call_replace_on_storage(space_name, tuple)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, ReplaceError:new("Space %q doesn't exists", space_name)
+        return nil, ReplaceError:new("Space %q doesn't exist", space_name)
     end
 
     return space:replace(tuple)
@@ -30,7 +30,7 @@ function replace.init()
     })
 end
 
---- Insert or replace a tuple in the specifed space
+--- Insert or replace a tuple in the specified space
 --
 -- @function call
 --
@@ -56,11 +56,11 @@ function replace.call(space_name, obj, opts)
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then
-        return nil, ReplaceError:new("Space %q doesn't exists", space_name)
+        return nil, ReplaceError:new("Space %q doesn't exist", space_name)
     end
 
     local space_format = space:format()
-    -- compute default buckect_id
+    -- compute default bucket_id
     local tuple, err = utils.flatten(obj, space_format)
     if err ~= nil then
         return nil, ReplaceError:new("Object is specified in bad format: %s", err)

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -35,12 +35,12 @@ local function call_select_on_storage(space_name, index_id, conditions, opts)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, SelectError:new("Space %s doesn't exists", space_name)
+        return nil, SelectError:new("Space %s doesn't exist", space_name)
     end
 
     local index = space.index[index_id]
     if index == nil then
-        return nil, SelectError:new("Index with ID %s doesn't exists", index_id)
+        return nil, SelectError:new("Index with ID %s doesn't exist", index_id)
     end
 
     local filter_func, err = select_filters.gen_func(space, conditions, {
@@ -149,7 +149,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
 
     local space = utils.get_space(space_name, replicasets)
     if space == nil then
-        return nil, SelectError:new("Space %s doesn't exists", space_name)
+        return nil, SelectError:new("Space %s doesn't exist", space_name)
     end
     local space_format = space:format()
 

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -18,7 +18,7 @@ local function call_update_on_storage(space_name, key, operations)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, UpdateError:new("Space %q doesn't exists", space_name)
+        return nil, UpdateError:new("Space %q doesn't exist", space_name)
     end
 
     local tuple = space:update(key, operations)
@@ -31,7 +31,7 @@ function update.init()
     })
 end
 
---- Updates tuple in the specifed space
+--- Updates tuple in the specified space
 --
 -- @function call
 --
@@ -61,7 +61,7 @@ function update.call(space_name, key, user_operations, opts)
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then
-        return nil, UpdateError:new("Space %q doesn't exists", space_name)
+        return nil, UpdateError:new("Space %q doesn't exist", space_name)
     end
     local space_format = space:format()
 

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -18,7 +18,7 @@ local function call_upsert_on_storage(space_name, tuple, operations)
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, UpsertError:new("Space %q doesn't exists", space_name)
+        return nil, UpsertError:new("Space %q doesn't exist", space_name)
     end
 
     return space:upsert(tuple, operations)
@@ -60,7 +60,7 @@ function upsert.call(space_name, obj, user_operations, opts)
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then
-        return nil, UpsertError:new("Space %q doesn't exists", space_name)
+        return nil, UpsertError:new("Space %q doesn't exist", space_name)
     end
 
     local space_format = space:format()
@@ -69,7 +69,7 @@ function upsert.call(space_name, obj, user_operations, opts)
         return nil, UpsertError:new("Wrong operations are specified: %s", err)
     end
 
-    -- compute default buckect_id
+    -- compute default bucket_id
     local tuple, err = utils.flatten(obj, space_format)
     if err ~= nil then
         return nil, UpsertError:new("Object is specified in bad format: %s", err)

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -116,7 +116,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, "Space non_existent_space doesn't exists")
+    t.assert_str_contains(err.err, "Space non_existent_space doesn't exist")
 end)
 
 add('test_select_all', function(g)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -89,7 +89,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exists')
+    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exist')
 
     -- get
     local obj, err = g.cluster.main_server.net_box:eval([[
@@ -98,7 +98,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exists')
+    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exist')
 
     -- update
     local obj, err = g.cluster.main_server.net_box:eval([[
@@ -107,7 +107,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exists')
+    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exist')
 
     -- delete
     local obj, err = g.cluster.main_server.net_box:eval([[
@@ -116,7 +116,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exists')
+    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exist')
 
     -- replace
     local obj, err = g.cluster.main_server.net_box:eval([[
@@ -125,7 +125,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exists')
+    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exist')
 
     -- upsert
     local obj, err = g.cluster.main_server.net_box:eval([[
@@ -134,7 +134,7 @@ add('test_non_existent_space', function(g)
     ]])
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exists')
+    t.assert_str_contains(err.err, 'Space "non_existent_space" doesn\'t exist')
 end)
 
 add('test_insert_get', function(g)


### PR DESCRIPTION
  * `doesn\'t exists` -> `doesn\'t exist`
  * `specifed` -> `specified`
 * `buckect_id` -> `bucket_id`

