### PR TITLE
added show_bucket_id opt to simple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build.luarocks/
 myapp/
 **.snap
 **.xlog
+.vscode
+.history

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -43,6 +43,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] object
 -- @treturn[2] nil
@@ -51,6 +53,7 @@ end
 function delete.call(space_name, key, opts)
     checks('string', '?', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}
@@ -81,8 +84,21 @@ function delete.call(space_name, key, opts)
     end
 
     local tuple = results[replicaset.uuid]
+    local metadata = table.copy(space:format())
+
+    if not opts.show_bucket_id then
+        local bucket_id_fieldno, err = utils.get_bucket_id_fieldno(space)
+        if err ~= nil then
+            return nil, err
+        end
+        if tuple then
+            table.remove(tuple, bucket_id_fieldno)
+        end
+        table.remove(metadata, bucket_id_fieldno)
+    end
+
     return {
-        metadata = table.copy(space:format()),
+        metadata = metadata,
         rows = {tuple},
     }
 end

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -43,6 +43,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] object
 -- @treturn[2] nil
@@ -51,6 +53,7 @@ end
 function get.call(space_name, key, opts)
     checks('string', '?', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}
@@ -81,8 +84,21 @@ function get.call(space_name, key, opts)
     end
 
     local tuple = results[replicaset.uuid]
+    local metadata = table.copy(space:format())
+
+    if not opts.show_bucket_id then
+        local bucket_id_fieldno, err = utils.get_bucket_id_fieldno(space)
+        if err ~= nil then
+            return nil, err
+        end
+            if tuple then
+                table.remove(tuple, bucket_id_fieldno)
+            end
+            table.remove(metadata, bucket_id_fieldno)
+    end
+
     return {
-        metadata = table.copy(space:format()),
+        metadata = metadata,
         rows = {tuple},
     }
 end

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -42,6 +42,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] tuple
 -- @treturn[2] nil
@@ -50,6 +52,7 @@ end
 function insert.tuple(space_name, tuple, opts)
     checks('string', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}
@@ -88,8 +91,17 @@ function insert.tuple(space_name, tuple, opts)
     end
 
     local tuple = results[replicaset.uuid]
+    local metadata = table.copy(space_format)
+
+    if not opts.show_bucket_id then
+        if tuple then
+            table.remove(tuple, bucket_id_fieldno)
+        end
+        table.remove(metadata, bucket_id_fieldno)
+    end
+
     return {
-        metadata = table.copy(space_format),
+        metadata = metadata,
         rows = {tuple},
     }
 end
@@ -106,6 +118,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] object
 -- @treturn[2] nil
@@ -114,6 +128,7 @@ end
 function insert.object(space_name, obj, opts)
     checks('string', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -99,7 +99,7 @@ function replace.tuple(space_name, tuple, opts)
         end
         table.remove(metadata, bucket_id_fieldno)
     end
-    
+
     return {
         metadata = metadata,
         rows = {tuple},

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -42,6 +42,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] object
 -- @treturn[2] nil
@@ -50,6 +52,7 @@ end
 function replace.tuple(space_name, tuple, opts)
     checks('string', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}
@@ -88,8 +91,17 @@ function replace.tuple(space_name, tuple, opts)
     end
 
     local tuple = results[replicaset.uuid]
+    local metadata = table.copy(space:format())
+
+    if not opts.show_bucket_id then
+        if tuple then
+            table.remove(tuple, bucket_id_fieldno)
+        end
+        table.remove(metadata, bucket_id_fieldno)
+    end
+    
     return {
-        metadata = table.copy(space:format()),
+        metadata = metadata,
         rows = {tuple},
     }
 end
@@ -114,6 +126,7 @@ end
 function replace.object(space_name, obj, opts)
     checks('string', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -47,6 +47,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] object
 -- @treturn[2] nil
@@ -55,6 +57,7 @@ end
 function update.call(space_name, key, user_operations, opts)
     checks('string', '?', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}
@@ -90,8 +93,21 @@ function update.call(space_name, key, user_operations, opts)
     end
 
     local tuple = results[replicaset.uuid]
+    local metadata = table.copy(space_format)
+
+    if not opts.show_bucket_id then
+        local bucket_id_fieldno, err = utils.get_bucket_id_fieldno(space)
+        if err ~= nil then
+            return nil, err
+        end
+        if tuple then
+            table.remove(tuple, bucket_id_fieldno)
+        end
+        table.remove(metadata, bucket_id_fieldno)
+    end
+
     return {
-        metadata = table.copy(space_format),
+        metadata = metadata,
         rows = {tuple},
     }
 end

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -46,6 +46,8 @@ end
 --
 -- @tparam ?number opts.timeout
 --  Function call timeout
+-- @tparam ?number opts.show_bucket_id
+--  Flag indicating whether to add bucket_id into return dataset or not (default is false)
 --
 -- @return[1] tuple
 -- @treturn[2] nil
@@ -54,6 +56,7 @@ end
 function upsert.tuple(space_name, tuple, user_operations, opts)
     checks('string', '?', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}
@@ -97,9 +100,18 @@ function upsert.tuple(space_name, tuple, user_operations, opts)
         return nil, UpsertError:new("Failed to upsert: %s", err)
     end
 
+    local metadata = table.copy(space_format)
+
+    if not opts.show_bucket_id then
+        if tuple then
+            table.remove(tuple, bucket_id_fieldno)
+        end
+        table.remove(metadata, bucket_id_fieldno)
+    end
+
     -- upsert always returns nil
     return {
-        metadata = table.copy(space_format),
+        metadata = metadata,
         rows = {},
     }
 end
@@ -128,6 +140,7 @@ end
 function upsert.object(space_name, obj, user_operations, opts)
     checks('string', '?', 'table', {
         timeout = '?number',
+        show_bucket_id = '?boolean',
     })
 
     opts = opts or {}

--- a/test/integration/pairs_test.lua
+++ b/test/integration/pairs_test.lua
@@ -87,7 +87,7 @@ local function insert_customers(g, customers)
         local result, err = g.cluster.main_server.net_box:eval([[
             local crud = require('crud')
             return crud.insert_object('customers', ...)
-        ]],{customer})
+        ]],{customer, {show_bucket_id = true}})
 
         t.assert_equals(err, nil)
 

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -82,7 +82,7 @@ local function insert_customers(g, customers)
         local result, err = g.cluster.main_server.net_box:eval([[
             local crud = require('crud')
             return crud.insert_object('customers', ...)
-        ]],{customer})
+        ]],{customer, {show_bucket_id = true}})
 
         t.assert_equals(err, nil)
 

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -149,7 +149,11 @@ add('test_non_existent_space', function(g)
     -- upsert
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
-        return crud.upsert_object('non_existent_space', {0, box.NULL, 'Fedor', 59}, {{'+', 'age', 1}}, {show_bucket_id = true})
+        return crud.upsert_object(
+            'non_existent_space', 
+            {0, box.NULL, 'Fedor', 59}, {{'+', 'age', 1}}, 
+            {show_bucket_id = true}
+        )
     ]])
 
     t.assert_equals(result, nil)
@@ -158,7 +162,11 @@ add('test_non_existent_space', function(g)
     -- upsert_object
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
-        return crud.upsert_object('non_existent_space', {id = 0, name = 'Fedor', age = 59}, {{'+', 'age', 1}}, {show_bucket_id = true})
+        return crud.upsert_object(
+            'non_existent_space', 
+            {id = 0, name = 'Fedor', age = 59}, {{'+', 'age', 1}}, 
+            {show_bucket_id = true}
+        )
     ]])
 
     t.assert_equals(result, nil)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -150,8 +150,8 @@ add('test_non_existent_space', function(g)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
         return crud.upsert_object(
-            'non_existent_space', 
-            {0, box.NULL, 'Fedor', 59}, {{'+', 'age', 1}}, 
+            'non_existent_space',
+            {0, box.NULL, 'Fedor', 59}, {{'+', 'age', 1}},
             {show_bucket_id = true}
         )
     ]])
@@ -163,8 +163,8 @@ add('test_non_existent_space', function(g)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
         return crud.upsert_object(
-            'non_existent_space', 
-            {id = 0, name = 'Fedor', age = 59}, {{'+', 'age', 1}}, 
+            'non_existent_space',
+            {id = 0, name = 'Fedor', age = 59}, {{'+', 'age', 1}},
             {show_bucket_id = true}
         )
     ]])


### PR DESCRIPTION
This patch aplies to the following methods:
crud.delete(), crud.get(), crud.insert(), crud.update(), crud.upsert(), crud.replace()

Whats new:
1. Added new option - show_bucket_id
2. By default show_bucket_id = false which means absense of bucket_id field both in returning data and metadata.
3. Added set of tests for show_bucket_id = true and show_bucket_id = false cases