### PR TITLE
replace "sharding key" to "bucket_id" in error message

### DIFF
--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -73,7 +73,7 @@ function insert.tuple(space_name, tuple, opts)
     end
 
     if tuple[bucket_id_fieldno] ~= nil then
-        return nil, InsertError:new("Unexpected value (%s) at field %s (sharding key)",
+        return nil, InsertError:new("Unexpected value (%s) at field %s (bucket_id)",
                 tuple[bucket_id_fieldno], bucket_id_fieldno)
     end
 

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -73,7 +73,7 @@ function replace.tuple(space_name, tuple, opts)
     end
 
     if tuple[bucket_id_fieldno] ~= nil then
-        return nil, ReplaceError:new("Unexpected value (%s) at field %s (sharding key)",
+        return nil, ReplaceError:new("Unexpected value (%s) at field %s (bucket_id)",
                 tuple[bucket_id_fieldno], bucket_id_fieldno)
     end
 

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -83,7 +83,7 @@ function upsert.tuple(space_name, tuple, user_operations, opts)
     end
 
     if tuple[bucket_id_fieldno] ~= nil then
-        return nil, UpsertError:new("Unexpected value (%s) at field %s (sharding key)",
+        return nil, UpsertError:new("Unexpected value (%s) at field %s (bucket_id)",
                 tuple[bucket_id_fieldno], bucket_id_fieldno)
     end
 


### PR DESCRIPTION
Initially we expect that first field of "bucket_id" index is
empty as user shouldn't affect internal processes in our system.
So we return an error in case then this field in tuple is not
empty.

But some logic error in error message was done. When we say
"sharing key" we mean a part of tuple (currently primary key for
bucket_id calculation). May be "shard key" is more vshard-agnostic
varian. So to avoid over complication let's use "bucket_id" as in
vshard.

