### PR TITLE
Select: after option is tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `checks` is disabled for internal functions by default
 * `limit` option is renamed to `first`
 * Reverse pagination (negative `first`) is supported
+* `after` option accepts a tuple
 
 ## [0.1.0] - 2020-09-23
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ where:
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
-Returns metadata and array contains one deleted row, error.
+Returns metadata and array contains one deleted row (empty for vinyl), error.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ where:
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
-Returns inserted rows and metadata or nil with error.
+Returns metadata and array contains one inserted row, error.
 
 **Example:**
 
@@ -76,7 +76,7 @@ where:
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
-Returns object, error.
+Returns metadata and array contains one row, error.
 
 **Example:**
 
@@ -107,7 +107,7 @@ where:
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
-Returns updated object, error.
+Returns metadata and array contains one updated row, error.
 
 **Example:**
 
@@ -137,7 +137,7 @@ where:
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
-Returns deleted object, error.
+Returns metadata and array contains one deleted row, error.
 
 **Example:**
 
@@ -264,11 +264,11 @@ where:
   * `first` (`?number`) - the maximum count of the objects to return.
      If negative value is specified, the last objects are returned
      (`after` option is required in this case).
-  * `after` (`?table`) - object after which objects should be selected
+  * `after` (`?table`) - tuple after which objects should be selected
   * `batch_size` (`?number`) - number of tuples to process per one request to storage
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
-Returns selected objects, error.
+Returns metadata and array of rows, error.
 
 #### Select conditions
 

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -149,13 +149,10 @@ local function build_select_iterator(space_name, user_conditions, opts)
     end
     local space_format = space:format()
 
-    -- set after tuple
-    local after_tuple = utils.flatten(opts.after, space_format)
-
     -- plan select
     local plan, err = select_plan.new(space, conditions, {
         first = opts.first,
-        after_tuple = after_tuple,
+        after_tuple = opts.after,
     })
 
     if err ~= nil then

--- a/test/integration/pairs_test.lua
+++ b/test/integration/pairs_test.lua
@@ -3,7 +3,9 @@ local fio = require('fio')
 local t = require('luatest')
 local g_memtx = t.group('pairs_memtx')
 local g_vinyl = t.group('pairs_vinyl')
+
 local crud = require('crud')
+local crud_utils = require('crud.common.utils')
 
 local helpers = require('test.helper')
 
@@ -48,6 +50,8 @@ local function before_all(g, engine)
     })
     g.engine = engine
     g.cluster:start()
+
+    g.space_format = g.cluster.servers[2].net_box.space.customers:format()
 end
 
 local function after_all(g)
@@ -175,7 +179,7 @@ add('test_pairs_no_conditions', function(g)
     t.assert_equals(objects, customers)
 
     -- after obj 2
-    local after = customers[2]
+    local after = crud_utils.flatten(customers[2], g.space_format)
     local objects, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -193,7 +197,7 @@ add('test_pairs_no_conditions', function(g)
     t.assert_equals(objects, get_by_ids(customers, {3, 4}))
 
     -- after obj 4 (last)
-    local after = customers[4]
+    local after = crud_utils.flatten(customers[4], g.space_format)
     local objects, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -252,7 +256,7 @@ add('test_ge_condition_with_index', function(g)
     t.assert_equals(objects, get_by_ids(customers, {3, 2, 4})) -- in age order
 
     -- after obj 3
-    local after = customers[3]
+    local after = crud_utils.flatten(customers[3], g.space_format)
     local objects, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -311,7 +315,7 @@ add('test_le_condition_with_index', function(g)
     t.assert_equals(objects, get_by_ids(customers, {3, 1})) -- in age order
 
     -- after obj 3
-    local after = customers[3]
+    local after = crud_utils.flatten(customers[3], g.space_format)
     local objects, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -3,7 +3,9 @@ local fio = require('fio')
 local t = require('luatest')
 local g_memtx = t.group('select_memtx')
 local g_vinyl = t.group('select_vinyl')
+
 local crud = require('crud')
+local crud_utils = require('crud.common.utils')
 
 local helpers = require('test.helper')
 
@@ -48,6 +50,8 @@ local function before_all(g, engine)
     })
     g.engine = engine
     g.cluster:start()
+
+    g.space_format = g.cluster.servers[2].net_box.space.customers:format()
 end
 
 g_memtx.before_all = function() before_all(g_memtx, 'memtx') end
@@ -174,7 +178,7 @@ add('test_select_all', function(g)
     t.assert_equals(objects, customers)
 
     -- after obj 2
-    local after = customers[2]
+    local after = crud_utils.flatten(customers[2], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -189,7 +193,7 @@ add('test_select_all', function(g)
     t.assert_equals(objects, get_by_ids(customers, {3, 4}))
 
     -- after obj 4 (last)
-    local after = customers[4]
+    local after = crud_utils.flatten(customers[4], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -308,7 +312,7 @@ add('test_negative_first', function(g)
     -- no conditions
     -- first -3 after 5 (batch_size is 1)
     local first = -3
-    local after = customers[5]
+    local after = crud_utils.flatten(customers[5], g.space_format)
     local batch_size = 1
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
@@ -333,7 +337,7 @@ add('test_negative_first', function(g)
         {'>=', 'id', 2},
     }
     local first = -2
-    local after = customers[5]
+    local after = crud_utils.flatten(customers[5], g.space_format)
     local batch_size = 1
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
@@ -358,7 +362,7 @@ add('test_negative_first', function(g)
         {'>=', 'age', 22},
     }
     local first = -2
-    local after = customers[5]
+    local after = crud_utils.flatten(customers[5], g.space_format)
     local batch_size = 1
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
@@ -383,7 +387,7 @@ add('test_negative_first', function(g)
         {'<=', 'id', 6},
     }
     local first = -2
-    local after = customers[5]
+    local after = crud_utils.flatten(customers[5], g.space_format)
     local batch_size = 1
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
@@ -408,7 +412,7 @@ add('test_negative_first', function(g)
         {'<=', 'age', 66},
     }
     local first = -2
-    local after = customers[5]
+    local after = crud_utils.flatten(customers[5], g.space_format)
     local batch_size = 1
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
@@ -552,7 +556,7 @@ add('test_eq_condition_with_index', function(g)
     t.assert_equals(objects, get_by_ids(customers, {1, 3, 5, 7})) -- in id order
 
     -- after obj 3
-    local after = customers[3]
+    local after = crud_utils.flatten(customers[3], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -607,7 +611,7 @@ add('test_ge_condition_with_index', function(g)
     t.assert_equals(objects, get_by_ids(customers, {3, 2, 4})) -- in age order
 
     -- after obj 3
-    local after = customers[3]
+    local after = crud_utils.flatten(customers[3], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -662,7 +666,7 @@ add('test_le_condition_with_index',function(g)
     t.assert_equals(objects, get_by_ids(customers, {3, 1})) -- in age order
 
     -- after obj 3
-    local after = customers[3]
+    local after = crud_utils.flatten(customers[3], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -717,7 +721,7 @@ add('test_lt_condition_with_index', function(g)
     t.assert_equals(objects, get_by_ids(customers, {1})) -- in age order
 
     -- after obj 1
-    local after = customers[1]
+    local after = crud_utils.flatten(customers[1], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -777,7 +781,7 @@ add('test_multiple_conditions', function(g)
     t.assert_equals(objects, get_by_ids(customers, {5, 2})) -- in age order
 
     -- after obj 5
-    local after = customers[5]
+    local after = crud_utils.flatten(customers[5], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 
@@ -832,7 +836,7 @@ add('test_composite_index', function(g)
     t.assert_equals(objects, get_by_ids(customers, {2, 1, 4})) -- in full_name order
 
     -- after obj 2
-    local after = customers[2]
+    local after = crud_utils.flatten(customers[2], g.space_format)
     local result, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
 


### PR DESCRIPTION
Since all operations return rows, it seems logical to use row (a.k.a. tuple) as `after` value for `select` and `pairs`.

- [x] Tests
- [x] Changelog
- [x] Documentation
