### PR TITLE
Allow to specify custom bucket ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* `bucket_id` option for all operations to specify custom bucket ID.
+  For operations that accepts tuple/object bucket ID can be specified as
+  tuple/object field as well as `opts.bucket_id` value.
+
 ### Fixed
 
 * Select by primary index name

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ to make `crud` functions callable via `net.box`.
 **Notes:**
 
 * A space should have a format.
-* `bucket_id` is computed as `vshard.router.bucket_id_strcrc32(key)`,
+* By default, `bucket_id` is computed as `vshard.router.bucket_id_strcrc32(key)`,
   where `key` is the primary key value.
+  Custom bucket ID can be specified as `opts.bucket_id` for each operation.
+  For operations that accepts tuple/object bucket ID can be specified as
+  tuple/object field as well as `opts.bucket_id` value.
 
 ### Insert
 
@@ -35,6 +38,7 @@ where:
 * `tuple` / `object` (`table`) - tuple/object to insert
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
 
 Returns metadata and array contains one inserted row, error.
 
@@ -77,6 +81,7 @@ where:
 * `key` (`any`) - primary key value
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
 
 Returns metadata and array contains one row, error.
 
@@ -108,6 +113,7 @@ where:
 * `operations` (`table`) - update [operations](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/#box-space-update)
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
 
 Returns metadata and array contains one updated row, error.
 
@@ -138,6 +144,7 @@ where:
 * `key` (`any`) - primary key value
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
 
 Returns metadata and array contains one deleted row (empty for vinyl), error.
 
@@ -170,6 +177,7 @@ where:
 * `tuple` / `object` (`table`) - tuple/object to insert or replace exist one
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
 
 Returns inserted or replaced rows and metadata or nil with error.
 
@@ -216,6 +224,7 @@ where:
 * `operations` (`table`) - update [operations](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/#box-space-update) if there is an existing tuple which matches the key fields of tuple
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
 
 Returns metadata and empty array of rows or nil, error.
 
@@ -269,6 +278,8 @@ where:
   * `after` (`?table`) - tuple after which objects should be selected
   * `batch_size` (`?number`) - number of tuples to process per one request to storage
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `bucket_id` (`?number|cdata`) - bucket ID
+    (is used when select by full primary key is performed)
 
 Returns metadata and array of rows, error.
 

--- a/crud/common/sharding.lua
+++ b/crud/common/sharding.lua
@@ -1,0 +1,54 @@
+local vshard = require('vshard')
+local errors = require('errors')
+
+local BucketIDError = errors.new_class("BucketIDError", {capture_stack = false})
+
+local utils = require('crud.common.utils')
+
+local sharding = {}
+
+function sharding.key_get_bucket_id(key, specified_bucket_id)
+    if specified_bucket_id ~= nil then
+        return specified_bucket_id
+    end
+
+    return vshard.router.bucket_id_strcrc32(key)
+end
+
+function sharding.tuple_get_bucket_id(tuple, space, specified_bucket_id)
+    if specified_bucket_id ~= nil then
+        return specified_bucket_id
+    end
+
+    local key = utils.extract_key(tuple, space.index[0].parts)
+    return sharding.key_get_bucket_id(key)
+end
+
+function sharding.tuple_set_and_return_bucket_id(tuple, space, specified_bucket_id)
+    local bucket_id_fieldno, err = utils.get_bucket_id_fieldno(space)
+    if err ~= nil then
+        return nil, BucketIDError:new("Failed to get bucket ID fielno:", err)
+    end
+
+    if specified_bucket_id ~= nil then
+        if tuple[bucket_id_fieldno] == nil then
+            tuple[bucket_id_fieldno] = specified_bucket_id
+        else
+            if tuple[bucket_id_fieldno] ~= specified_bucket_id then
+                return nil, BucketIDError:new(
+                    "Tuple and opts.bucket_id contain different bucket_id values: %s and %s",
+                    tuple[bucket_id_fieldno], specified_bucket_id
+                )
+            end
+        end
+    end
+
+    if tuple[bucket_id_fieldno] == nil then
+        tuple[bucket_id_fieldno] = sharding.tuple_get_bucket_id(tuple, space)
+    end
+
+    local bucket_id = tuple[bucket_id_fieldno]
+    return bucket_id
+end
+
+return sharding

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -4,6 +4,7 @@ local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local utils = require('crud.common.utils')
+local sharding = require('crud.common.sharding')
 local dev_checks = require('crud.common.dev_checks')
 
 local GetError = errors.new_class('Get',  {capture_stack = false})
@@ -41,6 +42,10 @@ end
 -- @tparam ?number opts.timeout
 --  Function call timeout
 --
+-- @tparam ?number opts.bucket_id
+--  Bucket ID
+--  (by default, it's vshard.router.bucket_id_strcrc32 of primary key)
+--
 -- @return[1] object
 -- @treturn[2] nil
 -- @treturn[2] table Error description
@@ -48,6 +53,7 @@ end
 function get.call(space_name, key, opts)
     checks('string', '?', {
         timeout = '?number',
+        bucket_id = '?number|cdata',
     })
 
     opts = opts or {}
@@ -61,7 +67,7 @@ function get.call(space_name, key, opts)
         key = key:totable()
     end
 
-    local bucket_id = vshard.router.bucket_id_strcrc32(key)
+    local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
     -- We don't use callro() here, because if the replication is
     -- async, there could be a lag between master and replica, so a
     -- connector which sequentially calls put() and then get() may get

--- a/test/integration/custom_bucket_id_test.lua
+++ b/test/integration/custom_bucket_id_test.lua
@@ -1,0 +1,647 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g_memtx = t.group('custom_bucket_id_memtx')
+local g_vinyl = t.group('custom_bucket_id_vinyl')
+
+local crud_utils = require('crud.common.utils')
+
+local helpers = require('test.helper')
+
+local function before_all(g, engine)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_simple_operations'),
+        use_vshard = true,
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                alias = 'router',
+                roles = { 'customers-router' },
+                servers = {
+                    { instance_uuid = helpers.uuid('a', 1), alias = 'router' },
+                },
+            },
+            {
+                uuid = helpers.uuid('b'),
+                alias = 's-1',
+                roles = { 'customers-storage' },
+                servers = {
+                    { instance_uuid = helpers.uuid('b', 1), alias = 's1-master' },
+                    { instance_uuid = helpers.uuid('b', 2), alias = 's1-replica' },
+                },
+            },
+            {
+                uuid = helpers.uuid('c'),
+                alias = 's-2',
+                roles = { 'customers-storage' },
+                servers = {
+                    { instance_uuid = helpers.uuid('c', 1), alias = 's2-master' },
+                    { instance_uuid = helpers.uuid('c', 2), alias = 's2-replica' },
+                },
+            }
+        },
+        env = {
+            ['ENGINE'] = engine,
+        },
+    })
+    g.engine = engine
+    g.cluster:start()
+
+    g.space_format = g.cluster.servers[2].net_box.space.customers:format()
+end
+
+g_memtx.before_all = function() before_all(g_memtx, 'memtx') end
+g_vinyl.before_all = function() before_all(g_vinyl, 'vinyl') end
+
+local function after_all(g)
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+g_memtx.after_all = function() after_all(g_memtx) end
+g_vinyl.after_all = function() after_all(g_vinyl) end
+
+local function before_each(g)
+    for _, server in ipairs(g.cluster.servers) do
+        server.net_box:eval([[
+            local space = box.space.customers
+            if space ~= nil and not box.cfg.read_only then
+                space:truncate()
+            end
+        ]])
+    end
+end
+
+g_memtx.before_each(function() before_each(g_memtx) end)
+g_vinyl.before_each(function() before_each(g_vinyl) end)
+
+local function add(name, fn)
+    g_memtx[name] = fn
+    g_vinyl[name] = fn
+end
+
+local function get_other_storage_bucket_id(g, key)
+    local res_bucket_id, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
+
+        local key = ...
+        local bucket_id = vshard.router.bucket_id_strcrc32(key)
+
+        local replicasets = vshard.router.routeall()
+
+        local other_replicaset_uuid
+        for replicaset_uuid, replicaset in pairs(replicasets) do
+            local stat, err = replicaset:callrw('vshard.storage.bucket_stat', {bucket_id})
+
+            if err ~= nil and err.name == 'WRONG_BUCKET' then
+                other_replicaset_uuid = replicaset_uuid
+                break
+            end
+
+            if err ~= nil then
+                return nil, string.format(
+                    'vshard.storage.bucket_stat returned unexpected error: %s',
+                    require('json').encode(err)
+                )
+            end
+        end
+
+        if other_replicaset_uuid == nil then
+            return nil, 'Other replicaset is not found'
+        end
+
+        local other_replicaset = replicasets[other_replicaset_uuid]
+        if other_replicaset == nil then
+            return nil, string.format('Replicaset %s not found', other_replicaset_uuid)
+        end
+
+        local buckets_info = other_replicaset:callrw('vshard.storage.buckets_info')
+        local res_bucket_id = next(buckets_info)
+
+        return res_bucket_id
+    ]], {key})
+
+    t.assert(res_bucket_id ~= nil, err)
+    return res_bucket_id
+end
+
+local function check_get(g, space_name, id, bucket_id, tuple)
+    local result, err = g.cluster.main_server.net_box:call('crud.get', {
+        space_name, id,
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    -- get w/ right bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.get', {
+        space_name, id, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+end
+
+add('test_update', function(g)
+    local tuple = {2, box.NULL, 'Ivan', 20}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+
+    local update_operations = {
+        {'+', 'age', 10},
+        {'=', 'name', 'Leo Tolstoy'},
+    }
+
+    -- insert tuple
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 1)
+
+    -- update w/ default bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.update', {
+        'customers', tuple[1], update_operations,
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    -- tuple not found, update returned nil
+    t.assert_equals(#result.rows, 0)
+
+    -- update w/ right bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.update', {
+        'customers', tuple[1], update_operations, {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 1)
+end)
+
+add('test_delete', function(g)
+    local tuple = {2, box.NULL, 'Ivan', 20}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+
+    -- insert tuple
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 1)
+
+    -- delete w/ default bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.delete', {
+        'customers', tuple[1],
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    -- since delete returns nil for vinyl,
+    -- just get tuple to check it wasn't deleted
+
+    -- get w/ right bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.get', {
+        'customers', tuple[1], {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    -- tuple wasn't deleted
+    t.assert_equals(#result.rows, 1)
+
+    -- delete w/ right bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.delete', {
+        'customers', tuple[1], {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+
+    -- get w/ right bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.get', {
+        'customers', tuple[1], {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    -- tuple was deleted
+    t.assert_equals(#result.rows, 0)
+end)
+
+add('test_insert_object', function(g)
+    local object = {id = 2, name = 'Ivan', age = 46}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+    object.bucket_id = bucket_id
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- insert_object
+    local result, err = g.cluster.main_server.net_box:call('crud.insert_object', {
+        'customers', object, {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_insert_object_bucket_id_opt', function(g)
+    local object = {id = 1, name = 'Fedor', age = 59}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- insert_object
+    local result, err = g.cluster.main_server.net_box:call('crud.insert_object', {
+        'customers', object, {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_insert_object_bucket_id_specified_twice', function(g)
+    local object = {id = 1, name = 'Fedor', age = 59}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+    object.bucket_id = bucket_id
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- insert_object, opts.bucket_id is different
+    local result, err = g.cluster.main_server.net_box:call('crud.insert_object', {
+        'customers', object, {bucket_id = bucket_id + 1},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, 'Tuple and opts.bucket_id contain different bucket_id values')
+
+    -- insert_object, opts.bucket_id is the same
+    local result, err = g.cluster.main_server.net_box:call('crud.insert_object', {
+        'customers', object, {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_insert', function(g)
+    local tuple = {2, box.NULL, 'Ivan', 20}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+    tuple[2] = bucket_id
+
+    -- insert
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple,
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple)
+end)
+
+add('test_insert_bucket_id_opt', function(g)
+    local tuple = {1, box.NULL, 'Ivan', 20}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+
+    local tuple_with_bucket_id = table.copy(tuple)
+    tuple_with_bucket_id[2] = bucket_id
+
+    -- insert
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple, {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple_with_bucket_id})
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple_with_bucket_id)
+end)
+
+add('test_insert_bucket_id_specified_twice', function(g)
+    local tuple = {2, box.NULL, 'Ivan', 20}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+    tuple[2] = bucket_id
+
+    -- insert, opts.bucket_id is different
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple, {bucket_id = bucket_id + 1}
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, 'Tuple and opts.bucket_id contain different bucket_id values')
+
+    -- insert, opts.bucket_id is the same
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple)
+end)
+
+add('test_replace_object', function(g)
+    local object = {id = 2, name = 'Jane', age = 21}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+    object.bucket_id = bucket_id
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- replace_object
+    local result, err = g.cluster.main_server.net_box:call('crud.replace_object', {
+        'customers', object,
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_replace_object_bucket_id_opt', function(g)
+    local object = {id = 1, name = 'John', age = 25}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- replace_object
+    local result, err = g.cluster.main_server.net_box:call('crud.replace_object', {
+        'customers', object, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_replace_object_bucket_id_specified_twice', function(g)
+    local object = {id = 1, name = 'Fedor', age = 59}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+    object.bucket_id = bucket_id
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- replace_object, opts.bucket_id is different
+    local result, err = g.cluster.main_server.net_box:call('crud.replace_object', {
+        'customers', object, {bucket_id = bucket_id + 1}
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, 'Tuple and opts.bucket_id contain different bucket_id values')
+
+    -- replace_object, opts.bucket_id is the same
+    local result, err = g.cluster.main_server.net_box:call('crud.replace_object', {
+        'customers', object, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_replace', function(g)
+    local tuple = {2, box.NULL, 'Jane', 21}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+    tuple[2] = bucket_id
+
+    -- replace
+    local result, err = g.cluster.main_server.net_box:call('crud.replace', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple)
+end)
+
+add('test_replace_bucket_id_opt', function(g)
+    local tuple = {1, box.NULL, 'John', 25}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+
+    local tuple_with_bucket_id = table.copy(tuple)
+    tuple_with_bucket_id[2] = bucket_id
+
+    -- replace
+    local result, err = g.cluster.main_server.net_box:call('crud.replace', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple_with_bucket_id})
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple_with_bucket_id)
+end)
+
+add('test_replace_bucket_id_specified_twice', function(g)
+    local tuple = {1, box.NULL, 'John', 25}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+    tuple[2] = bucket_id
+
+    -- replace, opts.bucket_id is different
+    local result, err = g.cluster.main_server.net_box:call('crud.replace', {
+        'customers', tuple, {bucket_id = bucket_id + 1}
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, 'Tuple and opts.bucket_id contain different bucket_id values')
+
+    -- replace, opts.bucket_id is the same
+    local result, err = g.cluster.main_server.net_box:call('crud.replace', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(result.rows, {tuple})
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple)
+end)
+
+add('test_upsert_object', function(g)
+    local  object = {id = 2, name = 'Jane', age = 21}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+    object.bucket_id = bucket_id
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- upsert_object
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert_object', {
+        'customers', object, {},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_upsert_object_bucket_id_opt', function(g)
+    local object = {id = 1, name = 'John', age = 25}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- upsert_object
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert_object', {
+        'customers', object, {}, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_upsert_object_bucket_id_specified_twice', function(g)
+    local object = {id = 1, name = 'Fedor', age = 59}
+    local bucket_id = get_other_storage_bucket_id(g, object.id)
+    object.bucket_id = bucket_id
+
+    local tuple = crud_utils.flatten(object, g.space_format, bucket_id)
+
+    -- upsert_object, opts.bucket_id is different
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert_object', {
+        'customers', object, {}, {bucket_id = bucket_id + 1}
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, 'Tuple and opts.bucket_id contain different bucket_id values')
+
+    -- upsert_object, opts.bucket_id is the same
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert_object', {
+        'customers', object, {}, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    check_get(g, 'customers', object.id, bucket_id, tuple)
+end)
+
+add('test_upsert', function(g)
+    local tuple = {1, box.NULL, 'John', 25}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+    tuple[2] = bucket_id
+
+    -- upsert
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert', {
+        'customers', tuple, {}, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple)
+end)
+
+add('test_upsert_bucket_id_opt', function(g)
+    local tuple = {1, box.NULL, 'John', 25}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+
+    local tuple_with_bucket_id = table.copy(tuple)
+    tuple_with_bucket_id[2] = bucket_id
+
+    -- upsert
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert', {
+        'customers', tuple, {}, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple_with_bucket_id)
+end)
+
+add('test_upsert_bucket_id_specified_twice', function(g)
+    local tuple = {1, box.NULL, 'John', 25}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+    tuple[2] = bucket_id
+
+    -- upsert, opts.bucket_id is different
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert', {
+        'customers', tuple, {}, {bucket_id = bucket_id + 1}
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, 'Tuple and opts.bucket_id contain different bucket_id values')
+
+    -- upsert, opts.bucket_id is the same
+    local result, err = g.cluster.main_server.net_box:call('crud.upsert', {
+        'customers', tuple, {}, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 0)
+
+    check_get(g, 'customers', tuple[1], bucket_id, tuple)
+end)
+
+add('test_select', function(g)
+    local tuple = {2, box.NULL, 'Ivan', 20}
+    local bucket_id = get_other_storage_bucket_id(g, tuple[1])
+
+    -- insert tuple
+    local result, err = g.cluster.main_server.net_box:call('crud.insert', {
+        'customers', tuple, {bucket_id = bucket_id}
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    t.assert_equals(#result.rows, 1)
+
+    local conditions = {{'==', 'id', tuple[1]}}
+
+    -- select w/ default bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {
+        'customers', conditions,
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    -- tuple not found
+    t.assert_equals(#result.rows, 0)
+
+    -- select w/ right bucket_id
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {
+        'customers', conditions, {bucket_id = bucket_id},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert(result ~= nil)
+    -- tuple is found
+    t.assert_equals(#result.rows, 1)
+end)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -7,8 +7,6 @@ local crud = require('crud')
 
 local helpers = require('test.helper')
 
-math.randomseed(os.time())
-
 local function before_all(g, engine)
     g.cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
@@ -409,7 +407,6 @@ add('test_upsert_object', function(g)
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{id = 66, name = 'Leo Tolstoy', age = 50, bucket_id = 486}})
-
 end)
 
 add('test_upsert', function(g)


### PR DESCRIPTION
* Bucket ID can be specified using `opts.bucket_id` for all operations
* For operations that accepts tuple/object bucket ID can be specified as
   tuple/object field as well as `opts.bucket_id` value

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #46 
