### PR TITLE
ci: fix release push

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -52,6 +52,9 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@master
+      # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
+      - name: Set env
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Push scm rockspec
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
@@ -64,7 +67,7 @@ jobs:
             https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@${{ secrets.ROCKS_SERVER }} \
           cat $ROCK_NAME-scm-1.rockspec |
               sed -E \
-                -e "s/branch = '.+'/tag = '${GITHUB_REF#refs/*/}'/g" \
-                -e "s/version = '.+'/version = '${GITHUB_REF#refs/*/}-1'/g" |
-              curl --fail -X PUT -F "rockspec=@-;filename=$ROCK_NAME-${GITHUB_REF#refs/*/}-1.rockspec" \
+                -e "s/branch = '.+'/tag = '${GIT_TAG}'/g" \
+                -e "s/version = '.+'/version = '${GIT_TAG}-1'/g" |
+              curl --fail -X PUT -F "rockspec=@-;filename=$ROCK_NAME-${GIT_TAG}-1.rockspec" \
                 https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@rocks.tarantool.org

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -58,13 +58,13 @@ jobs:
           curl --fail -X PUT -F rockspec=@$ROCK_NAME-scm-1.rockspec \
             https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@${{ secrets.ROCKS_SERVER }}
       - name: Push release rockspec
-        if: github.event_name == 'push' && github.ref == 'refs/tags/'
+        if: startsWith(github.ref, 'refs/tags')
         run: |
           curl --fail -X PUT -F rockspec=@$ROCK_NAME-scm-1.rockspec \
             https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@${{ secrets.ROCKS_SERVER }} \
           cat $ROCK_NAME-scm-1.rockspec |
               sed -E \
-                -e "s/branch = '.+'/tag = '$GITHUB_REF'/g" \
-                -e "s/version = '.+'/version = '$GITHUB_REF-1'/g" |
-              curl --fail -X PUT -F "rockspec=@-;filename=$ROCK_NAME-$GITHUB_REF-1.rockspec" \
+                -e "s/branch = '.+'/tag = '${GITHUB_REF#refs/*/}'/g" \
+                -e "s/version = '.+'/version = '${GITHUB_REF#refs/*/}-1'/g" |
+              curl --fail -X PUT -F "rockspec=@-;filename=$ROCK_NAME-${GITHUB_REF#refs/*/}-1.rockspec" \
                 https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@rocks.tarantool.org


### PR DESCRIPTION
Previousely we use wrong syntax to detect the case when tag was
pushed. This patch fixes it in following way:
  - Use startsWith(github.ref, 'refs/tags') for tag detection
  - Use ${GITHUB_REF#refs/*/} to extract tag from ref

