### PR TITLE
Don't use print in pairs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,12 +322,16 @@ User could pass use_tomap flag (false by default) to iterate over flat tuples or
 **Example:**
 
 ```lua
+local tuples = {}
 for _, tuple in crud.pairs('customers', {{'<=', 'age', 35}}, {use_tomap = false}) do
-    print(json.encode(tuple)) -- {5, 1172, 'Jack', 35}
+    -- {5, 1172, 'Jack', 35}
+    table.insert(tuples, tuple)
 end
 
+local objects = {}
 for _, object in crud.pairs('customers', {{'<=', 'age', 35}}, {use_tomap = true}) do
-    print(json.encode(object)) -- {id = 5, name = 'Jack', bucket_id = 1172, age = 35}
+    -- {id = 5, name = 'Jack', bucket_id = 1172, age = 35}
+    table.insert(objects, object)
 end
 ```
 


### PR DESCRIPTION
In some cases when user explores how does `crud.pairs` work
`print` doesn't work as expected (when connected to running
instance console, message is printed to instance log, 
see https://github.com/tarantool/tarantool/issues/1986)
The better way is to collect data fetched by `pairs` to a
table.
