### PR TITLE
Fixed typo in error format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Select by primary index name
 * Fix error handling select with invalid type value
 * Get rid of performing map-reduce for single-replicaset operations
+* Fix typo in error format. Now returned error contains parent error
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.0] - 2020-10-26
 
+* Fix typo in error format. Now returned error contains parent error
+
 ### Fixed
 
 * Select by primary index name
 * Fix error handling select with invalid type value
 * Get rid of performing map-reduce for single-replicaset operations
-* Fix typo in error format. Now returned error contains parent error
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.3.0] - 2020-10-26
+### Fixed
 
 * Fix typo in error format. Now returned error contains parent error
+
+## [0.3.0] - 2020-10-26
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-* Fix typo in error format. Now returned error contains parent error
+* Fixed typo in error for case when failed to get `bucket_id`
 
 ## [0.3.0] - 2020-10-26
 

--- a/crud/common/sharding.lua
+++ b/crud/common/sharding.lua
@@ -27,7 +27,7 @@ end
 function sharding.tuple_set_and_return_bucket_id(tuple, space, specified_bucket_id)
     local bucket_id_fieldno, err = utils.get_bucket_id_fieldno(space)
     if err ~= nil then
-        return nil, BucketIDError:new("Failed to get bucket ID fielno:", err)
+        return nil, BucketIDError:new("Failed to get bucket ID fielno: %s", err)
     end
 
     if specified_bucket_id ~= nil then


### PR DESCRIPTION
Fixed typo in error format in `tuple_set_and_return_bucket_id()` (`%s` was missed)
