### PR TITLE
implement truncate for spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   selecting by equality of partially specified multipart primary index
   value was misinterpreted as a selecting by fully specified key value.
 
+### Added
+
+* `truncate` operation
+
 ## [0.3.0] - 2020-10-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -335,6 +335,38 @@ for _, object in crud.pairs('customers', {{'<=', 'age', 35}}, {use_tomap = true}
 end
 ```
 
+### Truncate
+
+```lua
+-- Truncate space
+local result, err = crud.truncate(space_name, opts)
+```
+
+where:
+
+* `space_name` (`string`) - name of the space
+* `opts`:
+  * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+
+Returns true or nil with error.
+
+**Example:**
+
+```lua
+#crud.select('customers', {{'<=', 'age', 35}})
+---
+- 1
+...
+crud.truncate('customers', {timeout = 2})
+---
+- true
+...
+#crud.select('customers', {{'<=', 'age', 35}})
+---
+- 0
+...
+```
+
 ## Cartridge roles
 
 `cartridge.roles.crud-storage` is a Tarantool Cartridge role that depends on the

--- a/crud.lua
+++ b/crud.lua
@@ -9,6 +9,7 @@ local update = require('crud.update')
 local upsert = require('crud.upsert')
 local delete = require('crud.delete')
 local select = require('crud.select')
+local truncate = require('crud.truncate')
 local utils = require('crud.common.utils')
 
 local crud = {}
@@ -64,6 +65,10 @@ crud.pairs = select.pairs
 -- @function unflatten_rows
 crud.unflatten_rows = utils.unflatten_rows
 
+-- @refer truncate.call
+-- @function truncate
+crud.truncate = truncate.call
+
 --- Initializes crud on node
 --
 -- Exports all functions that are used for calls
@@ -83,6 +88,7 @@ function crud.init_storage()
     upsert.init()
     delete.init()
     select.init()
+    truncate.init()
 end
 
 function crud.init_router()

--- a/crud/truncate.lua
+++ b/crud/truncate.lua
@@ -1,0 +1,63 @@
+local checks = require('checks')
+local errors = require('errors')
+local vshard = require('vshard')
+
+local dev_checks = require('crud.common.dev_checks')
+local call = require('crud.common.call')
+
+local TruncateError = errors.new_class('Truncate',  {capture_stack = false})
+
+local truncate = {}
+
+local TRUNCATE_FUNC_NAME = '_crud.truncate_on_storage'
+
+local function truncate_on_storage(space_name)
+    dev_checks('string')
+
+    local space = box.space[space_name]
+    if space == nil then
+        return nil, TruncateError:new("Space %q doesn't exist", space_name)
+    end
+
+    return space:truncate()
+end
+
+function truncate.init()
+   _G._crud.truncate_on_storage = truncate_on_storage
+end
+
+--- Truncates specified space
+--
+-- @function call
+--
+-- @param string space_name
+--  A space name
+--
+-- @tparam ?number opts.timeout
+--  Function call timeout
+--
+-- @return[1] boolean true
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+--
+function truncate.call(space_name, opts)
+    checks('string', {
+        timeout = '?number',
+    })
+
+    opts = opts or {}
+
+    local replicasets = vshard.router.routeall()
+    local _, err = call.rw(TRUNCATE_FUNC_NAME, {space_name}, {
+        replicasets = replicasets,
+        timeout = opts.timeout,
+    })
+
+    if err ~= nil then
+        return nil, TruncateError:new("Failed to truncate: %s", err)
+    end
+
+    return true
+end
+
+return truncate

--- a/test/integration/truncate_test.lua
+++ b/test/integration/truncate_test.lua
@@ -1,0 +1,124 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g_memtx = t.group('truncate_memtx')
+local g_vinyl = t.group('truncate_vinyl')
+
+local helpers = require('test.helper')
+
+math.randomseed(os.time())
+
+local function before_all(g, engine)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_select'),
+        use_vshard = true,
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                alias = 'router',
+                roles = { 'customers-router' },
+                servers = {
+                    { instance_uuid = helpers.uuid('a', 1), alias = 'router' },
+                },
+            },
+            {
+                uuid = helpers.uuid('b'),
+                alias = 's-1',
+                roles = { 'customers-storage' },
+                servers = {
+                    { instance_uuid = helpers.uuid('b', 1), alias = 's1-master' },
+                    { instance_uuid = helpers.uuid('b', 2), alias = 's1-replica' },
+                },
+            },
+            {
+                uuid = helpers.uuid('c'),
+                alias = 's-2',
+                roles = { 'customers-storage' },
+                servers = {
+                    { instance_uuid = helpers.uuid('c', 1), alias = 's2-master' },
+                    { instance_uuid = helpers.uuid('c', 2), alias = 's2-replica' },
+                },
+            }
+        },
+        env = {
+            ['ENGINE'] = engine,
+        },
+    })
+    g.engine = engine
+    g.cluster:start()
+
+    g.space_format = g.cluster.servers[2].net_box.space.customers:format()
+end
+
+g_memtx.before_all = function() before_all(g_memtx, 'memtx') end
+g_vinyl.before_all = function() before_all(g_vinyl, 'vinyl') end
+
+local function after_all(g)
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+g_memtx.after_all = function() after_all(g_memtx) end
+g_vinyl.after_all = function() after_all(g_vinyl) end
+
+local function before_each(g)
+    for _, server in ipairs(g.cluster.servers) do
+        server.net_box:eval([[
+            local space = box.space.customers
+            if space ~= nil and not box.cfg.read_only then
+                space:truncate()
+            end
+        ]])
+    end
+end
+
+g_memtx.before_each(function() before_each(g_memtx) end)
+g_vinyl.before_each(function() before_each(g_vinyl) end)
+
+local function add(name, fn)
+    g_memtx[name] = fn
+    g_vinyl[name] = fn
+end
+
+add('test_non_existent_space', function(g)
+    -- insert
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.truncate', {'non_existent_space'}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_str_contains(err.err, "Space \"non_existent_space\" doesn't exist")
+end)
+
+add('test_truncate', function(g)
+    local customers = helpers.insert_objects(g, 'customers', {
+        {
+            id = 1, name = "Elizabeth", last_name = "Jackson",
+            age = 12, city = "New York",
+        }, {
+            id = 2, name = "Mary", last_name = "Brown",
+            age = 46, city = "Los Angeles",
+        }, {
+            id = 3, name = "David", last_name = "Smith",
+            age = 33, city = "Los Angeles",
+        }, {
+            id = 4, name = "William", last_name = "White",
+            age = 81, city = "Chicago",
+        },
+    })
+
+    table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
+
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil})
+    t.assert_equals(err, nil)
+    t.assert(#result.rows > 0)
+
+    local result, err = g.cluster.main_server.net_box:call('crud.truncate', {'customers'})
+    t.assert_equals(err, nil)
+    t.assert_equals(result, true)
+
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil})
+    t.assert_equals(err, nil)
+    t.assert(#result.rows == 0)
+end)


### PR DESCRIPTION
This patch implements "crud.truncate" call. It's needed for spaces
truncation.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #91