### PR TITLE
ci: show rocks server hostname in logs

### DIFF
--- a/.github/workflows/push_rockspec.yaml
+++ b/.github/workflows/push_rockspec.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Push scm rockspec
         run: |
           curl --fail -X PUT -F rockspec=@$ROCK_NAME-scm-1.rockspec \
-            https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@${{ secrets.ROCKS_SERVER }}
+            https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@rocks.tarantool.org
   push-tagged-rockspec:
     runs-on: [ ubuntu-latest ]
     if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
There is no reason to hide a server that will serve the rock out. Now it
is always rocks.tarantool.org, but it may be not so obvious for one, who
don't know our infrastructure details.

If we'll have more than one rocks server in a future (say, for testing
purposes), the explicit server hostname in the CI logs may be helpful
for debugging infrastructural problems.

See also [1].

[1]: https://github.com/tarantool/rocks.tarantool.org/issues/22