### PR TITLE
Fixed select crash when dropping indexes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Support for UUID field types and UUID values
 
+### Fixed
+
+* Fixed select crash when dropping indexes.
+
 ## [0.4.0] - 2020-12-02
 
 ### Fixed

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -15,19 +15,23 @@ local function index_is_allowed(index)
 end
 
 local function get_index_for_condition(space_indexes, space_format, condition)
-    for i= 0, #space_indexes do
+    for i= 0, table.maxn(space_indexes) do
         local index = space_indexes[i]
-        if index.name == condition.operand and index_is_allowed(index) then
-            return index
+        if index ~= nil then
+            if index.name == condition.operand and index_is_allowed(index) then
+                return index
+            end
         end
     end
 
-    for i = 0, #space_indexes do
+    for i = 0, table.maxn(space_indexes) do
         local index = space_indexes[i]
-        local first_part_fieldno = index.parts[1].fieldno
-        local first_part_name = space_format[first_part_fieldno].name
-        if first_part_name == condition.operand and index_is_allowed(index) then
-            return index
+        if index ~= nil then
+            local first_part_fieldno = index.parts[1].fieldno
+            local first_part_name = space_format[first_part_fieldno].name
+            if first_part_name == condition.operand and index_is_allowed(index) then
+                return index
+            end
         end
     end
 end
@@ -39,18 +43,40 @@ local function validate_conditions(conditions, space_indexes, space_format)
     end
 
     local index_names = {}
-    for i = 0, #space_indexes do
+
+    --local file = io.open("test100500.txt", "w+")
+    --io.output(file)
+    --io.close(file)
+    for i = 0, table.maxn(space_indexes) do
         local index = space_indexes[i]
         if index ~= nil then
             index_names[index.name] = true
+            --[=====[
+            --if index.name == "name_tree" then
+                io.write(index.name)
+                io.write("\n")
+                for _, condition in ipairs(conditions) do
+                    io.write(string.format("%q", index_names[condition.operand]))
+                    io.write("\n")
+                    io.write(string.format("%q", field_names[condition.operand]))
+                    io.write("\n")
+                    io.write(condition.operand)
+                    io.write("\n")
+                end
+                io.write("cycle end\n")
+            --end
+            --]=====]
         end
     end
+ --   io.close(file)
 
+    --io.output(file)
     for _, condition in ipairs(conditions) do
         if index_names[condition.operand] == nil and field_names[condition.operand] == nil then
             return false, ValidateConditionsError:new("No field or index %q found", condition.operand)
         end
     end
+   -- io.close(file)
 
     return true
 end

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -15,7 +15,7 @@ local function index_is_allowed(index)
 end
 
 local function get_index_for_condition(space_indexes, space_format, condition)
-    -- If we use # (not table.maxn), we may lose indexes, 
+    -- If we use # (not table.maxn), we may lose indexes,
     -- when user drop some indexes.
     local max_index = table.maxn(space_indexes)
     for i = 0, max_index do

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -44,39 +44,18 @@ local function validate_conditions(conditions, space_indexes, space_format)
 
     local index_names = {}
 
-    --local file = io.open("test100500.txt", "w+")
-    --io.output(file)
-    --io.close(file)
     for i = 0, table.maxn(space_indexes) do
         local index = space_indexes[i]
         if index ~= nil then
             index_names[index.name] = true
-            --[=====[
-            --if index.name == "name_tree" then
-                io.write(index.name)
-                io.write("\n")
-                for _, condition in ipairs(conditions) do
-                    io.write(string.format("%q", index_names[condition.operand]))
-                    io.write("\n")
-                    io.write(string.format("%q", field_names[condition.operand]))
-                    io.write("\n")
-                    io.write(condition.operand)
-                    io.write("\n")
-                end
-                io.write("cycle end\n")
-            --end
-            --]=====]
         end
     end
- --   io.close(file)
 
-    --io.output(file)
     for _, condition in ipairs(conditions) do
         if index_names[condition.operand] == nil and field_names[condition.operand] == nil then
             return false, ValidateConditionsError:new("No field or index %q found", condition.operand)
         end
     end
-   -- io.close(file)
 
     return true
 end

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -15,8 +15,10 @@ local function index_is_allowed(index)
 end
 
 local function get_index_for_condition(space_indexes, space_format, condition)
-    local maxn = table.maxn(space_indexes)
-    for i = 0, maxn do
+    -- If we use # (not table.maxn), we may lose indexes, 
+    -- when user drop some indexes.
+    local max_index = table.maxn(space_indexes)
+    for i = 0, max_index do
         local index = space_indexes[i]
         if index ~= nil then
             if index.name == condition.operand and index_is_allowed(index) then
@@ -25,7 +27,7 @@ local function get_index_for_condition(space_indexes, space_format, condition)
         end
     end
 
-    for i = 0, maxn do
+    for i = 0, max_index do
         local index = space_indexes[i]
         if index ~= nil then
             local first_part_fieldno = index.parts[1].fieldno

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -15,8 +15,10 @@ local function index_is_allowed(index)
 end
 
 local function get_index_for_condition(space_indexes, space_format, condition)
-    -- If we use # (not table.maxn), we may lose indexes,
-    -- when user drop some indexes.
+    -- If we use # (not table.maxn), we may lose indexes, when user drop some indexes.
+    -- E.g: we have table with indexes id {1, 2, 3, nil, nil, 6}.
+    -- If we use #{1, 2, 3, nil, nil, 6} (== 3) we will lose index with id = 6.
+    -- See details: https://github.com/tarantool/crud/issues/103
     local max_index = table.maxn(space_indexes)
     for i = 0, max_index do
         local index = space_indexes[i]
@@ -47,6 +49,10 @@ local function validate_conditions(conditions, space_indexes, space_format)
 
     local index_names = {}
 
+    -- If we use # (not table.maxn), we may lose indexes, when user drop some indexes.
+    -- E.g: we have table with indexes id {1, 2, 3, nil, nil, 6}.
+    -- If we use #{1, 2, 3, nil, nil, 6} (== 3) we will lose index with id = 6.
+    -- See details: https://github.com/tarantool/crud/issues/103
     for i = 0, table.maxn(space_indexes) do
         local index = space_indexes[i]
         if index ~= nil then

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -41,7 +41,9 @@ local function validate_conditions(conditions, space_indexes, space_format)
     local index_names = {}
     for i = 0, #space_indexes do
         local index = space_indexes[i]
-        index_names[index.name] = true
+        if index ~= nil then
+            index_names[index.name] = true
+        end
     end
 
     for _, condition in ipairs(conditions) do

--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -15,7 +15,8 @@ local function index_is_allowed(index)
 end
 
 local function get_index_for_condition(space_indexes, space_format, condition)
-    for i= 0, table.maxn(space_indexes) do
+    local maxn = table.maxn(space_indexes)
+    for i = 0, maxn do
         local index = space_indexes[i]
         if index ~= nil then
             if index.name == condition.operand and index_is_allowed(index) then
@@ -24,7 +25,7 @@ local function get_index_for_condition(space_indexes, space_format, condition)
         end
     end
 
-    for i = 0, table.maxn(space_indexes) do
+    for i = 0, maxn do
         local index = space_indexes[i]
         if index ~= nil then
             local first_part_fieldno = index.parts[1].fieldno

--- a/test/unit/select_dropped_indexes_test.lua
+++ b/test/unit/select_dropped_indexes_test.lua
@@ -42,13 +42,13 @@ g.before_all = function()
         if_not_exists = true,
     })
 
-    customers:create_index('index_dropped1', {
+    customers:create_index('index4_dropped', {
         type = 'HASH',
         parts = {'name'},
         if_not_exists = true,
     })
 
-    customers:create_index('index_dropped2', {
+    customers:create_index('index5_dropped', {
         type = 'HASH',
         parts = {'age'},
         if_not_exists = true,
@@ -61,25 +61,27 @@ g.before_all = function()
         if_not_exists = true,
     })
 
-    customers.index.index_dropped1:drop()
-    customers.index.index_dropped2:drop()
+    customers.index.index4_dropped:drop()
+    customers.index.index5_dropped:drop()
 end
 
 g.after_all = function()
     box.space.customers:drop()
 end
 
+g.test_conditions = function()
+    t.assert(#box.space.customers.index ~= table.maxn(box.space.customers.index))
+end
 
 g.test_dropped_index_call = function()
     local plan, err = select_plan.new(box.space.customers, {
-        cond_funcs.gt('index_dropped1', 15),
+        cond_funcs.gt('index4_dropped', 15),
     })
 
     t.assert_equals(plan, nil)
     t.assert(err ~= nil)
-    t.assert_str_contains(err.err, 'No field or index "index_dropped1" found')
+    t.assert_str_contains(err.err, 'No field or index "index4_dropped" found')
 end
-
 
 g.test_before_dropped_index_field = function()
     local conditions = { cond_funcs.eq('index3', 20) }

--- a/test/unit/select_dropped_indexes_test.lua
+++ b/test/unit/select_dropped_indexes_test.lua
@@ -63,24 +63,13 @@ g.before_all = function()
 
     customers.index.index4_dropped:drop()
     customers.index.index5_dropped:drop()
+
+    -- We need this check to make sure that tests actually covers a problem.
+    t.assert(#box.space.customers.index ~= table.maxn(box.space.customers.index))
 end
 
 g.after_all = function()
     box.space.customers:drop()
-end
-
-g.test_conditions = function()
-    t.assert(#box.space.customers.index ~= table.maxn(box.space.customers.index))
-end
-
-g.test_dropped_index_call = function()
-    local plan, err = select_plan.new(box.space.customers, {
-        cond_funcs.gt('index4_dropped', 15),
-    })
-
-    t.assert_equals(plan, nil)
-    t.assert(err ~= nil)
-    t.assert_str_contains(err.err, 'No field or index "index4_dropped" found')
 end
 
 g.test_before_dropped_index_field = function()

--- a/test/unit/select_dropped_indexes_test.lua
+++ b/test/unit/select_dropped_indexes_test.lua
@@ -8,8 +8,6 @@ local g = t.group('select_dropped_indexes')
 
 local helpers = require('test.helper')
 
-local NOT_FOUND_INDEX_ERR_MSG = 'An index that matches specified conditions was not found'
-
 g.before_all = function()
     helpers.box_cfg()
 
@@ -25,7 +23,7 @@ g.before_all = function()
         if_not_exists = true,
     })
 
-    customers:create_index('id', { 
+    customers:create_index('id', {
         type = 'TREE',
         parts = {'id'},
         if_not_exists = true,
@@ -71,6 +69,7 @@ g.after_all = function()
     box.space.customers:drop()
 end
 
+
 g.test_dropped_index_call = function()
     local plan, err = select_plan.new(box.space.customers, {
         cond_funcs.gt('age_hash', 15),
@@ -81,7 +80,8 @@ g.test_dropped_index_call = function()
     t.assert_str_contains(err.err, 'No field or index "age_hash" found')
 end
 
-g.test_before_dropped_index_field = function() 
+
+g.test_before_dropped_index_field = function()
     local conditions = { cond_funcs.eq('age_tree', 20) }
     local plan, err = select_plan.new(box.space.customers, conditions)
 
@@ -97,7 +97,7 @@ g.test_before_dropped_index_field = function()
     t.assert_equals(plan.iter, box.index.EQ)
     t.assert_equals(plan.total_tuples_count, nil)
     t.assert_equals(plan.sharding_key, nil)
-end 
+end
 
 g.test_after_dropped_index_field = function()
     local conditions = { cond_funcs.eq('name_tree', 'Alexey') }

--- a/test/unit/select_dropped_indexes_test.lua
+++ b/test/unit/select_dropped_indexes_test.lua
@@ -1,0 +1,136 @@
+local select_plan = require('crud.select.plan')
+
+local select_conditions = require('crud.select.conditions')
+local cond_funcs = select_conditions.funcs
+
+local t = require('luatest')
+local g = t.group('select_dropped_indexes')
+
+local helpers = require('test.helper')
+
+local NOT_FOUND_INDEX_ERR_MSG = 'An index that matches specified conditions was not found'
+
+g.before_all = function()
+    helpers.box_cfg()
+
+    local customers = box.schema.space.create('customers', {
+        format = {
+            {'id', 'unsigned'},
+            {'bucket_id', 'unsigned'},
+            {'name', 'string'},
+            {'age', 'unsigned'},
+            {'number_of_pets', 'unsigned'},
+            {'cars', 'array'},
+        },
+        if_not_exists = true,
+    })
+
+    customers:create_index('id', { 
+        type = 'TREE',
+        parts = {'id'},
+        if_not_exists = true,
+    })
+
+    customers:create_index('bucket_id', {
+        parts = {'bucket_id'},
+        unique = false,
+        if_not_exists = true,
+    })
+
+    customers:create_index('age_tree', {
+        type = 'TREE',
+        parts = {'age'},
+        unique = false,
+        if_not_exists = true,
+    })
+
+    customers:create_index('name_hash', {
+        type = 'HASH',
+        parts = {'name'},
+        if_not_exists = true,
+    })
+
+    customers:create_index('age_hash', {
+        type = 'HASH',
+        parts = {'age'},
+        if_not_exists = true,
+    })
+
+    customers:create_index('name_tree', {
+        type = 'TREE',
+        parts = {'name'},
+        unique = false,
+        if_not_exists = true,
+    })
+
+    customers.index.name_hash:drop()
+    customers.index.age_hash:drop()
+end
+
+g.after_all = function()
+    box.space.customers:drop()
+end
+
+g.test_dropped_index_call = function()
+    local plan, err = select_plan.new(box.space.customers, {
+        cond_funcs.gt('age_hash', 15),
+    })
+
+    t.assert_equals(plan, nil)
+    t.assert(err ~= nil)
+    t.assert_str_contains(err.err, 'No field or index "age_hash" found')
+end
+
+g.test_before_dropped_index_field = function() 
+    local conditions = { cond_funcs.eq('age_tree', 20) }
+    local plan, err = select_plan.new(box.space.customers, conditions)
+
+    t.assert_equals(err, nil)
+    t.assert_type(plan, 'table')
+
+    t.assert_equals(plan.conditions, conditions)
+    t.assert_equals(plan.space_name, 'customers')
+    t.assert_equals(plan.index_id, 2)
+    t.assert_equals(plan.scan_value, {20})
+    t.assert_equals(plan.after_tuple, nil)
+    t.assert_equals(plan.scan_condition_num, 1)
+    t.assert_equals(plan.iter, box.index.EQ)
+    t.assert_equals(plan.total_tuples_count, nil)
+    t.assert_equals(plan.sharding_key, nil)
+end 
+
+g.test_after_dropped_index_field = function()
+    local conditions = { cond_funcs.eq('name_tree', 'Alexey') }
+    local plan, err = select_plan.new(box.space.customers, conditions)
+
+    t.assert_equals(err, nil)
+    t.assert_type(plan, 'table')
+
+    t.assert_equals(plan.conditions, conditions)
+    t.assert_equals(plan.space_name, 'customers')
+    t.assert_equals(plan.index_id, 5)
+    t.assert_equals(plan.scan_value, {'Alexey'})
+    t.assert_equals(plan.after_tuple, nil)
+    t.assert_equals(plan.scan_condition_num, 1)
+    t.assert_equals(plan.iter, box.index.EQ)
+    t.assert_equals(plan.total_tuples_count, nil)
+    t.assert_equals(plan.sharding_key, nil)
+end
+
+g.test_non_indexed_field = function()
+    local conditions = { cond_funcs.eq('number_of_pets', 2) }
+    local plan, err = select_plan.new(box.space.customers, conditions)
+
+    t.assert_equals(err, nil)
+    t.assert_type(plan, 'table')
+
+    t.assert_equals(plan.conditions, conditions)
+    t.assert_equals(plan.space_name, 'customers')
+    t.assert_equals(plan.index_id, 0) -- PK
+    t.assert_equals(plan.scan_value, {})
+    t.assert_equals(plan.after_tuple, nil)
+    t.assert_equals(plan.scan_condition_num, nil)
+    t.assert_equals(plan.iter, box.index.GE)
+    t.assert_equals(plan.total_tuples_count, nil)
+    t.assert_equals(plan.sharding_key, nil)
+end

--- a/test/unit/select_dropped_indexes_test.lua
+++ b/test/unit/select_dropped_indexes_test.lua
@@ -64,7 +64,7 @@ g.before_all = function()
     customers.index.index4_dropped:drop()
     customers.index.index5_dropped:drop()
 
-    -- We need this check to make sure that tests actually covers a problem.
+    -- We need this check to make sure that test actually covers a problem.
     t.assert(#box.space.customers.index ~= table.maxn(box.space.customers.index))
 end
 


### PR DESCRIPTION
Fixed selection error when dropping indexes by replacing the ``#`` operator with a call to ``table.maxn`` when creating a select plan.

Closes #103.
