### PR TITLE
Fix using outdated space schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Using outdated schema on router-side
+
 ### Added
 
 * Support for UUID field types and UUID values

--- a/crud/common/call.lua
+++ b/crud/common/call.lua
@@ -160,6 +160,8 @@ function call.rw_single(bucket_id, func_name, func_args, options)
             )
         end
 
+        err = errors.wrap(err)
+
         return nil, CallError:new(utils.format_replicaset_error(
              replicaset.uuid, "Function returned an error: %s", err
         ))

--- a/crud/common/const.lua
+++ b/crud/common/const.lua
@@ -1,0 +1,6 @@
+local const = {}
+
+const.RELOAD_RETRIES_NUM = 1
+const.RELOAD_SCHEMA_TIMEOUT = 3 -- 3 seconds
+
+return const

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -1,0 +1,170 @@
+local fiber = require('fiber')
+local msgpack = require('msgpack')
+local digest = require('digest')
+local vshard = require('vshard')
+local errors = require('errors')
+local log = require('log')
+
+local ReloadSchemaError = errors.new_class('ReloadSchemaError',  {capture_stack = false})
+
+local const = require('crud.common.const')
+
+local schema = {}
+
+local function table_len(t)
+    local len = 0
+    for _ in pairs(t) do
+        len = len + 1
+    end
+    return len
+end
+
+local function call_reload_schema_on_replicaset(replicaset, channel)
+    replicaset.master.conn:reload_schema()
+    channel:put(true)
+end
+
+local function call_reload_schema(replicasets)
+    local replicasets_num = table_len(replicasets)
+    local channel = fiber.channel(replicasets_num)
+
+    local fibers = {}
+    for _, replicaset in pairs(replicasets) do
+        local f = fiber.new(call_reload_schema_on_replicaset, replicaset, channel)
+        table.insert(fibers, f)
+    end
+
+    for _ = 1,replicasets_num do
+        if channel:get(const.RELOAD_SCHEMA_TIMEOUT) == nil then
+            for _, f in ipairs(fibers) do
+                if fiber:status() ~= 'dead' then
+                    f:cancel()
+                end
+            end
+            return nil, ReloadSchemaError:new("Reloading schema timed out")
+        end
+    end
+
+    return true
+end
+
+local reload_in_progress = false
+local reload_schema_cond = fiber.cond()
+
+local function reload_schema(replicasets)
+    if reload_in_progress then
+        if not reload_schema_cond:wait(const.RELOAD_SCHEMA_TIMEOUT) then
+            return nil, ReloadSchemaError:new('Waiting for schema to be reloaded is timed out')
+        end
+    else
+        reload_in_progress = true
+
+        local ok, err = call_reload_schema(replicasets)
+        if not ok then
+            return nil, err
+        end
+
+        reload_schema_cond:broadcast()
+        reload_in_progress = false
+    end
+
+    return true
+end
+
+-- schema.wrap_func_reload calls func with specified arguments.
+-- func should return `res, err, need_reload`
+-- If function returned error and `need_reload` is true,
+-- then schema is reloaded and one more attempt is performed
+-- (but no more than RELOAD_RETRIES_NUM).
+-- This wrapper is used for functions that can fail if router uses outdated
+-- space schema. In case of such errors these functions returns `need_reload`
+-- for schema-dependent errors.
+function schema.wrap_func_reload(func, ...)
+    local i = 0
+
+    local res, err, need_reload
+    while true do
+        res, err, need_reload = func(...)
+
+        if err == nil or not need_reload then
+            break
+        end
+
+        local ok, reload_schema_err = reload_schema(vshard.router.routeall())
+        if not ok then
+            log.warn("Failed to reload schema: %s", reload_schema_err)
+            break
+        end
+
+        i = i + 1
+        if i > const.RELOAD_RETRIES_NUM then
+            break
+        end
+    end
+
+    return res, err
+end
+
+local function get_space_schema_hash(space)
+    if space == nil then
+        return ''
+    end
+
+    local indexes_info = {}
+    for i = 0, table.maxn(space.index) do
+        local index = space.index[i]
+        if index ~= nil then
+            indexes_info[i] = {
+                unique = index.unique,
+                parts = index.parts,
+                id = index.id,
+                type = index.type,
+                name = index.name,
+                path = index.path,
+            }
+        end
+    end
+
+    local space_info = {
+        format = space:format(),
+        indexes = indexes_info,
+    }
+
+    return digest.murmur(msgpack.encode(space_info))
+end
+
+-- schema.wrap_box_space_func_result pcalls some box.space function
+-- and returns its result as a table
+-- `{res = ..., err = ..., space_schema_hash = ...}`
+-- space_schema_hash is computed if function failed and
+-- `add_space_schema_hash` is true
+function schema.wrap_box_space_func_result(add_space_schema_hash, space, func_name, ...)
+    local result = {}
+
+    local ok, func_res = pcall(space[func_name], space, ...)
+    if not ok then
+        result.err = func_res
+        if add_space_schema_hash then
+            result.space_schema_hash = get_space_schema_hash(space)
+        end
+    else
+        result.res = func_res
+    end
+
+    return result
+end
+
+-- schema.result_needs_reload checks that schema reload can
+-- be helpful to avoid storage error.
+-- It checks if space_schema_hash returned by storage
+-- is the same as hash of space used on router.
+-- Note, that storage returns `space_schema_hash = nil`
+-- if reloading space format can't avoid the error.
+function schema.result_needs_reload(space, result)
+    if result.space_schema_hash == nil then
+        return false
+    end
+    return result.space_schema_hash ~= get_space_schema_hash(space)
+end
+
+return schema

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -6,6 +6,7 @@ local call = require('crud.common.call')
 local utils = require('crud.common.utils')
 local sharding = require('crud.common.sharding')
 local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
 
 local GetError = errors.new_class('Get',  {capture_stack = false})
 
@@ -21,12 +22,62 @@ local function get_on_storage(space_name, key)
         return nil, GetError:new("Space %q doesn't exist", space_name)
     end
 
-    local tuple = space:get(key)
-    return tuple
+    -- add_space_schema_hash is false because
+    -- reloading space format on router can't avoid get error on storage
+    return schema.wrap_box_space_func_result(false, space, 'get', key)
 end
 
 function get.init()
    _G._crud.get_on_storage = get_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_get_on_router(space_name, key, opts)
+    dev_checks('string', '?', {
+        timeout = '?number',
+        bucket_id = '?number|cdata',
+    })
+
+    opts = opts or {}
+
+    local space = utils.get_space(space_name, vshard.router.routeall())
+    if space == nil then
+        return nil, GetError:new("Space %q doesn't exist", space_name), true
+    end
+
+    if box.tuple.is(key) then
+        key = key:totable()
+    end
+
+    local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
+    -- We don't use callro() here, because if the replication is
+    -- async, there could be a lag between master and replica, so a
+    -- connector which sequentially calls put() and then get() may get
+    -- a stale result.
+    local storage_result, err = call.rw_single(
+        bucket_id, GET_FUNC_NAME,
+        {space_name, key},
+        {timeout = opts.timeout}
+    )
+
+    if err ~= nil then
+        return nil, GetError:new("Failed to call get on storage-side: %s", err)
+    end
+
+    if storage_result.err ~= nil then
+        return nil, GetError:new("Failed to get: %s", storage_result.err)
+    end
+
+    local tuple = storage_result.res
+
+    -- protect against box.NULL
+    if tuple == nil then
+        tuple = nil
+    end
+
+    return utils.format_result({tuple}, space)
 end
 
 --- Get tuple from the specified space by key
@@ -56,39 +107,7 @@ function get.call(space_name, key, opts)
         bucket_id = '?number|cdata',
     })
 
-    opts = opts or {}
-
-    local space = utils.get_space(space_name, vshard.router.routeall())
-    if space == nil then
-        return nil, GetError:new("Space %q doesn't exist", space_name)
-    end
-
-    if box.tuple.is(key) then
-        key = key:totable()
-    end
-
-    local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
-    -- We don't use callro() here, because if the replication is
-    -- async, there could be a lag between master and replica, so a
-    -- connector which sequentially calls put() and then get() may get
-    -- a stale result.
-    local result, err = call.rw_single(
-        bucket_id, GET_FUNC_NAME,
-        {space_name, key}, {timeout=opts.timeout})
-
-    if err ~= nil then
-        return nil, GetError:new("Failed to get: %s", err)
-    end
-
-    -- protect against box.NULL
-    if result == nil then
-       result = nil
-    end
-
-    return {
-       metadata = table.copy(space:format()),
-       rows = {result},
-    }
+    return schema.wrap_func_reload(call_get_on_router, space_name, key, opts)
 end
 
 return get

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -6,6 +6,7 @@ local call = require('crud.common.call')
 local utils = require('crud.common.utils')
 local sharding = require('crud.common.sharding')
 local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
 
 local InsertError = errors.new_class('Insert',  {capture_stack = false})
 
@@ -13,19 +14,72 @@ local insert = {}
 
 local INSERT_FUNC_NAME = '_crud.insert_on_storage'
 
-local function insert_on_storage(space_name, tuple)
-    dev_checks('string', 'table')
+local function insert_on_storage(space_name, tuple, opts)
+    dev_checks('string', 'table', {
+        add_space_schema_hash = '?boolean',
+    })
+
+    opts = opts or {}
 
     local space = box.space[space_name]
     if space == nil then
         return nil, InsertError:new("Space %q doesn't exist", space_name)
     end
 
-    return space:insert(tuple)
+    -- add_space_schema_hash is true only in case of insert_object
+    -- the only one case when reloading schema can avoid insert error
+    -- is flattening object on router
+    return schema.wrap_box_space_func_result(opts.add_space_schema_hash, space, 'insert', tuple)
 end
 
 function insert.init()
    _G._crud.insert_on_storage = insert_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_insert_on_router(space_name, tuple, opts)
+    dev_checks('string', 'table', {
+        timeout = '?number',
+        bucket_id = '?number|cdata',
+        add_space_schema_hash = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = utils.get_space(space_name, vshard.router.routeall())
+    if space == nil then
+        return nil, InsertError:new("Space %q doesn't exist", space_name), true
+    end
+
+    local bucket_id, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
+    if err ~= nil then
+        return nil, InsertError:new("Failed to get bucket ID: %s", err), true
+    end
+
+    local insert_on_storage_opts = {
+        add_space_schema_hash = opts.add_space_schema_hash,
+    }
+
+    local storage_result, err = call.rw_single(
+        bucket_id, INSERT_FUNC_NAME,
+        {space_name, tuple, insert_on_storage_opts},
+        {timeout = opts.timeout}
+    )
+
+    if err ~= nil then
+        return nil, InsertError:new("Failed to call insert on storage-side: %s", err)
+    end
+
+    if storage_result.err ~= nil then
+        local need_reload = schema.result_needs_reload(space, storage_result)
+        return nil, InsertError:new("Failed to insert: %s", storage_result.err), need_reload
+    end
+
+    local tuple = storage_result.res
+
+    return utils.format_result({tuple}, space)
 end
 
 --- Inserts a tuple to the specified space
@@ -53,33 +107,10 @@ function insert.tuple(space_name, tuple, opts)
     checks('string', 'table', {
         timeout = '?number',
         bucket_id = '?number|cdata',
+        add_space_schema_hash = '?boolean',
     })
 
-    opts = opts or {}
-
-    local space = utils.get_space(space_name, vshard.router.routeall())
-    if space == nil then
-        return nil, InsertError:new("Space %q doesn't exist", space_name)
-    end
-    local space_format = space:format()
-
-    local bucket_id, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
-    if err ~= nil then
-        return nil, InsertError:new("Failed to get bucket ID: %s", err)
-    end
-
-    local result, err = call.rw_single(
-        bucket_id, INSERT_FUNC_NAME,
-        {space_name, tuple}, {timeout=opts.timeout})
-
-    if err ~= nil then
-        return nil, InsertError:new("Failed to insert: %s", err)
-    end
-
-    return {
-        metadata = table.copy(space_format),
-        rows = {result},
-    }
+    return schema.wrap_func_reload(call_insert_on_router, space_name, tuple, opts)
 end
 
 --- Inserts an object to the specified space
@@ -104,15 +135,12 @@ function insert.object(space_name, obj, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
-    if space == nil then
-        return nil, InsertError:new("Space %q doesn't exist", space_name)
-    end
-    local space_format = space:format()
+    -- insert can fail if router uses outdated schema to flatten object
+    opts.add_space_schema_hash = true
 
-    local tuple, err = utils.flatten(obj, space_format)
+    local tuple, err = utils.flatten_obj_reload(space_name, obj)
     if err ~= nil then
-        return nil, InsertError:new("Object is specified in bad format: %s", err)
+        return nil, InsertError:new("Failed to flatten object: %s", err)
     end
 
     return insert.tuple(space_name, tuple, opts)

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -6,6 +6,7 @@ local call = require('crud.common.call')
 local utils = require('crud.common.utils')
 local sharding = require('crud.common.sharding')
 local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
 
 local ReplaceError = errors.new_class('Replace', { capture_stack = false })
 
@@ -13,19 +14,76 @@ local replace = {}
 
 local REPLACE_FUNC_NAME = '_crud.replace_on_storage'
 
-local function replace_on_storage(space_name, tuple)
-    dev_checks('string', 'table')
+local function replace_on_storage(space_name, tuple, opts)
+    dev_checks('string', 'table', {
+        add_space_schema_hash = '?boolean',
+    })
+
+    opts = opts or {}
 
     local space = box.space[space_name]
     if space == nil then
         return nil, ReplaceError:new("Space %q doesn't exist", space_name)
     end
 
-    return space:replace(tuple)
+    -- add_space_schema_hash is true only in case of replace_object
+    -- the only one case when reloading schema can avoid insert error
+    -- is flattening object on router
+    return schema.wrap_box_space_func_result(opts.add_space_schema_hash, space, 'replace', tuple)
 end
 
 function replace.init()
    _G._crud.replace_on_storage = replace_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_replace_on_router(space_name, tuple, opts)
+    dev_checks('string', 'table', {
+        timeout = '?number',
+        bucket_id = '?number|cdata',
+        add_space_schema_hash = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space, err = utils.get_space(space_name, vshard.router.routeall())
+    if err ~= nil then
+        return nil, ReplaceError:new("Failed to get space %q: %s", space_name, err), true
+    end
+
+    if space == nil then
+        return nil, ReplaceError:new("Space %q doesn't exist", space_name), true
+    end
+
+    local bucket_id, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
+    if err ~= nil then
+        return nil, ReplaceError:new("Failed to get bucket ID: %s", err), true
+    end
+
+    local insert_on_storage_opts = {
+        add_space_schema_hash = opts.add_space_schema_hash,
+    }
+
+    local storage_result, err = call.rw_single(
+        bucket_id, REPLACE_FUNC_NAME,
+        {space_name, tuple, insert_on_storage_opts},
+        {timeout = opts.timeout}
+    )
+
+    if err ~= nil then
+        return nil, ReplaceError:new("Failed to call replace on storage-side: %s", err)
+    end
+
+    if storage_result.err ~= nil then
+        local need_reload = schema.result_needs_reload(space, storage_result)
+        return nil, ReplaceError:new("Failed to replace: %s", storage_result.err), need_reload
+    end
+
+    local tuple = storage_result.res
+
+    return utils.format_result({tuple}, space)
 end
 
 --- Insert or replace a tuple in the specified space
@@ -53,33 +111,10 @@ function replace.tuple(space_name, tuple, opts)
     checks('string', 'table', {
         timeout = '?number',
         bucket_id = '?number|cdata',
+        add_space_schema_hash = '?boolean',
     })
 
-    opts = opts or {}
-
-    local space = utils.get_space(space_name, vshard.router.routeall())
-    if space == nil then
-        return nil, ReplaceError:new("Space %q doesn't exist", space_name)
-    end
-
-    local bucket_id, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
-    if err ~= nil then
-        return nil, ReplaceError:new("Failed to get bucket ID: %s", err)
-    end
-
-    local result, err = call.rw_single(
-        bucket_id, REPLACE_FUNC_NAME,
-        {space_name, tuple}, {timeout=opts.timeout})
-
-
-    if err ~= nil then
-        return nil, ReplaceError:new("Failed to replace: %s", err)
-    end
-
-     return {
-        metadata = table.copy(space:format()),
-        rows = {result},
-    }
+    return schema.wrap_func_reload(call_replace_on_router, space_name, tuple, opts)
 end
 
 --- Insert or replace an object in the specified space
@@ -104,15 +139,12 @@ function replace.object(space_name, obj, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
-    if space == nil then
-        return nil, ReplaceError:new("Space %q doesn't exist", space_name)
-    end
+    -- replace can fail if router uses outdated schema to flatten object
+    opts.add_space_schema_hash = true
 
-    local space_format = space:format()
-    local tuple, err = utils.flatten(obj, space_format)
+    local tuple, err = utils.flatten_obj_reload(space_name, obj)
     if err ~= nil then
-        return nil, ReplaceError:new("Object is specified in bad format: %s", err)
+        return nil, ReplaceError:new("Failed to flatten object: %s", err)
     end
 
     return replace.tuple(space_name, tuple, opts)

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -6,6 +6,7 @@ local call = require('crud.common.call')
 local utils = require('crud.common.utils')
 local sharding = require('crud.common.sharding')
 local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
 
 local UpdateError = errors.new_class('Update',  {capture_stack = false})
 
@@ -21,12 +22,60 @@ local function update_on_storage(space_name, key, operations)
         return nil, UpdateError:new("Space %q doesn't exist", space_name)
     end
 
-    local tuple = space:update(key, operations)
-    return tuple
+    -- add_space_schema_hash is false because
+    -- reloading space format on router can't avoid update error on storage
+    return schema.wrap_box_space_func_result(false, space, 'update', key, operations)
 end
 
 function update.init()
    _G._crud.update_on_storage = update_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_update_on_router(space_name, key, user_operations, opts)
+    dev_checks('string', '?', 'table', {
+        timeout = '?number',
+        bucket_id = '?number|cdata',
+    })
+
+    opts = opts or {}
+
+    local space = utils.get_space(space_name, vshard.router.routeall())
+    if space == nil then
+        return nil, UpdateError:new("Space %q doesn't exist", space_name), true
+    end
+
+    local space_format = space:format()
+
+    if box.tuple.is(key) then
+        key = key:totable()
+    end
+
+    local operations, err = utils.convert_operations(user_operations, space_format)
+    if err ~= nil then
+        return nil, UpdateError:new("Wrong operations are specified: %s", err), true
+    end
+
+    local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
+    local storage_result, err = call.rw_single(
+        bucket_id, UPDATE_FUNC_NAME,
+        {space_name, key, operations},
+        {timeout = opts.timeout}
+    )
+
+    if err ~= nil then
+        return nil, UpdateError:new("Failed to call update on storage-side: %s", err)
+    end
+
+    if storage_result.err ~= nil then
+        return nil, UpdateError:new("Failed to update: %s", storage_result.err)
+    end
+
+    local tuple = storage_result.res
+
+    return utils.format_result({tuple}, space)
 end
 
 --- Updates tuple in the specified space
@@ -60,36 +109,7 @@ function update.call(space_name, key, user_operations, opts)
         bucket_id = '?number|cdata',
     })
 
-    opts = opts or {}
-
-    local space = utils.get_space(space_name, vshard.router.routeall())
-    if space == nil then
-        return nil, UpdateError:new("Space %q doesn't exist", space_name)
-    end
-    local space_format = space:format()
-
-    if box.tuple.is(key) then
-        key = key:totable()
-    end
-
-    local operations, err = utils.convert_operations(user_operations, space_format)
-    if err ~= nil then
-        return nil, UpdateError:new("Wrong operations are specified: %s", err)
-    end
-
-    local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
-    local result, err = call.rw_single(
-        bucket_id, UPDATE_FUNC_NAME, {space_name, key, operations},
-        {timeout=opts.timeout})
-
-    if err ~= nil then
-        return nil, UpdateError:new("Failed to update: %s", err)
-    end
-
-    return {
-        metadata = table.copy(space_format),
-        rows = {result},
-    }
+    return schema.wrap_func_reload(call_update_on_router, space_name, key, user_operations, opts)
 end
 
 return update

--- a/test/entrypoint/srv_update_schema.lua
+++ b/test/entrypoint/srv_update_schema.lua
@@ -1,0 +1,79 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+_G.is_initialized = function() return false end
+
+local log = require('log')
+local errors = require('errors')
+local cartridge = require('cartridge')
+
+package.preload['customers-storage'] = function()
+    local engine = os.getenv('ENGINE') or 'memtx'
+    return {
+        role_name = 'customers-storage',
+        init = function()
+            rawset(_G, 'create_space', function()
+                local customers_space = box.schema.space.create('customers', {
+                    format = {
+                        {name = 'id', type = 'unsigned'},
+                        {name = 'bucket_id', type = 'unsigned'},
+                        {name = 'value', type = 'string'},
+                    },
+                    if_not_exists = true,
+                    engine = engine,
+                })
+
+                -- primary index
+                customers_space:create_index('id_index', {
+                    parts = { {field = 'id'} },
+                    if_not_exists = true,
+                })
+            end)
+
+            rawset(_G, 'create_bucket_id_index', function()
+                box.space.customers:create_index('bucket_id', {
+                    parts = { {field = 'bucket_id'} },
+                    if_not_exists = true,
+                    unique = false,
+                })
+            end)
+
+            rawset(_G, 'set_value_type_to_unsigned', function()
+                local new_format = {}
+
+                for _, field_format in ipairs(box.space.customers:format()) do
+                    if field_format.name == 'value' then
+                        field_format.type = 'unsigned'
+                    end
+                    table.insert(new_format, field_format)
+                end
+
+                box.space.customers:format(new_format)
+            end)
+
+            rawset(_G, 'add_extra_field', function()
+                local new_format = box.space.customers:format()
+                table.insert(new_format, {name = 'extra', type = 'string', is_nullable = true})
+                box.space.customers:format(new_format)
+            end)
+        end,
+    }
+end
+
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+    advertise_uri = 'localhost:3301',
+    http_port = 8081,
+    bucket_count = 3000,
+    roles = {
+        'cartridge.roles.crud-router',
+        'cartridge.roles.crud-storage',
+        'customers-storage',
+    },
+})
+
+if not ok then
+    log.error('%s', err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -118,6 +118,19 @@ function helpers.stop_cluster(cluster)
     fio.rmtree(cluster.datadir)
 end
 
+function helpers.drop_space_on_cluster(cluster, space_name)
+    assert(cluster ~= nil)
+    for _, server in ipairs(cluster.servers) do
+        server.net_box:eval([[
+            local space_name = ...
+            local space = box.space[space_name]
+            if space ~= nil and not box.cfg.read_only then
+                space:drop()
+            end
+        ]], {space_name})
+    end
+end
+
 function helpers.truncate_space_on_cluster(cluster, space_name)
     assert(cluster ~= nil)
     for _, server in ipairs(cluster.servers) do
@@ -160,6 +173,13 @@ function helpers.get_test_replicasets()
             },
         }
     }
+end
+
+function helpers.call_on_servers(cluster, aliases, func)
+    for _, alias in ipairs(aliases) do
+        local server = cluster:server(alias)
+        func(server)
+    end
 end
 
 return helpers

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -41,7 +41,7 @@ pgroup:add('test_non_existent_space', function(g)
     )
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, "Space non_existent_space doesn't exist")
+    t.assert_str_contains(err.err, "Space \"non_existent_space\" doesn't exist")
 end)
 
 pgroup:add('test_not_valid_value_type', function(g)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -119,7 +119,6 @@ pgroup:add('test_insert_object_get', function(g)
         'crud.insert_object', {'customers', {id = 1, name = 'Alexander', age = 37}})
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-000000000000", true)
     t.assert_str_contains(err.err, "Duplicate key exists")
 
     -- bad format
@@ -155,7 +154,6 @@ pgroup:add('test_insert_get', function(g)
     local obj, err = g.cluster.main_server.net_box:call('crud.insert', {'customers', {2, box.NULL, 'Ivan', 20}})
 
     t.assert_equals(obj, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-000000000000", true)
     t.assert_str_contains(err.err, "Duplicate key exists")
 
     -- get non-existent
@@ -205,7 +203,6 @@ pgroup:add('test_update', function(g)
         'crud.update', {'customers', 'bad-key', {{'+', 'age', 10},}})
 
     t.assert_equals(result, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-000000000000", true)
     t.assert_str_contains(err.err, "Supplied key type of part 0 does not match index part type:")
 
     -- update by field numbers
@@ -262,7 +259,6 @@ pgroup:add('test_delete', function(g)
     local result, err = g.cluster.main_server.net_box:call('crud.delete', {'customers', 'bad-key'})
 
     t.assert_equals(result, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-000000000000", true)
     t.assert_str_contains(err.err, "Supplied key type of part 0 does not match index part type:")
 end)
 

--- a/test/integration/updated_shema_test.lua
+++ b/test/integration/updated_shema_test.lua
@@ -1,0 +1,682 @@
+local fio = require('fio')
+
+local t = require('luatest')
+
+local helpers = require('test.helper')
+
+local crud_utils = require('crud.common.utils')
+
+local pgroup = helpers.pgroup.new('updated_schema', {
+    engine = {'memtx', 'vinyl'},
+})
+
+pgroup:set_before_all(function(g)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_update_schema'),
+        use_vshard = true,
+        replicasets = helpers.get_test_replicasets(),
+        env = {
+            ['ENGINE'] = g.params.engine,
+        },
+    })
+
+    g.cluster:start()
+end)
+
+pgroup:set_after_all(function(g) helpers.stop_cluster(g.cluster) end)
+
+pgroup:set_before_each(function(g)
+    helpers.drop_space_on_cluster(g.cluster, 'customers')
+    -- force schema update on router
+    g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
+        for _, replicaset in pairs(vshard.router.routeall()) do
+            local master = replicaset.master
+
+            if not master.conn:ping({timeout = 3}) then
+                return nil, FetchSchemaError:new(
+                    "Failed to ping replicaset %s master (%s)",
+                    replicaset.uuid,
+                    master.uuid
+                )
+            end
+        end
+    ]])
+end)
+
+pgroup:add('test_insert_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_insert_object_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert_object', {'customers', {id = 11, value = 'XXX'}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert_object', {'customers', {id = 11, value = 'XXX'}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_get_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.get', {'customers', 1}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.get', {'customers', 1}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_delete_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.delete', {'customers', 11}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.delete', {'customers', 11}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_update_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.update', {'customers', 11, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- insert tuple
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert', {'customers', {11, nil, 'XXX'}}
+    )
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.update', {'customers', 11, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_replace_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_replace_object_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace_object', {'customers', {id = 11, value = 'XXX'}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace_object', {'customers', {id = 11, value = 'XXX'}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_upsert_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 'XXX'}, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 'XXX'}, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_upsert_object_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert_object', {'customers', {id = 11, value = 'XXX'}, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert_object', {'customers', {id = 11, value = 'XXX'}, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_select_non_existent_space', function(g)
+    -- non-existent space err
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers'}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+
+    -- create space
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers'}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_insert_no_bucket_id_index', function(g)
+    -- create space w/o bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+    end)
+
+    -- no bucket ID index error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.insert', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "\"bucket_id\" index is not found")
+
+    -- create bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_replace_no_bucket_id_index', function(g)
+    -- create space w/o bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+    end)
+
+    -- no bucket ID index error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "\"bucket_id\" index is not found")
+
+    -- create bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace', {'customers', {11, nil, 'XXX'}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_upsert_no_bucket_id_index', function(g)
+    -- create space w/o bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+    end)
+
+    -- no bucket ID index error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 'XXX'}, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "\"bucket_id\" index is not found")
+
+    -- create bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 'XXX'}, {{'=', 'value', 'YYY'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_insert_field_type_changed', function(g)
+    -- create space w/ bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- value should be string error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.insert', {'customers', {11, nil, 123}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Tuple field 3 type does not match one required by operation: expected string")
+
+    -- set value type to unsigned
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('set_value_type_to_unsigned')
+    end)
+
+    -- check that schema changes were applied
+    -- insert value unsigned - OK
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert', {'customers', {11, nil, 123}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_replace_field_type_changed', function(g)
+    -- create space w/ bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- value should be string error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace', {'customers', {11, nil, 123}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Tuple field 3 type does not match one required by operation: expected string")
+
+    -- set value type to unsigned
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('set_value_type_to_unsigned')
+    end)
+
+    -- check that schema changes were applied
+    -- insert value unsigned - OK
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace', {'customers', {11, nil, 123}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_upsert_field_type_changed', function(g)
+    -- create space w/ bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- value should be string error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 123}, {{'=', 'value', 456}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Tuple field 3 type does not match one required by operation: expected string")
+
+    -- set value type to unsigned
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('set_value_type_to_unsigned')
+    end)
+
+    -- check that schema changes were applied
+    -- insert value unsigned - OK
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 123}, {{'=', 'value', 456}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_update_field_added', function(g)
+    -- create space w/ bucket_id index and insert tuple
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.insert', {'customers', {11, nil, 'XXX'}}
+    )
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+
+    -- unknown field error
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.update', {'customers', 11, {{'=', 'extra', 'EXTRRRRA'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+
+    if not crud_utils.tarantool_supports_fieldpaths() then
+        t.assert_str_contains(err.err, "Space format doesn't contain field named \"extra\"")
+    else
+        t.assert_str_contains(err.err, "Field 'extra' was not found in the tuple")
+    end
+
+    -- add extra field
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('add_extra_field')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.update', {'customers', 11, {{'=', 'extra', 'EXTRRRRA'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_upsert_field_added', function(g)
+    -- create space w/ bucket_id index and insert tuple
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- unknown field error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 'XXX'}, {{'=', 'extra', 'EXTRRRRA'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+
+    if not crud_utils.tarantool_supports_fieldpaths() then
+        t.assert_str_contains(err.err, "Space format doesn't contain field named \"extra\"")
+    else
+        t.assert_str_contains(err.err, "Field 'extra' was not found in the tuple")
+    end
+
+    -- add extra field
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('add_extra_field')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert', {'customers', {11, nil, 'XXX'}, {{'=', 'extra', 'EXTRRRRA'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_select_field_added', function(g)
+    -- create space w/ bucket_id index and insert tuple
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- unknown field error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', {{'==', 'extra', 'EXTRRRRA'}}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "No field or index \"extra\" found")
+
+    -- add extra field
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('add_extra_field')
+    end)
+
+    -- check that schema changes were applied
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', {{'==', 'extra', 'EXTRRRRA'}}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_insert_object_field_type_changed', function(g)
+    -- create space w/ bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- value should be string error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.insert_object', {'customers', {id = 11, value = 123}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Tuple field 3 type does not match one required by operation: expected string")
+
+    -- set value type to unsigned
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('set_value_type_to_unsigned')
+    end)
+
+    -- check that schema changes were applied
+    -- insert value unsigned - OK
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.insert_object', {'customers', {id = 11, value = 123}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_replace_object_field_type_changed', function(g)
+    -- create space w/ bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- value should be string error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.replace_object', {'customers', {id = 11, value = 123}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Tuple field 3 type does not match one required by operation: expected string")
+
+    -- set value type to unsigned
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('set_value_type_to_unsigned')
+    end)
+
+    -- check that schema changes were applied
+    -- insert value unsigned - OK
+    local obj, err = g.cluster.main_server.net_box:call(
+       'crud.replace_object', {'customers', {id = 11, value = 123}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)
+
+pgroup:add('test_upsert_object_field_type_changed', function(g)
+    -- create space w/ bucket_id index
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('create_space')
+        server.net_box:call('create_bucket_id_index')
+    end)
+
+    -- value should be string error
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert_object', {'customers', {id = 11, value = 123}, {}}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, "Tuple field 3 type does not match one required by operation: expected string")
+
+    -- set value type to unsigned
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('set_value_type_to_unsigned')
+    end)
+
+    -- check that schema changes were applied
+    -- insert value unsigned - OK
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.upsert_object', {'customers', {id = 11, value = 123}, {}}
+    )
+
+    t.assert_is_not(obj, nil)
+    t.assert_equals(err, nil)
+end)

--- a/test/unit/serialization_test.lua
+++ b/test/unit/serialization_test.lua
@@ -90,6 +90,20 @@ g.test_flatten = function()
     local tuple, err = utils.flatten(object, space_format)
     t.assert(err == nil)
     t.assert_equals(tuple, {1, 1024, 'Marilyn', nil})
+
+    -- unknown field is specififed
+    local object = {
+        id = 1,
+        bucket_id = 1024,
+        name = 'Marilyn',
+        age = 50,
+        some_unknown_field = 'XXX',
+    }
+
+    local tuple, err = utils.flatten(object, space_format)
+    t.assert_is(tuple, nil)
+    t.assert_is_not(err, nil)
+    t.assert_str_contains(err.err, 'Unknown field \"some_unknown_field\" is specified')
 end
 
 g.test_unflatten = function()


### PR DESCRIPTION
The problem is that if schema is changed on storages, router still uses
outdated schema from vshard connection. It leads to errors like 
"non-existent space" when space is already created. 
The solution is quite simple - all such errors leads to `conn:reload_schema()` 
call and then crud retries. In case of error on the storage-side (e.g. in `*_object` 
functions when object was flattened using outdated space format) space schema
hash is returned. Router compares this hash with hash of schema that was used 
on router-side, and reloads schema if hashes are different.
 `conn:reload_schema()` is called by one fiber at time - if reloading is in progress,
other fibers just wait for it to end.

Closes #98 
