### PR TITLE
utils: implement flatten function using codegeneration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Fixed select crash when dropping indexes
 * Using outdated schema on router-side
+* Sparsed tuples generation that led to "Tuple/Key must be MsgPack array" error
 
 ### Added
 
 * Support for UUID field types and UUID values
-
-### Fixed
-
-* Fixed select crash when dropping indexes.
 
 ## [0.4.0] - 2020-12-02
 

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -52,40 +52,71 @@ function utils.get_space_format(space_name, replicasets)
     return space_format
 end
 
-local system_fields = { bucket_id = true }
+local function append(lines, s, ...)
+    table.insert(lines, string.format(s, ...))
+end
+
+local flatten_functions_cache = setmetatable({}, {__mode = 'k'})
 
 function utils.flatten(object, space_format, bucket_id)
-    if object == nil then return nil end
+    local flatten_func = flatten_functions_cache[space_format]
+    if flatten_func ~= nil then
+        local data, err = flatten_func(object, bucket_id)
+        if err ~= nil then
+            return nil, FlattenError:new(err)
+        end
+        return data
+    end
 
-    local tuple = {}
+    local lines = {}
+    append(lines, 'local object, bucket_id = ...')
 
-    local fieldnames = {}
+    append(lines, 'for k in pairs(object) do')
+    append(lines, '    if fieldmap[k] == nil then')
+    append(lines, '        return nil, format(\'Unknown field %%q is specified\', k)')
+    append(lines, '    end')
+    append(lines, 'end')
 
-    for fieldno, field_format in ipairs(space_format) do
-        local fieldname = field_format.name
-        local value = object[fieldname]
+    local len = #space_format
+    append(lines, 'local result = {%s}', string.rep('NULL,', len))
 
-        if not system_fields[fieldname] then
-            if not field_format.is_nullable and value == nil then
-                return nil, FlattenError:new("Field %q isn't nullable", fieldname)
+    local fieldmap = {}
+
+    for i, field in ipairs(space_format) do
+        fieldmap[field.name] = true
+        if field.name ~= 'bucket_id' then
+            append(lines, 'if object[%q] ~= nil then', field.name)
+            append(lines, '    result[%d] = object[%q]', i, field.name)
+            if field.is_nullable ~= true then
+                append(lines, 'else')
+                append(lines, '    return nil, \'Field %q isn\\\'t nullable\'', field.name)
             end
-        end
-
-        if bucket_id ~= nil and fieldname == 'bucket_id' then
-            value = bucket_id
-        end
-
-        tuple[fieldno] = value
-        fieldnames[fieldname] = true
-    end
-
-    for fieldname in pairs(object) do
-        if not fieldnames[fieldname] then
-            return nil, FlattenError:new("Unknown field %q is specified", fieldname)
+            append(lines, 'end')
+        else
+            append(lines, 'if bucket_id ~= nil then')
+            append(lines, '    result[%d] = bucket_id', i, field.name)
+            append(lines, 'else')
+            append(lines, '    result[%d] = object[%q]', i, field.name)
+            append(lines, 'end')
         end
     end
+    append(lines, 'return result')
 
-    return tuple
+    local code = table.concat(lines, '\n')
+    local env = {
+        pairs = pairs,
+        format = string.format,
+        fieldmap = fieldmap,
+        NULL = box.NULL,
+    }
+    flatten_func = assert(load(code, '@flatten', 't', env))
+
+    flatten_functions_cache[space_format] = flatten_func
+    local data, err = flatten_func(object, bucket_id)
+    if err ~= nil then
+        return nil, FlattenError:new(err)
+    end
+    return data
 end
 
 function utils.unflatten(tuple, space_format)

--- a/test/entrypoint/srv_simple_operations.lua
+++ b/test/entrypoint/srv_simple_operations.lua
@@ -31,6 +31,39 @@ package.preload['customers-storage'] = function()
                 unique = false,
                 if_not_exists = true,
             })
+
+            -- Space with huge amount of nullable fields
+            -- an object that inserted in such space should get
+            -- explicit nulls in absence fields otherwise
+            -- Tarantool serializers could consider such object as map (not array).
+            local tags_space = box.schema.space.create('tags', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                    {name = 'bucket_id', type = 'unsigned'},
+                    {name = 'is_red', type = 'boolean', is_nullable = true},
+                    {name = 'is_green', type = 'boolean', is_nullable = true},
+                    {name = 'is_blue', type = 'boolean', is_nullable = true},
+                    {name = 'is_yellow', type = 'boolean', is_nullable = true},
+                    {name = 'is_sweet', type = 'boolean', is_nullable = true},
+                    {name = 'is_dirty', type = 'boolean', is_nullable = true},
+                    {name = 'is_long', type = 'boolean', is_nullable = true},
+                    {name = 'is_short', type = 'boolean', is_nullable = true},
+                    {name = 'is_useful', type = 'boolean', is_nullable = true},
+                    {name = 'is_correct', type = 'boolean', is_nullable = true},
+                },
+                if_not_exists = true,
+                engine = engine,
+            })
+
+            tags_space:create_index('id', {
+                parts = { {field = 'id'} },
+                if_not_exists = true,
+            })
+            tags_space:create_index('bucket_id', {
+                parts = { {field = 'bucket_id'} },
+                unique = false,
+                if_not_exists = true,
+            })
         end,
     }
 end

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -391,3 +391,113 @@ pgroup:add('test_upsert', function(g)
     t.assert_equals(err, nil)
     t.assert_equals(result.rows, {{67, 1143, 'Mikhail Saltykov-Shchedrin', 63}})
 end)
+
+pgroup:add('test_object_with_nullable_fields', function(g)
+    -- Insert
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.insert_object', {'tags', {id = 1, is_green = true}})
+    t.assert_equals(err, nil)
+
+    -- {1, 477, NULL, true, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            bucket_id = 477,
+            id = 1,
+            is_blue = box.NULL,
+            is_correct = box.NULL,
+            is_dirty = box.NULL,
+            is_green = true,
+            is_long = box.NULL,
+            is_red = box.NULL,
+            is_short = box.NULL,
+            is_sweet = box.NULL,
+            is_useful = box.NULL,
+            is_yellow = box.NULL,
+        }
+    })
+
+    -- Update
+    -- {1, 477, NULL, true, NULL, NULL, true, NULL, NULL, NULL, NULL, NULL}
+    -- Shouldn't failed because of https://github.com/tarantool/tarantool/issues/3378
+    result, err = g.cluster.main_server.net_box:call(
+        'crud.update', {'tags', 1, {{'=', 'is_sweet', true}}})
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            bucket_id = 477,
+            id = 1,
+            is_blue = box.NULL,
+            is_correct = box.NULL,
+            is_dirty = box.NULL,
+            is_green = true,
+            is_long = box.NULL,
+            is_red = box.NULL,
+            is_short = box.NULL,
+            is_sweet = true,
+            is_useful = box.NULL,
+            is_yellow = box.NULL,
+        }
+    })
+
+    -- Replace
+    -- {2, 401, NULL, true, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
+    result, err = g.cluster.main_server.net_box:call(
+        'crud.replace_object', {'tags', {id = 2, is_green = true}})
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            bucket_id = 401,
+            id = 2,
+            is_blue = box.NULL,
+            is_correct = box.NULL,
+            is_dirty = box.NULL,
+            is_green = true,
+            is_long = box.NULL,
+            is_red = box.NULL,
+            is_short = box.NULL,
+            is_sweet = box.NULL,
+            is_useful = box.NULL,
+            is_yellow = box.NULL,
+        }
+    })
+
+    -- Upsert: first is insert then update
+    -- {3, 2804, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, NULL, NULL}
+    local _, err = g.cluster.main_server.net_box:call(
+        'crud.upsert_object', {'tags', {id = 3, is_dirty = true}, {
+             {'=', 'is_dirty', true},
+    }})
+    t.assert_equals(err, nil)
+
+    -- {3, 2804, NULL, NULL, NULL, NULL, NULL, true, NULL, true, true, NULL}
+    -- Shouldn't failed because of https://github.com/tarantool/tarantool/issues/3378
+    _, err = g.cluster.main_server.net_box:call(
+        'crud.upsert_object', {'tags', {id = 3, is_dirty = true}, {
+             {'=', 'is_useful', true},
+    }})
+    t.assert_equals(err, nil)
+
+    -- Get
+    result, err = g.cluster.main_server.net_box:call('crud.get', {'tags', 3})
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            bucket_id = 2804,
+            id = 3,
+            is_blue = box.NULL,
+            is_correct = box.NULL,
+            is_dirty = true,
+            is_green = box.NULL,
+            is_long = box.NULL,
+            is_red = box.NULL,
+            is_short = box.NULL,
+            is_sweet = box.NULL,
+            is_useful = true,
+            is_yellow = box.NULL,
+        }
+    })
+end)


### PR DESCRIPTION
This patch introduces new approach to "flatten" function. Before
thus patch we dynamically process every object using cycles,
temporary tables, etc.

This patch implements "flatten" function using codegeneration.
No temporary tables, no redundant loops, simple linear code that
just assign input object fields to corresponding tuple fields.
My simple benchmarks (8 fields + bucket_id) show that this
implementation at least 3 times faster than previous.

Example of code is following:
```lua
local object, bucket_id = ...
for k in pairs(object) do
    if fieldmap[k] == nil then
        return nil, format('Unknown field %q is specified', k)
    end
end
local result = {NULL,NULL,NULL,NULL,}
if object["id"] == nil then
    return nil, 'Field "id" isn\'t nullable'
end
result[1] = object["id"]
if bucket_id ~= nil then
    result[2] = bucket_id
else
    result[2] = object["bucket_id"]
end
if object["name"] == nil then
    return nil, 'Field "name" isn\'t nullable'
end
result[3] = object["name"]
result[4] = object["age"]
return result
```

Closes #119