### PR TITLE
Update function now adds intermediate nullable fields (if they needed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-* Fixed not fining field in tuple on ``crud.update`` if
+* Fixed not finding field in tuple on ``crud.update`` if
   there are ``is_nullable`` fields in front of it that were added
   when the schema was changed.
 * Fixed select crash when dropping indexes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Fixed not fining field in tuple on ``crud.update`` if
+  there are ``is_nullable`` fields in front of it that were added
+  when the schema was changed.
 * Fixed select crash when dropping indexes
 * Using outdated schema on router-side
 * Sparsed tuples generation that led to "Tuple/Key must be MsgPack array" error

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -261,7 +261,7 @@ local function convert_jsonpath_operation(operation)
     if #field_parts > 1 or field_id == nil then
         -- Checking '[4].a.b' case
         if field_name:sub(1, 1) == '[' and field_name:sub(-1, -1) == ']' then
-            local field_id = tonumber(field_name:sub(2, -2))
+            field_id = tonumber(field_name:sub(2, -2))
 
             if field_id == nil then
                 -- Checking '["field_name"]' case

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -291,32 +291,6 @@ function utils.convert_operations(user_operations, space_format)
     return converted_operations
 end
 
-function utils.get_operations_map(user_operations, space_format)
-    local operations_map = {}
-
-    for _, operation in ipairs(user_operations) do
-        if type(operation[2]) == 'string' then
-            local field_id
-            for fieldno, field_format in ipairs(space_format) do
-                if field_format.name == operation[2] then
-                    field_id = fieldno
-                    break
-                end
-            end
-
-            if field_id == nil then
-                return nil, ParseOperationsError:new(
-                        "Space format doesn't contain field named %q", operation[2])
-            end
-            operations_map[field_id] = operation
-        else
-            operations_map[operation[2]] = operation
-        end
-    end
-
-    return operations_map
-end
-
 function utils.unflatten_rows(rows, metadata)
     if metadata == nil then
         return nil, UnflattenError:new('Metadata is not provided')

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -223,19 +223,25 @@ local function add_nullable_fields_rec(operations, space_format, tuple, id)
 end
 
 function utils.add_intermediate_nullable_fields(operations, space_format, tuple)
-    if tuple ~= nil then
-        for i = 1, #operations do
-            operations = add_nullable_fields_rec(
-                operations,
-                space_format,
-                tuple,
-                operations[i][2]
-            )
-        end
-
-        table.sort(operations, function(v1, v2) return v1[2] < v2[2] end)
+    if tuple == nil then
+        return operations
     end
 
+    local operations, err = utils.convert_operations(operations, space_format)
+    if err ~= nil then
+        return nil, UpdateError:new("Wrong operations are specified: %s", err), true
+    end
+
+    for i = 1, #operations do
+        operations = add_nullable_fields_rec(
+            operations,
+            space_format,
+            tuple,
+            operations[i][2]
+        )
+    end
+
+    table.sort(operations, function(v1, v2) return v1[2] < v2[2] end)
     return operations
 end
 

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -229,7 +229,7 @@ function utils.add_intermediate_nullable_fields(operations, space_format, tuple)
 
     local operations, err = utils.convert_operations(operations, space_format)
     if err ~= nil then
-        return nil, UpdateError:new("Wrong operations are specified: %s", err), true
+        return operations
     end
 
     for i = 1, #operations do

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -199,82 +199,47 @@ function utils.tarantool_supports_uuids()
     return enabled_tarantool_features.uuids
 end
 
-function utils.table_to_string(tbl)
-    local result = "{"
-    for k, v in pairs(tbl) do
-        -- Check the key type (ignore any numerical keys - assume its an array)
-        if type(k) == "string" then
-            result = result.."[\""..k.."\"]".."="
+local function id_not_in_table(operations, id)
+    for _, operation in ipairs(operations) do
+        if operation[2] == id then
+            return false
         end
+    end
 
-        -- Check the value type
-        if type(v) == "table" then
-            result = result..utils.table_to_string(v)
-        elseif type(v) == "boolean" then
-            result = result..tostring(v)
-        else
-            result = result.."\""..v.."\""
-        end
-        result = result..","
-    end
-    -- Remove leading commas from the result
-    if result ~= "" then
-        result = result:sub(1, result:len()-1)
-    end
-    return result.."}"
+    return true
 end
 
-function utils.add_intermediate_nullable_fields(user_operations, space_format)
-    local math = require('math')
-    local formatted_operations = {}
-    local max_field_id = 0
-    local file = io.open('test_form', 'a+')
-    io.output(file)
-
-    for _, operation in ipairs(user_operations) do
-        if type(operation[2]) == 'string' then
-            local field_id
-            for fieldno, field_format in ipairs(space_format) do
-                io.write(table_to_string(field_format))
-                if field_format.name == operation[2] then
-                    field_id = fieldno
-                    break
-                end
-                io.write(field_format.name)
-            end
-
-            if field_id == nil then
-                return nil, ParseOperationsError:new(
-                        "Space format doesn't contain field named %q", operation[2])
-            end
-
-            max_field_id = math.max(field_id, max_field_id)
-            table.insert(formatted_operations, {
-                operation[1], field_id, operation[3]
-            })
-        else
-            max_field_id = math.max(operation[2], max_field_id)
-            table.insert(formatted_operations, operation)
-        end
+local function add_nullable_fields_rec(operations, space_format, tuple, id)
+    if id < 2 or tuple[id - 1] ~= box.NULL then
+        return operations
     end
 
-    if max_field_id == #space_format then
-        for fieldno, field_format in ipairs(space_format) do
-            if field_format.is_nullable == true and fieldno ~= max_field_id then
-                table.insert(formatted_operations, {'=', fieldno, box.NULL})
-            end
-        end
+    if space_format[id - 1].is_nullable and id_not_in_table(operations, id - 1) then
+        table.insert(operations, {'=', id - 1, box.NULL})
+        return add_nullable_fields_rec(operations, space_format, tuple, id - 1)
     end
 
-    table.sort(formatted_operations, function(v1, v2) return v1[2] < v2[2] end)
-    return formatted_operations
+    return operations
+end
+
+function utils.add_intermediate_nullable_fields(operations, space_format, tuple)
+    if tuple ~= nil then
+        for i = 1, #operations do
+            operations = add_nullable_fields_rec(
+                operations,
+                space_format,
+                tuple,
+                operations[i][2]
+            )
+        end
+
+        table.sort(operations, function(v1, v2) return v1[2] < v2[2] end)
+    end
+
+    return operations
 end
 
 function utils.convert_operations(user_operations, space_format)
-    if utils.tarantool_supports_fieldpaths() then
-        return user_operations
-    end
-
     local converted_operations = {}
 
     for _, operation in ipairs(user_operations) do

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -222,22 +222,15 @@ local function add_nullable_fields_rec(operations, space_format, tuple, id)
     return operations
 end
 
--- Tarantool < 2 has no fields `box.error.NO_SUCH_FIELD_NO` and `box.error.NO_SUCH_FIELD_NAME`.
-function utils.is_field_not_found(err_code)
-    local patch_parts = _G._TARANTOOL:split('-', 1)[1]:split('.', 2)
-    local major = tonumber(patch_parts[1])
-
-    if major >= 2 then
-        if err_code == box.error.NO_SUCH_FIELD_NO or err_code == box.error.NO_SUCH_FIELD_NAME then
-            return true
-        end
-    else
-        if err_code == box.error.NO_SUCH_FIELD then
-            return true
-        end
+-- Tarantool < 2.3 has no fields `box.error.NO_SUCH_FIELD_NO` and `box.error.NO_SUCH_FIELD_NAME`.
+if _TARANTOOL >= "2.3" then
+    function utils.is_field_not_found(err_code)
+        return err_code == box.error.NO_SUCH_FIELD_NO or err_code == box.error.NO_SUCH_FIELD_NAME
     end
-
-    return false
+else
+    function utils.is_field_not_found(err_code)
+        return err_code == box.error.NO_SUCH_FIELD
+    end
 end
 
 function utils.add_intermediate_nullable_fields(operations, space_format, tuple)

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -227,22 +227,22 @@ function utils.add_intermediate_nullable_fields(operations, space_format, tuple)
         return operations
     end
 
-    local operations, err = utils.convert_operations(operations, space_format)
+    local formatted_operations, err = utils.convert_operations(operations, space_format)
     if err ~= nil then
         return operations
     end
 
-    for i = 1, #operations do
-        operations = add_nullable_fields_rec(
-            operations,
+    for i = 1, #formatted_operations do
+        formatted_operations = add_nullable_fields_rec(
+            formatted_operations,
             space_format,
             tuple,
-            operations[i][2]
+            formatted_operations[i][2]
         )
     end
 
-    table.sort(operations, function(v1, v2) return v1[2] < v2[2] end)
-    return operations
+    table.sort(formatted_operations, function(v1, v2) return v1[2] < v2[2] end)
+    return formatted_operations
 end
 
 function utils.convert_operations(user_operations, space_format)

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -222,6 +222,24 @@ local function add_nullable_fields_rec(operations, space_format, tuple, id)
     return operations
 end
 
+-- Tarantool < 2 has no fields `box.error.NO_SUCH_FIELD_NO` and `box.error.NO_SUCH_FIELD_NAME`.
+function utils.is_field_not_found(err_code)
+    local patch_parts = _G._TARANTOOL:split('-', 1)[1]:split('.', 2)
+    local major = tonumber(patch_parts[1])
+
+    if major >= 2 then
+        if err_code == box.error.NO_SUCH_FIELD_NO or err_code == box.error.NO_SUCH_FIELD_NAME then
+            return true
+        end
+    else
+        if err_code == box.error.NO_SUCH_FIELD then
+            return true
+        end
+    end
+
+    return false
+end
+
 function utils.add_intermediate_nullable_fields(operations, space_format, tuple)
     if tuple == nil then
         return operations

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -74,8 +74,9 @@ local function call_update_on_router(space_name, key, user_operations, opts)
         key = key:totable()
     end
 
+    local err
     if not utils.tarantool_supports_fieldpaths() then
-        local user_operations, err = utils.convert_operations(user_operations, space_format)
+        user_operations, err = utils.convert_operations(user_operations, space_format)
         if err ~= nil then
             return nil, UpdateError:new("Wrong operations are specified: %s", err), true
         end

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -82,7 +82,7 @@ local function call_update_on_router(space_name, key, user_operations, opts)
     end
 
     local space_format = space:format()
-    local formatted_operations, err = utils.convert_operations(user_operations, space_format)
+    local operations, err = utils.convert_operations(user_operations, space_format)
     if err ~= nil then
         return nil, UpdateError:new("Wrong operations are specified: %s", err), true
     end
@@ -90,7 +90,7 @@ local function call_update_on_router(space_name, key, user_operations, opts)
     local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
     local storage_result, err = call.rw_single(
         bucket_id, UPDATE_FUNC_NAME,
-        {space_name, key, formatted_operations, opts.fields},
+        {space_name, key, operations, opts.fields},
         {timeout = opts.timeout}
     )
 

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -37,9 +37,8 @@ local function update_on_storage(space_name, key, operations, field_names)
         return res, nil
     end
 
-    if (res.err.code == box.error.NO_SUCH_FIELD_NO or res.err.code == box.error.NO_SUCH_FIELD_NAME) then
+    if res.err.code == box.error.NO_SUCH_FIELD_NO or res.err.code == box.error.NO_SUCH_FIELD_NAME then
         operations = utils.add_intermediate_nullable_fields(operations, space:format(), space:get(key))
-
         res, err = schema.wrap_box_space_func_result(space, 'update', {key, operations}, {
             add_space_schema_hash = false,
             field_names = field_names,

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -77,11 +77,12 @@ local function call_update_on_router(space_name, key, user_operations, opts)
         return nil, UpdateError:new("Space %q doesn't exist", space_name), true
     end
 
+    local space_format = space:format()
+
     if box.tuple.is(key) then
         key = key:totable()
     end
 
-    local space_format = space:format()
     local operations, err = utils.convert_operations(user_operations, space_format)
     if err ~= nil then
         return nil, UpdateError:new("Wrong operations are specified: %s", err), true

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -82,17 +82,15 @@ local function call_update_on_router(space_name, key, user_operations, opts)
     end
 
     local space_format = space:format()
-    if not utils.tarantool_supports_fieldpaths() then
-        user_operations, err = utils.convert_operations(user_operations, space_format)
-        if err ~= nil then
-            return nil, UpdateError:new("Wrong operations are specified: %s", err), true
-        end
+    local formatted_operations, err = utils.convert_operations(user_operations, space_format)
+    if err ~= nil then
+        return nil, UpdateError:new("Wrong operations are specified: %s", err), true
     end
 
     local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
     local storage_result, err = call.rw_single(
         bucket_id, UPDATE_FUNC_NAME,
-        {space_name, key, user_operations, opts.fields},
+        {space_name, key, formatted_operations, opts.fields},
         {timeout = opts.timeout}
     )
 

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -57,18 +57,15 @@ local function call_update_on_router(space_name, key, user_operations, opts)
         key = key:totable()
     end
 
-    --local user_operations, err = utils.add_intermediate_nullable_fields(user_operations, space_format)
-    --if err ~= nil then
-        --return nil, UpdateError:new("%s", err), true
-    --end
     local operations, err = utils.convert_operations(user_operations, space_format)
-    local file = io.open('test1.txt', 'a+')
-    io.output(file)
-    io.write('\n\n')
-    io.write(utils.table_to_string(space_format))
-    io.write('\n\n')
     if err ~= nil then
         return nil, UpdateError:new("Wrong operations are specified: %s", err), true
+    end
+
+    if type(key) == 'table' or type(key) == 'number' then
+        local tuple = space:get{key}
+        -- See https://github.com/tarantool/crud/issues/113
+        operations = utils.add_intermediate_nullable_fields(operations, space_format, tuple)
     end
 
     local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -57,7 +57,16 @@ local function call_update_on_router(space_name, key, user_operations, opts)
         key = key:totable()
     end
 
+    --local user_operations, err = utils.add_intermediate_nullable_fields(user_operations, space_format)
+    --if err ~= nil then
+        --return nil, UpdateError:new("%s", err), true
+    --end
     local operations, err = utils.convert_operations(user_operations, space_format)
+    local file = io.open('test1.txt', 'a+')
+    io.output(file)
+    io.write('\n\n')
+    io.write(utils.table_to_string(space_format))
+    io.write('\n\n')
     if err ~= nil then
         return nil, UpdateError:new("Wrong operations are specified: %s", err), true
     end

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -74,15 +74,17 @@ local function call_update_on_router(space_name, key, user_operations, opts)
         key = key:totable()
     end
 
-    local operations, err = utils.convert_operations(user_operations, space_format)
-    if err ~= nil then
-        return nil, UpdateError:new("Wrong operations are specified: %s", err), true
+    if not utils.tarantool_supports_fieldpaths() then
+        local user_operations, err = utils.convert_operations(user_operations, space_format)
+        if err ~= nil then
+            return nil, UpdateError:new("Wrong operations are specified: %s", err), true
+        end
     end
 
     local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
     local storage_result, err = call.rw_single(
         bucket_id, UPDATE_FUNC_NAME,
-        {space_name, key, operations, opts.fields},
+        {space_name, key, user_operations, opts.fields},
         {timeout = opts.timeout}
     )
 

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -61,11 +61,9 @@ local function call_upsert_on_router(space_name, tuple, user_operations, opts)
     end
 
     local space_format = space:format()
-    if not utils.tarantool_supports_fieldpaths() then
-        user_operations, err = utils.convert_operations(user_operations, space_format)
-        if err ~= nil then
-            return nil, UpsertError:new("Wrong operations are specified: %s", err), true
-        end
+    local operations, err = utils.convert_operations(user_operations, space_format)
+    if err ~= nil then
+        return nil, UpsertError:new("Wrong operations are specified: %s", err), true
     end
 
     local bucket_id, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
@@ -75,7 +73,7 @@ local function call_upsert_on_router(space_name, tuple, user_operations, opts)
 
     local storage_result, err = call.rw_single(
         bucket_id, UPSERT_FUNC_NAME,
-        {space_name, tuple, user_operations},
+        {space_name, tuple, operations},
         {timeout = opts.timeout}
     )
 

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -61,9 +61,12 @@ local function call_upsert_on_router(space_name, tuple, user_operations, opts)
     end
 
     local space_format = space:format()
-    local operations, err = utils.convert_operations(user_operations, space_format)
-    if err ~= nil then
-        return nil, UpsertError:new("Wrong operations are specified: %s", err), true
+    local operations = user_operations
+    if not utils.tarantool_supports_fieldpaths() then
+        operations, err = utils.convert_operations(user_operations, space_format)
+        if err ~= nil then
+            return nil, UpsertError:new("Wrong operations are specified: %s", err), true
+        end
     end
 
     local bucket_id, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)

--- a/test/entrypoint/srv_simple_operations.lua
+++ b/test/entrypoint/srv_simple_operations.lua
@@ -32,6 +32,30 @@ package.preload['customers-storage'] = function()
                 if_not_exists = true,
             })
 
+            local developers_space = box.schema.space.create('developers', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                    {name = 'bucket_id', type = 'unsigned'},
+                },
+                if_not_exists = true,
+                engine = engine,
+            })
+            developers_space:create_index('id', {
+                parts = { {field = 'id'} },
+                if_not_exists = true,
+            })
+            developers_space:create_index('bucket_id', {
+                parts = { {field = 'bucket_id'} },
+                unique = false,
+                if_not_exists = true,
+            })
+
+            rawset(_G, 'add_extra_field', function(name)
+                local new_format = box.space.developers:format()
+                table.insert(new_format, {name = name, type = 'string', is_nullable = true})
+                box.space.developers:format(new_format)
+            end)
+
             -- Space with huge amount of nullable fields
             -- an object that inserted in such space should get
             -- explicit nulls in absence fields otherwise

--- a/test/entrypoint/srv_simple_operations.lua
+++ b/test/entrypoint/srv_simple_operations.lua
@@ -52,7 +52,7 @@ package.preload['customers-storage'] = function()
 
             rawset(_G, 'add_extra_field', function(name)
                 local new_format = box.space.developers:format()
-                table.insert(new_format, {name = name, type = 'string', is_nullable = true})
+                table.insert(new_format, {name = name, type = 'any', is_nullable = true})
                 box.space.developers:format(new_format)
             end)
 

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -412,6 +412,11 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
         server.net_box:call('add_extra_field', {'extra_4'})
         server.net_box:call('add_extra_field', {'extra_5'})
         server.net_box:call('add_extra_field', {'extra_6'})
+        server.net_box:call('add_extra_field', {'extra_7'})
+        server.net_box:call('add_extra_field', {'extra_8'})
+        server.net_box:call('add_extra_field', {'extra_9'})
+        server.net_box:call('add_extra_field', {'extra_10'})
+        server.net_box:call('add_extra_field', {'extra_11'})
     end)
 
     -- TODO: delete this, when issue (https://github.com/tarantool/crud/issues/98) will be closed
@@ -448,6 +453,29 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
             extra_4 = box.NULL,
             extra_5 = box.NULL,
             extra_6 = 'extra_value_6'
+        }
+    })
+
+    result, err = g.cluster.main_server.net_box:call('crud.update',
+        {'developers', 1, {{'=', 13, 'extra_value_11'}, {'=', 'extra_8', 'extra_value_8'}}})
+
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            id = 1,
+            bucket_id = 477,
+            extra_1 = box.NULL,
+            extra_2 = box.NULL,
+            extra_3 = 'extra_value_3',
+            extra_4 = box.NULL,
+            extra_5 = box.NULL,
+            extra_6 = 'extra_value_6',
+            extra_7 = box.NULL,
+            extra_8 = 'extra_value_8',
+            extra_9 = box.NULL,
+            extra_10 = box.NULL,
+            extra_11 = 'extra_value_11'
         }
     })
 end)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -420,8 +420,7 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
     end)
 
     -- TODO: delete this, when issue (https://github.com/tarantool/crud/issues/98) will be closed
-    g.cluster.main_server.net_box:call('crud.select',
-        {'developers', nil})
+    g.cluster.main_server.net_box:call('crud.select', {'developers'})
 
     result, err = g.cluster.main_server.net_box:call('crud.update',
         {'developers', 1, {{'=', 'extra_3', 'extra_value_3'}}})

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -419,9 +419,6 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
         server.net_box:call('add_extra_field', {'extra_11'})
     end)
 
-    -- TODO: delete this, when issue (https://github.com/tarantool/crud/issues/98) will be closed
-    g.cluster.main_server.net_box:call('crud.select', {'developers'})
-
     result, err = g.cluster.main_server.net_box:call('crud.update',
         {'developers', 1, {{'=', 'extra_3', 'extra_value_3'}}})
 

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -406,22 +406,13 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
     })
 
     helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
-        server.net_box:call('add_extra_field', {'extra_1'})
-        server.net_box:call('add_extra_field', {'extra_2'})
-        server.net_box:call('add_extra_field', {'extra_3'})
-        server.net_box:call('add_extra_field', {'extra_4'})
-        server.net_box:call('add_extra_field', {'extra_5'})
-        server.net_box:call('add_extra_field', {'extra_6'})
-        server.net_box:call('add_extra_field', {'extra_7'})
-        server.net_box:call('add_extra_field', {'extra_8'})
-        server.net_box:call('add_extra_field', {'extra_9'})
-        server.net_box:call('add_extra_field', {'extra_10'})
-        server.net_box:call('add_extra_field', {'extra_11'})
+        for i = 1, 12 do
+            server.net_box:call('add_extra_field', {'extra_' .. tostring(i)})
+        end
     end)
 
     result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 'extra_3', 'extra_value_3'}}})
-
+        {'developers', 1, {{'=', 'extra_3', { a = { b = {} } } }}})
     t.assert_equals(err, nil)
     objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {
@@ -430,13 +421,12 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
             bucket_id = 477,
             extra_1 = box.NULL,
             extra_2 = box.NULL,
-            extra_3 = 'extra_value_3',
+            extra_3 = {a = {b = {}}},
         }
     })
 
     result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 8, 'extra_value_6'}}}) -- update extra_6 field
-
+        {'developers', 1, {{'=', 'extra_3.a.b[1]', 2}, {'=', 'extra_5', 'extra_value_5'}}})
     t.assert_equals(err, nil)
     objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {
@@ -445,15 +435,14 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
             bucket_id = 477,
             extra_1 = box.NULL,
             extra_2 = box.NULL,
-            extra_3 = 'extra_value_3',
+            extra_3 = 2,
             extra_4 = box.NULL,
-            extra_5 = box.NULL,
-            extra_6 = 'extra_value_6'
+            extra_5 = 'extra_value_5'
         }
     })
 
     result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 13, 'extra_value_11'}, {'=', 'extra_8', 'extra_value_8'}}})
+        {'developers', 1, {{'=', 9, 'extra_value_7'}}}) -- update extra_7 field
 
     t.assert_equals(err, nil)
     objects = crud.unflatten_rows(result.rows, result.metadata)
@@ -463,15 +452,35 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
             bucket_id = 477,
             extra_1 = box.NULL,
             extra_2 = box.NULL,
-            extra_3 = 'extra_value_3',
+            extra_3 = 2,
             extra_4 = box.NULL,
-            extra_5 = box.NULL,
-            extra_6 = 'extra_value_6',
-            extra_7 = box.NULL,
-            extra_8 = 'extra_value_8',
-            extra_9 = box.NULL,
+            extra_5 = 'extra_value_5',
+            extra_6 = box.NULL,
+            extra_7 = 'extra_value_7'
+        }
+    })
+
+    result, err = g.cluster.main_server.net_box:call('crud.update',
+        {'developers', 1, {{'=', 14, 'extra_value_12'}, {'=', 'extra_9', 'extra_value_9'}}})
+
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            id = 1,
+            bucket_id = 477,
+            extra_1 = box.NULL,
+            extra_2 = box.NULL,
+            extra_3 = 2,
+            extra_4 = box.NULL,
+            extra_5 = 'extra_value_5',
+            extra_6 = box.NULL,
+            extra_7 = 'extra_value_7',
+            extra_8 = box.NULL,
+            extra_9 = 'extra_value_9',
             extra_10 = box.NULL,
-            extra_11 = 'extra_value_11'
+            extra_11 = box.NULL,
+            extra_12 = 'extra_value_12'
         }
     })
 end)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -425,64 +425,88 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
         }
     })
 
-    result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 'extra_3.a.b[1]', 2}, {'=', 'extra_5', 'extra_value_5'}}})
-    t.assert_equals(err, nil)
-    objects = crud.unflatten_rows(result.rows, result.metadata)
-    t.assert_equals(objects, {
-        {
-            id = 1,
-            bucket_id = 477,
-            extra_1 = box.NULL,
-            extra_2 = box.NULL,
-            extra_3 = 2,
-            extra_4 = box.NULL,
-            extra_5 = 'extra_value_5'
-        }
-    })
+    -- This tests use jsonpath updates.
+    if _TARANTOOL >= "2.3" then
+        result, err = g.cluster.main_server.net_box:call('crud.update',
+            {'developers', 1, {{'=', '[5].a.b[1]', 3}, {'=', 'extra_5', 'extra_value_5'}}})
+        t.assert_equals(err, nil)
+        objects = crud.unflatten_rows(result.rows, result.metadata)
+        t.assert_equals(objects, {
+            {
+                id = 1,
+                bucket_id = 477,
+                extra_1 = box.NULL,
+                extra_2 = box.NULL,
+                extra_3 = {a = {b = {3}}},
+                extra_4 = box.NULL,
+                extra_5 = 'extra_value_5'
+            }
+        })
 
-    result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 9, 'extra_value_7'}}}) -- update extra_7 field
+        result, err = g.cluster.main_server.net_box:call('crud.update',
+            {'developers', 1, {{'=', 'extra_3.a.b', 'extra_value_3'}, {'=', 9, 'extra_value_7'}}})
+        t.assert_equals(err, nil)
+        objects = crud.unflatten_rows(result.rows, result.metadata)
+        t.assert_equals(objects, {
+            {
+                id = 1,
+                bucket_id = 477,
+                extra_1 = box.NULL,
+                extra_2 = box.NULL,
+                extra_3 = {a = {b = 'extra_value_3'}},
+                extra_4 = box.NULL,
+                extra_5 = 'extra_value_5',
+                extra_6 = box.NULL,
+                extra_7 = 'extra_value_7'
+            }
+        })
 
-    t.assert_equals(err, nil)
-    objects = crud.unflatten_rows(result.rows, result.metadata)
-    t.assert_equals(objects, {
-        {
-            id = 1,
-            bucket_id = 477,
-            extra_1 = box.NULL,
-            extra_2 = box.NULL,
-            extra_3 = 2,
-            extra_4 = box.NULL,
-            extra_5 = 'extra_value_5',
-            extra_6 = box.NULL,
-            extra_7 = 'extra_value_7'
-        }
-    })
+        result, err = g.cluster.main_server.net_box:call('crud.update',
+            {'developers', 1, {
+                {'=', 14, 'extra_value_12'},
+                {'=', 'extra_9', 'extra_value_9'},
+                {'=', '["extra_3"]', 'updated_extra_value_3'}
+            }
+        })
 
-    result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 14, 'extra_value_12'}, {'=', 'extra_9', 'extra_value_9'}}})
-
-    t.assert_equals(err, nil)
-    objects = crud.unflatten_rows(result.rows, result.metadata)
-    t.assert_equals(objects, {
-        {
-            id = 1,
-            bucket_id = 477,
-            extra_1 = box.NULL,
-            extra_2 = box.NULL,
-            extra_3 = 2,
-            extra_4 = box.NULL,
-            extra_5 = 'extra_value_5',
-            extra_6 = box.NULL,
-            extra_7 = 'extra_value_7',
-            extra_8 = box.NULL,
-            extra_9 = 'extra_value_9',
-            extra_10 = box.NULL,
-            extra_11 = box.NULL,
-            extra_12 = 'extra_value_12'
-        }
-    })
+        t.assert_equals(err, nil)
+        objects = crud.unflatten_rows(result.rows, result.metadata)
+        t.assert_equals(objects, {
+            {
+                id = 1,
+                bucket_id = 477,
+                extra_1 = box.NULL,
+                extra_2 = box.NULL,
+                extra_3 = 'updated_extra_value_3',
+                extra_4 = box.NULL,
+                extra_5 = 'extra_value_5',
+                extra_6 = box.NULL,
+                extra_7 = 'extra_value_7',
+                extra_8 = box.NULL,
+                extra_9 = 'extra_value_9',
+                extra_10 = box.NULL,
+                extra_11 = box.NULL,
+                extra_12 = 'extra_value_12'
+            }
+        })
+    else
+        result, err = g.cluster.main_server.net_box:call('crud.update',
+            {'developers', 1, {{'=', 8, 'extra_value_6'}, {'=', 'extra_3', 'extra_value_3'}}})
+        t.assert_equals(err, nil)
+        objects = crud.unflatten_rows(result.rows, result.metadata)
+        t.assert_equals(objects, {
+            {
+                id = 1,
+                bucket_id = 477,
+                extra_1 = box.NULL,
+                extra_2 = box.NULL,
+                extra_3 = 'extra_value_3',
+                extra_4 = box.NULL,
+                extra_5 = box.NULL,
+                extra_6 = 'extra_value_6'
+            }
+        })
+    end
 end)
 
 pgroup:add('test_object_with_nullable_fields', function(g)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -411,7 +411,7 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
         end
     end)
 
-    result, err = g.cluster.main_server.net_box:call('crud.update',
+    local result, err = g.cluster.main_server.net_box:call('crud.update',
         {'developers', 1, {{'=', 'extra_3', { a = { b = {} } } }}})
     t.assert_equals(err, nil)
     objects = crud.unflatten_rows(result.rows, result.metadata)
@@ -427,86 +427,55 @@ pgroup:add('test_intermediate_nullable_fields_update', function(g)
 
     -- This tests use jsonpath updates.
     if _TARANTOOL >= "2.3" then
-        result, err = g.cluster.main_server.net_box:call('crud.update',
+        local _, err = g.cluster.main_server.net_box:call('crud.update',
             {'developers', 1, {{'=', '[5].a.b[1]', 3}, {'=', 'extra_5', 'extra_value_5'}}})
-        t.assert_equals(err, nil)
-        objects = crud.unflatten_rows(result.rows, result.metadata)
-        t.assert_equals(objects, {
-            {
-                id = 1,
-                bucket_id = 477,
-                extra_1 = box.NULL,
-                extra_2 = box.NULL,
-                extra_3 = {a = {b = {3}}},
-                extra_4 = box.NULL,
-                extra_5 = 'extra_value_5'
-            }
-        })
-
-        result, err = g.cluster.main_server.net_box:call('crud.update',
-            {'developers', 1, {{'=', 'extra_3.a.b', 'extra_value_3'}, {'=', 9, 'extra_value_7'}}})
-        t.assert_equals(err, nil)
-        objects = crud.unflatten_rows(result.rows, result.metadata)
-        t.assert_equals(objects, {
-            {
-                id = 1,
-                bucket_id = 477,
-                extra_1 = box.NULL,
-                extra_2 = box.NULL,
-                extra_3 = {a = {b = 'extra_value_3'}},
-                extra_4 = box.NULL,
-                extra_5 = 'extra_value_5',
-                extra_6 = box.NULL,
-                extra_7 = 'extra_value_7'
-            }
-        })
-
-        result, err = g.cluster.main_server.net_box:call('crud.update',
-            {'developers', 1, {
-                {'=', 14, 'extra_value_12'},
-                {'=', 'extra_9', 'extra_value_9'},
-                {'=', '["extra_3"]', 'updated_extra_value_3'}
-            }
-        })
-
-        t.assert_equals(err, nil)
-        objects = crud.unflatten_rows(result.rows, result.metadata)
-        t.assert_equals(objects, {
-            {
-                id = 1,
-                bucket_id = 477,
-                extra_1 = box.NULL,
-                extra_2 = box.NULL,
-                extra_3 = 'updated_extra_value_3',
-                extra_4 = box.NULL,
-                extra_5 = 'extra_value_5',
-                extra_6 = box.NULL,
-                extra_7 = 'extra_value_7',
-                extra_8 = box.NULL,
-                extra_9 = 'extra_value_9',
-                extra_10 = box.NULL,
-                extra_11 = box.NULL,
-                extra_12 = 'extra_value_12'
-            }
-        })
-    else
-        result, err = g.cluster.main_server.net_box:call('crud.update',
-            {'developers', 1, {{'=', 8, 'extra_value_6'}, {'=', 'extra_3', 'extra_value_3'}}})
-        t.assert_equals(err, nil)
-        objects = crud.unflatten_rows(result.rows, result.metadata)
-        t.assert_equals(objects, {
-            {
-                id = 1,
-                bucket_id = 477,
-                extra_1 = box.NULL,
-                extra_2 = box.NULL,
-                extra_3 = 'extra_value_3',
-                extra_4 = box.NULL,
-                extra_5 = box.NULL,
-                extra_6 = 'extra_value_6'
-            }
-        })
+        t.assert_equals(err.err, "Failed to update: Field ''extra_5'' was not found in the tuple")
     end
+
+    result, err = g.cluster.main_server.net_box:call('crud.update',
+        {'developers', 1, {{'=', 5, 'extra_value_3'}, {'=', 7, 'extra_value_5'}}})
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            id = 1,
+            bucket_id = 477,
+            extra_1 = box.NULL,
+            extra_2 = box.NULL,
+            extra_3 = 'extra_value_3',
+            extra_4 = box.NULL,
+            extra_5 = 'extra_value_5',
+        }
+    })
+
+    result, err = g.cluster.main_server.net_box:call('crud.update',
+        {'developers', 1, {
+            {'=', 14, 'extra_value_12'},
+            {'=', 'extra_9', 'extra_value_9'},
+            {'=', 'extra_3', 'updated_extra_value_3'}
+        }
+    })
+
+    t.assert_equals(err, nil)
+    objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {
+        {
+            id = 1,
+            bucket_id = 477,
+            extra_1 = box.NULL,
+            extra_2 = box.NULL,
+            extra_3 = 'updated_extra_value_3',
+            extra_4 = box.NULL,
+            extra_5 = 'extra_value_5',
+            extra_6 = box.NULL,
+            extra_7 = box.NULL,
+            extra_8 = box.NULL,
+            extra_9 = 'extra_value_9',
+            extra_10 = box.NULL,
+            extra_11 = box.NULL,
+            extra_12 = 'extra_value_12'
+        }
+    })
 end)
 
 pgroup:add('test_object_with_nullable_fields', function(g)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -392,6 +392,22 @@ pgroup:add('test_upsert', function(g)
     t.assert_equals(result.rows, {{67, 1143, 'Mikhail Saltykov-Shchedrin', 63}})
 end)
 
+pgroup:add('test_intermediate_nullable_fields_update', function(g)
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.insert', {'developers', {1, box.NULL}})
+    t.assert_equals(err, nil)
+
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
+        server.net_box:call('add_extra_field', {'extra_1'})
+        server.net_box:call('add_extra_field', {'extra_2'})
+    end)
+
+    local result, err = g.cluster.main_server.net_box:call('crud.update',
+        {'developers', 1, {{'=', 'extra_2', 'extra_value'}}})
+    t.assert_equals(err, nil)
+    --t.assert_equals(result, nil)
+end)
+
 pgroup:add('test_object_with_nullable_fields', function(g)
     -- Insert
     local result, err = g.cluster.main_server.net_box:call(


### PR DESCRIPTION
Fixed not fining field in tuple on ``crud.update`` if there are ``is_nullable`` fields in front of it that were added when the schema was changed. Closes #113 
