### PR TITLE
CI: Stop Mono server before tests

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -23,6 +23,10 @@ jobs:
           sudo apt install -y tarantool-dev
           ./deps.sh
 
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - name: Run linter
         run: .rocks/bin/luacheck .
 
@@ -47,6 +51,10 @@ jobs:
           sudo cp tarantool-enterprise/tarantool /usr/bin/tarantool
           source tarantool-enterprise/env.sh
           ./deps.sh
+
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 
       - name: Run linter
         run: .rocks/bin/luacheck .


### PR DESCRIPTION
Mono server starts unexpectedly on GitHub Actions. 
It uses 8084 port that is needed for tests.
Since this patch Mono process is killed before running tests.
