### PR TITLE
Add read strategy parameters opts

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,5 @@
 redefined = false
-globals = {'box', 'utf8'}
+globals = {'box', 'utf8', 'checkers'}
 include_files = {'**/*.lua', '*.luacheckrc', '*.rockspec'}
 exclude_files = {'**/*.rocks/', 'tmp/', 'tarantool-enterprise/'}
 max_line_length = 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* `mode`, `prefer_replica` and `balance` options for read operations
+  (get, select, pairs). According to this parameters one of vshard
+  calls (`callrw`, `callro`, `callbro`, `callre`, `callbre`) is selected
+
 ## [0.5.0] - 2021-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,9 +113,14 @@ where:
 * `space_name` (`string`) - name of the space
 * `key` (`any`) - primary key value
 * `opts`:
-  * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
-  * `bucket_id` (`?number|cdata`) - bucket ID
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `bucket_id` (`?number|cdata`) - bucket ID
+  * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `mode` (`?string`, `read` or `write`) - if `write` is specified then `get` is
+    performed on master
+  * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
+    the replicas
+  * `balance` (`?boolean`) - use replica according to vshard load balancing policy
 
 Returns metadata and array contains one row, error.
 
@@ -315,9 +320,14 @@ where:
      (`after` option is required in this case).
   * `after` (`?table`) - tuple after which objects should be selected
   * `batch_size` (`?number`) - number of tuples to process per one request to storage
-  * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `bucket_id` (`?number|cdata`) - bucket ID
-    (is used when select by full primary key is performed)
+  * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `mode` (`?string`, `read` or `write`) - if `write` is specified then `select` is
+    performed on master
+  * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
+    the replicas
+  * `balance` (`?boolean`) - use replica according to vshard load balancing policy
+
 
 Returns metadata and array of rows, error.
 

--- a/crud/common/call.lua
+++ b/crud/common/call.lua
@@ -12,13 +12,69 @@ local call = {}
 
 local DEFAULT_VSHARD_CALL_TIMEOUT = 2
 
-local function call_impl(vshard_call, func_name, func_args, opts)
-    dev_checks('string', 'string', '?table', {
+local function get_vshard_call_name(mode, prefer_replica, balance)
+    dev_checks('string', '?boolean', '?boolean')
+
+    if mode == 'write' then
+        return 'callrw'
+    end
+
+    if not prefer_replica and not balance then
+        return 'callro'
+    end
+
+    if not prefer_replica and balance then
+        return 'callbro'
+    end
+
+    if prefer_replica and not balance then
+        return 'callre'
+    end
+
+    -- prefer_replica and balance
+    return 'callbre'
+end
+
+local function wrap_vshard_err(err, func_name, replicaset_uuid, bucket_id)
+    if err.type == 'ClientError' and type(err.message) == 'string' then
+        if err.message == string.format("Procedure '%s' is not defined", func_name) then
+            if func_name:startswith('_crud.') then
+                err = NotInitializedError:new("crud isn't initialized on replicaset: %q", replicaset_uuid)
+            else
+                err = NotInitializedError:new("Function %s is not registered", func_name)
+            end
+        end
+    end
+
+    if replicaset_uuid == nil then
+        local replicaset, _ = vshard.router.route(bucket_id)
+        if replicaset == nil then
+            return CallError:new(
+                "Function returned an error, but we couldn't figure out the replicaset: %s", err
+            )
+        end
+
+        replicaset_uuid = replicaset.uuid
+    end
+
+    err = errors.wrap(err)
+
+    return CallError:new(utils.format_replicaset_error(
+        replicaset_uuid, "Function returned an error: %s", err
+    ))
+end
+
+function call.map(func_name, func_args, opts)
+    dev_checks('string', '?table', {
+        mode = 'string',
+        prefer_replica = '?boolean',
+        balance = '?boolean',
         timeout = '?number',
         replicasets = '?table',
     })
-
     opts = opts or {}
+
+    local vshard_call_name = get_vshard_call_name(opts.mode, opts.prefer_replica, opts.balance)
 
     local timeout = opts.timeout or DEFAULT_VSHARD_CALL_TIMEOUT
 
@@ -35,7 +91,7 @@ local function call_impl(vshard_call, func_name, func_args, opts)
     local futures_by_replicasets = {}
     local call_opts = {is_async = true}
     for _, replicaset in pairs(replicasets) do
-        local future = replicaset[vshard_call](replicaset, func_name, func_args, call_opts)
+        local future = replicaset[vshard_call_name](replicaset, func_name, func_args, call_opts)
         futures_by_replicasets[replicaset.uuid] = future
     end
 
@@ -53,101 +109,33 @@ local function call_impl(vshard_call, func_name, func_args, opts)
         end
 
         if err ~= nil then
-            if err.type == 'ClientError' and type(err.message) == 'string' then
-                if err.message == string.format("Procedure '%s' is not defined", func_name) then
-                    if func_name:startswith('_crud.') then
-                        err = NotInitializedError:new("crud isn't initialized on replicaset: %q", replicaset_uuid)
-                    else
-                        err = NotInitializedError:new("Function %s is not registered", func_name)
-                    end
-                end
-            end
-            err = errors.wrap(err)
-            return nil, CallError:new(utils.format_replicaset_error(
-                replicaset_uuid, "Function returned an error: %s", err
-            ))
+            return nil, wrap_vshard_err(err, func_name, replicaset_uuid)
         end
+
         results[replicaset_uuid] = result[1]
     end
 
     return results
 end
 
---- Calls specified function on all cluster storages.
---
--- Allowed functions to call can be specified by `crud.register` call.
--- If function with specified `opts.func_name` isn't registered,
--- global function with this name is called.
---
--- Uses vshard `replicaset:callrw`
---
--- @function rw
---
--- @param string func_name
---  A function name
---
--- @param ?table func_args
---  Array of arguments to be passed to the function
---
--- @tparam table opts Available options are:
---
--- @tparam ?number opts.timeout
---  Function call timeout
---
--- @tparam ?table opts.replicasets
---  vshard replicasets to call the function.
---  By default, function is called on the all storages.
---
--- Returns map {replicaset_uuid: result} with all specified replicasets results
---
--- @return[1] table
--- @treturn[2] nil
--- @treturn[2] table Error description
---
-function call.rw(func_name, func_args, opts)
-    return call_impl('callrw', func_name, func_args, opts)
-end
+function call.single(bucket_id, func_name, func_args, opts)
+    dev_checks('number', 'string', '?table', {
+        mode = 'string',
+        prefer_replica = '?boolean',
+        balance = '?boolean',
+        timeout = '?number',
+    })
 
---- Calls specified function on all cluster storages.
---
--- The same as `rw`, but uses vshard `replicaset:callro`
---
--- @function ro
---
-function call.ro(func_name, func_args, opts)
-    return call_impl('callro', func_name, func_args, opts)
-end
+    local vshard_call_name = get_vshard_call_name(opts.mode, opts.prefer_replica, opts.balance, opts.mode)
 
---- Calls specified function on a node according to bucket_id.
---
--- Exactly mimics the contract of vshard.router.callrw, but adds
--- better error hangling
---
--- @function rw_single
---
-function call.rw_single(bucket_id, func_name, func_args, options)
-    local res, err = vshard.router.callrw(bucket_id, func_name, func_args, options)
+    local timeout = opts.timeout or DEFAULT_VSHARD_CALL_TIMEOUT
 
-    -- This is a workaround, until vshard supports telling us where the error happened
+    local res, err = vshard.router[vshard_call_name](bucket_id, func_name, func_args, {
+        timeout = timeout,
+    })
+
     if err ~= nil then
-        if type(err) == 'table' and err.type == 'ClientError' and type(err.message) == 'string' then
-            if err.message == string.format("Procedure '%s' is not defined", func_name) then
-               err = NotInitializedError:new("crud isn't initialized on replicaset")
-            end
-        end
-
-        local replicaset, _ = vshard.router.route(bucket_id)
-        if replicaset == nil then
-            return nil, CallError:new(
-                "Function returned an error, but we couldn't figure out the replicaset: %s", err
-            )
-        end
-
-        err = errors.wrap(err)
-
-        return nil, CallError:new(utils.format_replicaset_error(
-             replicaset.uuid, "Function returned an error: %s", err
-        ))
+        return nil, wrap_vshard_err(err, func_name, nil, bucket_id)
     end
 
     if res == box.NULL then

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -56,10 +56,14 @@ local function call_delete_on_router(space_name, key, opts)
     end
 
     local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
-    local storage_result, err = call.rw_single(
+    local call_opts = {
+        mode = 'write',
+        timeout = opts.timeout,
+    }
+    local storage_result, err = call.single(
         bucket_id, DELETE_FUNC_NAME,
         {space_name, key, opts.fields},
-        {timeout = opts.timeout}
+        call_opts
     )
 
     if err ~= nil then

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -68,10 +68,14 @@ local function call_insert_on_router(space_name, tuple, opts)
         fields = opts.fields,
     }
 
-    local storage_result, err = call.rw_single(
+    local call_opts = {
+        mode = 'write',
+        timeout = opts.timeout,
+    }
+    local storage_result, err = call.single(
         bucket_id, INSERT_FUNC_NAME,
         {space_name, tuple, insert_on_storage_opts},
-        {timeout = opts.timeout}
+        call_opts
     )
 
     if err ~= nil then

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -72,10 +72,14 @@ local function call_replace_on_router(space_name, tuple, opts)
         fields = opts.fields,
     }
 
-    local storage_result, err = call.rw_single(
+    local call_opts = {
+        mode = 'write',
+        timeout = opts.timeout,
+    }
+    local storage_result, err = call.single(
         bucket_id, REPLACE_FUNC_NAME,
         {space_name, tuple, insert_on_storage_opts},
-        {timeout = opts.timeout}
+        call_opts
     )
 
     if err ~= nil then

--- a/crud/select/iterator.lua
+++ b/crud/select/iterator.lua
@@ -20,12 +20,12 @@ function Iterator.new(opts)
         iteration_func = 'function',
 
         plan = 'table',
+        field_names = '?table',
 
         batch_size = 'number',
         replicasets = 'table',
 
-        timeout = '?number',
-        field_names = '?table',
+        call_opts = 'table',
     })
 
     local iter = {
@@ -34,9 +34,9 @@ function Iterator.new(opts)
         iteration_func = opts.iteration_func,
 
         plan = opts.plan,
-
-        timeout = opts.timeout,
         field_names = opts.field_names,
+
+        call_opts = opts.call_opts,
 
         replicasets = table.copy(opts.replicasets),
         replicasets_count = utils.table_count(opts.replicasets),
@@ -99,9 +99,9 @@ local function update_replicasets_tuples(iter, after_tuple, replicaset_uuid)
     local results_map, err = iter.iteration_func(iter.space_name, iter.plan, {
         after_tuple = after_tuple,
         replicasets = replicasets,
-        timeout = iter.timeout,
         limit = limit_per_storage_call,
         field_names = iter.field_names,
+        call_opts = iter.call_opts,
     })
     if err ~= nil then
         return false, UpdateTuplesError:new('Failed to select tuples from storages: %s', err)

--- a/crud/truncate.lua
+++ b/crud/truncate.lua
@@ -48,7 +48,8 @@ function truncate.call(space_name, opts)
     opts = opts or {}
 
     local replicasets = vshard.router.routeall()
-    local _, err = call.rw(TRUNCATE_FUNC_NAME, {space_name}, {
+    local _, err = call.map(TRUNCATE_FUNC_NAME, {space_name}, {
+        mode = 'write',
         replicasets = replicasets,
         timeout = opts.timeout,
     })

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -92,10 +92,14 @@ local function call_update_on_router(space_name, key, user_operations, opts)
     end
 
     local bucket_id = sharding.key_get_bucket_id(key, opts.bucket_id)
-    local storage_result, err = call.rw_single(
+    local call_opts = {
+        mode = 'write',
+        timeout = opts.timeout,
+    }
+    local storage_result, err = call.single(
         bucket_id, UPDATE_FUNC_NAME,
         {space_name, key, operations, opts.fields},
-        {timeout = opts.timeout}
+        call_opts
     )
 
     if err ~= nil then

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -74,10 +74,14 @@ local function call_upsert_on_router(space_name, tuple, user_operations, opts)
         return nil, UpsertError:new("Failed to get bucket ID: %s", err), true
     end
 
-    local storage_result, err = call.rw_single(
+    local call_opts = {
+        mode = 'write',
+        timeout = opts.timeout,
+    }
+    local storage_result, err = call.single(
         bucket_id, UPSERT_FUNC_NAME,
         {space_name, tuple, operations},
-        {timeout = opts.timeout}
+        call_opts
     )
 
     if err ~= nil then

--- a/test/integration/read_calls_strategies_test.lua
+++ b/test/integration/read_calls_strategies_test.lua
@@ -1,0 +1,140 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g = t.group('read_calls_strategies')
+
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_read_calls_strategies'),
+        use_vshard = true,
+        replicasets = helpers.get_test_replicasets(),
+    })
+
+    g.cluster:start()
+
+    g.space_format = g.cluster.servers[2].net_box.space.customers:format()
+
+    g.clear_vshard_calls = function()
+        g.cluster.main_server.net_box:call('clear_vshard_calls')
+    end
+
+    g.get_vshard_calls = function()
+        return g.cluster.main_server.net_box:eval('return _G.vshard_calls')
+    end
+
+    -- patch vshard.router.call* functions
+    local vshard_call_names = {'callro', 'callbro', 'callre', 'callbre', 'callrw'}
+    g.cluster.main_server.net_box:call('patch_vshard_calls', {vshard_call_names})
+end)
+
+g.after_all(function()
+    helpers.stop_cluster(g.cluster)
+end)
+
+g.before_each(function()
+    helpers.truncate_space_on_cluster(g.cluster, 'customers')
+end)
+
+local function check_get(g, exp_vshard_call, opts)
+    g.clear_vshard_calls()
+    local _, err = g.cluster.main_server.net_box:call('crud.get', {'customers', 1, opts})
+    t.assert_equals(err, nil)
+    local vshard_calls = g.get_vshard_calls('call_single_impl')
+    t.assert_equals(vshard_calls, {exp_vshard_call})
+end
+
+local function check_select(g, exp_vshard_call, opts)
+    g.clear_vshard_calls()
+    local _, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil, opts})
+    t.assert_equals(err, nil)
+    local vshard_calls = g.get_vshard_calls('call_impl')
+    t.assert_equals(vshard_calls, {exp_vshard_call, exp_vshard_call})
+end
+
+local function check_pairs(g, exp_vshard_call, opts)
+    g.clear_vshard_calls()
+    local _, err = g.cluster.main_server.net_box:eval([[
+        local crud = require('crud')
+
+        local opts = ...
+        for _, _ in crud.pairs('customers', nil, opts) do end
+    ]], {opts})
+    t.assert_equals(err, nil)
+    local vshard_calls = g.get_vshard_calls('call_impl')
+    t.assert_equals(vshard_calls, {exp_vshard_call, exp_vshard_call})
+end
+
+g.test_get = function()
+    -- mode: write
+    check_get(g, 'callrw', {mode = 'write'})
+
+    -- mode: read
+
+    -- no params -> callro
+    check_get(g, 'callro')
+
+    -- not prefer_replica, not balance -> callro
+    check_get(g, 'callro', {prefer_replica = false, balance = false})
+
+    -- not prefer_replica, balance -> callbro
+    check_get(g, 'callbro', {prefer_replica = false, balance = true})
+    check_get(g, 'callbro', {balance = true})
+
+    -- prefer_replica, not balance -> callre
+    check_get(g, 'callre', {prefer_replica = true, balance = false})
+    check_get(g, 'callre', {prefer_replica = true})
+
+    -- prefer_replica, balance -> callbre
+    check_get(g, 'callbre', {prefer_replica = true, balance = true})
+end
+
+g.test_select = function()
+    -- mode: write
+    check_select(g, 'callrw', {mode = 'write'})
+
+    -- mode: read
+
+    -- no params -> callro
+    check_select(g, 'callro')
+
+    -- not prefer_replica, not balance -> callro
+    check_select(g, 'callro', {prefer_replica = false, balance = false})
+
+    -- not prefer_replica, balance -> callbro
+    check_select(g, 'callbro', {prefer_replica = false, balance = true})
+    check_select(g, 'callbro', {balance = true})
+
+    -- prefer_replica, not balance -> callre
+    check_select(g, 'callre', {prefer_replica = true, balance = false})
+    check_select(g, 'callre', {prefer_replica = true})
+
+    -- prefer_replica, balance -> callbre
+    check_select(g, 'callbre', {prefer_replica = true, balance = true})
+end
+
+g.test_pairs = function()
+    -- mode: write
+    check_pairs(g, 'callrw', {mode = 'write'})
+
+    -- mode: read
+
+    -- no params -> callro
+    check_pairs(g, 'callro')
+
+    -- not prefer_replica, not balance -> callro
+    check_pairs(g, 'callro', {prefer_replica = false, balance = false})
+
+    -- not prefer_replica, balance -> callbro
+    check_pairs(g, 'callbro', {prefer_replica = false, balance = true})
+    check_pairs(g, 'callbro', {balance = true})
+
+    -- prefer_replica, not balance -> callre
+    check_pairs(g, 'callre', {prefer_replica = true, balance = false})
+    check_pairs(g, 'callre', {prefer_replica = true})
+
+    -- prefer_replica, balance -> callbre
+    check_pairs(g, 'callbre', {prefer_replica = true, balance = true})
+end


### PR DESCRIPTION
Added `mode`, `prefer_replica` and `balance` options for read operations
(`get`, `select`, `pairs`). According to this parameters one of vshard
calls (`callrw`, `callro`, `callbro`, `callre`, `callbre`) is selected.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #124 
