### PR TITLE
Fix case with invalid pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed not finding field in tuple on `crud.update` if
   there are `is_nullable` fields in front of it that were added
   when the schema was changed for Tarantool version <= 2.2.
+
+* Pagination over multipart primary key.
   
 ### Added
 

--- a/crud/select/comparators.lua
+++ b/crud/select/comparators.lua
@@ -141,26 +141,16 @@ end
 
 function comparators.gen_func(cmp_operator, key_parts)
     local cmp_func = array_cmp_funcs_by_operators[cmp_operator]
-    if cmp_func == nil then
-        return nil, ComparatorsError:new('Unsupported operator %q', cmp_operator)
-    end
+    ComparatorsError:assert(cmp_func ~= nil, 'Unsupported operator %q', cmp_operator)
 
-    local func, err = gen_array_cmp_func(cmp_func, key_parts)
-    if err ~= nil then
-        return nil, ComparatorsError:new('Failed to generate comparator function %q', cmp_operator)
-    end
-
-    return func
+    return gen_array_cmp_func(cmp_func, key_parts)
 end
 
 function comparators.gen_tuples_comparator(cmp_operator, key_parts, field_names, space_format)
     local updated_key_parts = comparators.update_key_parts_by_field_names(
             space_format, field_names, key_parts
     )
-    local keys_comparator, err = comparators.gen_func(cmp_operator, updated_key_parts)
-    if err ~= nil then
-        return nil, ComparatorsError:new("Failed to generate comparator function: %s", err)
-    end
+    local keys_comparator = comparators.gen_func(cmp_operator, updated_key_parts)
 
     return function(lhs, rhs)
         local lhs_key = utils.extract_key(lhs, updated_key_parts)

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -135,12 +135,9 @@ local function build_select_iterator(space_name, user_conditions, opts)
     -- generator of tuples comparator needs field_names and space_format
     -- to update fieldno in each part in cmp_key_parts because storage result contains
     -- fields in order specified by field_names
-    local tuples_comparator, err = select_comparators.gen_tuples_comparator(
+    local tuples_comparator = select_comparators.gen_tuples_comparator(
         cmp_operator, cmp_key_parts, plan.field_names, space_format
     )
-    if err ~= nil then
-        return nil, SelectError:new("Failed to generate comparator function: %s", err)
-    end
 
     -- filter space format by plan.field_names (user defined fields + primary key + scan key)
     -- to pass it user as metadata

--- a/test/entrypoint/srv_select.lua
+++ b/test/entrypoint/srv_select.lua
@@ -104,6 +104,28 @@ package.preload['customers-storage'] = function()
                 if_not_exists = true,
             })
 
+            local book_translation = box.schema.space.create('book_translation', {
+                format = {
+                    { name = 'id', type = 'unsigned' },
+                    { name = 'bucket_id', type = 'unsigned' },
+                    { name = 'language', type = 'string' },
+                    { name = 'edition', type = 'integer' },
+                    { name = 'translator', type = 'string' },
+                    { name = 'comments', type = 'string', is_nullable = true },
+                },
+                if_not_exists = true,
+            })
+
+            book_translation:create_index('id', {
+                parts = { 'id', 'language', 'edition' },
+                if_not_exists = true,
+            })
+
+            book_translation:create_index('bucket_id', {
+                parts = { 'bucket_id' },
+                unique = false,
+                if_not_exists = true,
+            })
         end,
     }
 end


### PR DESCRIPTION
This quite strange that it didn't shoot before.
However, we introduced a merger usage so behaviour was changed a
bit. So pagination over primary key were broken and this patch
fixes it and introduces test for it.

Closes #137

