### PR TITLE
drop unused code

### DIFF
--- a/crud/select/type_comparators.lua
+++ b/crud/select/type_comparators.lua
@@ -73,12 +73,6 @@ local function eq_unicode_ci(lhs, rhs)
     return lhs == rhs
 end
 
-local function lt_uuid_default(lhs, rhs)
-    return tostring(lhs) < tostring(rhs)
-end
-
-local lt_uuid = lt_nullable(lt_uuid_default)
-
 local comparators_by_type = {
     boolean = function ()
         return lt_boolean, eq
@@ -95,9 +89,6 @@ local comparators_by_type = {
             UnsupportedCollationError:assert(false, 'Unsupported Tarantool collation %q', collation)
         end
     end,
-    uuid = function ()
-        return lt_uuid, eq
-    end
 }
 
 function types.get_comparators_by_type(key_part)

--- a/test/unit/select_comparators_test.lua
+++ b/test/unit/select_comparators_test.lua
@@ -1,5 +1,3 @@
-local uuid = require('uuid')
-
 local select_comparators = require('crud.select.comparators')
 local select_conditions = require('crud.select.conditions')
 local operators = select_conditions.operators
@@ -144,26 +142,4 @@ g.test_unicode_collations = function()
     t.assert(err == nil)
     t.assert(not func_le_unicode({'A', 'Á', 'Ä'}, {'a', 'A', 'a'}, 3))
     t.assert(func_le_unicode_ci({'A', 'Á', 'Ä'}, {'a', 'A', 'a'}, 3))
-end
-
-g.test_uuid_type_parts = function()
-    local key_parts = {
-        {type = 'uuid'}, {}
-    }
-
-    local func_eq, err = select_comparators.gen_func(operators.EQ, key_parts)
-    t.assert(err == nil)
-    local u1 = uuid.fromstr('8a1ffbc0-241e-11eb-8d27-0800200c9a66')
-    local u2 = uuid.fromstr('8f1ffbc0-241e-11eb-8d27-0800200c9a66')
-    local u1_copy = uuid.fromstr(u1:str())
-    t.assert(func_eq({u1, 'str'}, {u1, 'str'}))
-    t.assert(func_eq({u1, 'str'}, {u1_copy, 'str'}))
-    t.assert(not func_eq({u1, 'str'}, {u2, 'str'}))
-
-    local func_ge, err = select_comparators.gen_func(operators.GE, key_parts)
-    t.assert(err == nil)
-    t.assert(not func_ge({u1, 'str'}, {u2, 'str'}))
-    t.assert(func_ge({u1, 'str'}, {u1, 'str'}))
-    t.assert(func_ge({u1, 'ttr'}, {u1, 'str'}))
-    t.assert(func_ge({u2, 'str'}, {u1, 'str'}))
 end


### PR DESCRIPTION
Since we use merger for versions 2.4+ this code lines are not needed
anymore.
