### PR TITLE
Fix reverse pagination incorrect result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Fixed error for partial result option if field contains box.NULL.
+* Fixed incorrect ``crud`` results during reverse pagination
+  without specifying ``batch_size``.
 
 ### Added
 
 * `cut_rows` and `cut_objects` functions to cut off scan key and
   primary key values that were merged to the select/pairs partial result.
 * Functions ``stop()`` for the roles ``crud-storage`` and ``crud-router``.
-* Option flag `force_map_call` for `select()`/`pairs()` 
+* Option flag `force_map_call` for `select()`/`pairs()`
   to disable the `bucket_id` computation from primary key.
 
 ## [0.6.0] - 2021-03-29

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -75,16 +75,16 @@ local function build_select_iterator(space_name, user_conditions, opts)
         end
     end
 
-    local first = opts.first
-    if first ~= nil then
-        first = math.abs(opts.first)
+    local tuples_limit = opts.first
+    if tuples_limit ~= nil then
+        tuples_limit = math.abs(tuples_limit)
     end
 
-    -- If opts.batch_size is missed we should specify it to min(first, DEFAULT_BATCH_SIZE)
+    -- If opts.batch_size is missed we should specify it to min(tuples_limit, DEFAULT_BATCH_SIZE)
     local batch_size
     if opts.batch_size == nil then
-        if first ~= nil and first < common.DEFAULT_BATCH_SIZE then
-            batch_size = first
+        if tuples_limit ~= nil and tuples_limit < common.DEFAULT_BATCH_SIZE then
+            batch_size = tuples_limit
         else
             batch_size = common.DEFAULT_BATCH_SIZE
         end

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -79,7 +79,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
     local batch_size
     if opts.batch_size == nil then
         if opts.first ~= nil and opts.first < common.DEFAULT_BATCH_SIZE then
-            batch_size = opts.first
+            batch_size = math.abs(opts.first)
         else
             batch_size = common.DEFAULT_BATCH_SIZE
         end

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -75,15 +75,16 @@ local function build_select_iterator(space_name, user_conditions, opts)
         end
     end
 
-    if opts.first ~= nil then
-        opts.first = math.abs(opts.first)
+    local first = opts.first
+    if first ~= nil then
+        first = math.abs(opts.first)
     end
 
     -- If opts.batch_size is missed we should specify it to min(first, DEFAULT_BATCH_SIZE)
     local batch_size
     if opts.batch_size == nil then
-        if opts.first ~= nil and opts.first < common.DEFAULT_BATCH_SIZE then
-            batch_size = opts.first
+        if first ~= nil and first < common.DEFAULT_BATCH_SIZE then
+            batch_size = first
         else
             batch_size = common.DEFAULT_BATCH_SIZE
         end

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -75,11 +75,15 @@ local function build_select_iterator(space_name, user_conditions, opts)
         end
     end
 
+    if opts.first ~= nil then
+        opts.first = math.abs(opts.first)
+    end
+
     -- If opts.batch_size is missed we should specify it to min(first, DEFAULT_BATCH_SIZE)
     local batch_size
     if opts.batch_size == nil then
         if opts.first ~= nil and opts.first < common.DEFAULT_BATCH_SIZE then
-            batch_size = math.abs(opts.first)
+            batch_size = opts.first
         else
             batch_size = common.DEFAULT_BATCH_SIZE
         end

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -201,7 +201,7 @@ pgroup:add('test_negative_first', function(g)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2, 3, 4}))
 
     -- id >= 2
-    -- first -2 after 5 (batch_size is 1)
+    -- first -2 after 5
     local conditions = {
         {'>=', 'id', 2},
     }

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -189,6 +189,105 @@ pgroup:add('test_negative_first', function(g)
 
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
+    -- no conditions
+    -- first -3 after 5
+    local first = -3
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', nil, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2, 3, 4}))
+
+    -- id >= 2
+    -- first -2 after 5 (batch_size is 1)
+    local conditions = {
+        {'>=', 'id', 2},
+    }
+    local first = -2
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {3, 4}))
+
+    -- age >= 22
+    -- first -2 after 5
+    local conditions = {
+        {'>=', 'age', 22},
+    }
+    local first = -2
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {3, 4}))
+
+    -- id <= 6
+    -- first -2 after 5
+    local conditions = {
+        {'<=', 'id', 6},
+    }
+    local first = -2
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {6}))
+
+    -- age <= 66
+    -- first -2 after 5
+    local conditions = {
+        {'<=', 'age', 66},
+    }
+    local first = -2
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {6}))
+end)
+
+pgroup:add('test_negative_first_with_batch_size', function(g)
+    local customers = helpers.insert_objects(g, 'customers', {
+        {
+            id = 1, name = "Elizabeth", last_name = "Jackson",
+            age = 11, city = "New York",
+        }, {
+            id = 2, name = "Mary", last_name = "Brown",
+            age = 22, city = "Los Angeles",
+        }, {
+            id = 3, name = "David", last_name = "Smith",
+            age = 33, city = "Los Angeles",
+        }, {
+            id = 4, name = "William", last_name = "White",
+            age = 44, city = "Chicago",
+        }, {
+            id = 5, name = "Jack", last_name = "Sparrow",
+            age = 55, city = "London",
+        }, {
+            id = 6, name = "William", last_name = "Terner",
+            age = 66, city = "Oxford",
+        }, {
+            id = 7, name = "Elizabeth", last_name = "Swan",
+            age = 77, city = "Cambridge",
+        }, {
+            id = 8, name = "Hector", last_name = "Barbossa",
+            age = 88, city = "London",
+        },
+    })
+
+    table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
+
     -- negative first w/o after
     local first = -10
     local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil, {first=first}})
@@ -200,7 +299,7 @@ pgroup:add('test_negative_first', function(g)
     -- first -3 after 5 (batch_size is 1)
     local first = -3
     local after = crud_utils.flatten(customers[5], g.space_format)
-    local batch_size = 1
+    local batch_size = nil
     local result, err = g.cluster.main_server.net_box:call(
        'crud.select', {'customers', nil, {first=first, after=after, batch_size=batch_size}})
 

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -299,7 +299,7 @@ pgroup:add('test_negative_first_with_batch_size', function(g)
     -- first -3 after 5 (batch_size is 1)
     local first = -3
     local after = crud_utils.flatten(customers[5], g.space_format)
-    local batch_size = nil
+    local batch_size = 1
     local result, err = g.cluster.main_server.net_box:call(
        'crud.select', {'customers', nil, {first=first, after=after, batch_size=batch_size}})
 


### PR DESCRIPTION
``crud.select`` query using reverse pagination and without
specifying ``batch_size``, the [``limit``](https://github.com/tarantool/crud/blob/144f9035d44ceb242a3bf664e41d553690133dc2/crud/select/compat/select.lua#L94) became negative, 
which causes errors.