### PR TITLE
Fix roles reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   without specifying ``batch_size``.
 * Fixed crud roles reload:
   * before this patch reload wasn't fair - reloading `tuple.merger`
-    and `tuple.keydef` modules failed, and crud starting to use
-    `crud.select.compat.select_old` module with naive merger realization;
+    and `tuple.keydef` modules failed, and crud started to use
+    `crud.select.compat.select_old` module with naive merger implementation;
   * fair reloading `tuple.merger` and `tuple.keydef` led to the error that was
     fixed by caching loaded module in the special global variable not cleaned
     on reloading roles;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed error for partial result option if field contains box.NULL.
 * Fixed incorrect ``crud`` results during reverse pagination
   without specifying ``batch_size``.
+* Fixed crud roles reload:
+  * before this patch reload wasn't fair - reloading `tuple.merger`
+    and `tuple.keydef` modules failed, and crud starting to use
+    `crud.select.compat.select_old` module with naive merger realization;
+  * fair reloading `tuple.merger` and `tuple.keydef` led to the error that was
+    fixed by caching loaded module in the special global variable not cleaned
+    on reloading roles;
+  * ability of using `tuple.merger` and `tuple.keydef` modules now is checked
+    by calling `package.search`, built-in `merger` and `keydef` modules are used
+    if present in `package.loaded`. It allows to avoid ignoring errors on checking
+    modules existing via `pcall(require, '<module_name>')`.
 
 ### Added
 

--- a/crud/common/compat.lua
+++ b/crud/common/compat.lua
@@ -11,6 +11,8 @@ function compat.require(module_name, builtin_module_name)
     if module_cached ~= nil then
         module = module_cached
     elseif package.search(module_name) then
+        -- we don't use pcall(require, modile_name) here because it
+        -- leads to ignoring errors other than 'No LuaRocks module found'
         log.info('%q module is used', module_name)
         module = require(module_name)
     else

--- a/crud/common/compat.lua
+++ b/crud/common/compat.lua
@@ -1,0 +1,31 @@
+local log = require('log')
+
+local compat = {}
+
+function compat.require(module_name, builtin_module_name)
+    local module_cached_name = string.format('__crud_%s_cached', module_name)
+
+    local module
+
+    local module_cached = rawget(_G, module_cached_name)
+    if module_cached ~= nil then
+        module = module_cached
+    elseif package.search(module_name) then
+        log.info('%q module is used', module_name)
+        module = require(module_name)
+    else
+        log.info('%q module is not found. Built-in %q is used', module_name, builtin_module_name)
+        module = require(builtin_module_name)
+    end
+
+    rawset(_G, module_cached_name, module)
+
+    if package.search('cartridge.hotreload') ~= nil then
+        local hotreload = require('cartridge.hotreload')
+        hotreload.whitelist_globals({module_cached_name})
+    end
+
+    return module
+end
+
+return compat

--- a/crud/common/compat.lua
+++ b/crud/common/compat.lua
@@ -22,8 +22,8 @@ function compat.require(module_name, builtin_module_name)
 
     rawset(_G, module_cached_name, module)
 
-    if package.search('cartridge.hotreload') ~= nil then
-        local hotreload = require('cartridge.hotreload')
+    local hotreload = package.loaded['cartridge.hotreload']
+    if hotreload ~= nil then
         hotreload.whitelist_globals({module_cached_name})
     end
 

--- a/crud/compare/keydef.lua
+++ b/crud/compare/keydef.lua
@@ -6,14 +6,12 @@ local collations = require('crud.common.collations')
 
 local keydef_lib
 
-if pcall(require, 'tuple.keydef') then
+if package.search('tuple.keydef') ~= nil then
+    log.info('"tuple.keydef" module is used')
     keydef_lib = require('tuple.keydef')
-elseif pcall(require, 'keydef') then
-    log.info('Impossible to load "tuple-keydef" module. Built-in "keydef" is used')
-    keydef_lib = require('key_def')
 else
-    error(string.format('Seems your Tarantool version (%q' ..
-            ') does not support "tuple-keydef" or "keydef" modules', _TARANTOOL))
+    log.info('"tuple-keydef" module is not found. Built-in "key_def" is used')
+    keydef_lib = require('key_def')
 end
 
 -- As "tuple.key_def" doesn't support collation_id

--- a/crud/compare/keydef.lua
+++ b/crud/compare/keydef.lua
@@ -1,18 +1,10 @@
-local log = require('log')
 local msgpack = require('msgpack')
 
 local comparators = require('crud.compare.comparators')
 local collations = require('crud.common.collations')
 
-local keydef_lib
-
-if package.search('tuple.keydef') ~= nil then
-    log.info('"tuple.keydef" module is used')
-    keydef_lib = require('tuple.keydef')
-else
-    log.info('"tuple-keydef" module is not found. Built-in "key_def" is used')
-    keydef_lib = require('key_def')
-end
+local compat = require('crud.common.compat')
+local keydef_lib = compat.require('tuple.keydef', 'key_def')
 
 -- As "tuple.key_def" doesn't support collation_id
 -- we manually change it to collation

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -9,18 +9,15 @@ local SelectError = errors.new_class('SelectError')
 
 local select_module
 
--- "merger" segfaults here
--- See https://github.com/tarantool/tarantool/issues/4954
 if '2' <= _TARANTOOL and _TARANTOOL <= '2.3.3' then
+    -- "merger" segfaults here
+    -- See https://github.com/tarantool/tarantool/issues/4954
+    select_module = require('crud.select.compat.select_old')
+elseif not package.search('tuple.merger') and package.loaded['merger'] == nil then
+    -- "merger" isn't supported here
     select_module = require('crud.select.compat.select_old')
 else
-    -- Try to require built-in or external merger
-    local ok, module = pcall(require, 'crud.select.compat.select')
-    if ok then
-        select_module = module
-    else
-        select_module = require('crud.select.compat.select_old')
-    end
+    select_module = require('crud.select.compat.select')
 end
 
 local function make_cursor(data)

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -14,6 +14,9 @@ if '2' <= _TARANTOOL and _TARANTOOL <= '2.3.3' then
     -- See https://github.com/tarantool/tarantool/issues/4954
     select_module = require('crud.select.compat.select_old')
 elseif not package.search('tuple.merger') and package.loaded['merger'] == nil then
+    -- we don't use pcall(require, modile_name) here because it
+    -- leads to ignoring errors other than 'No LuaRocks module found'
+
     -- "merger" isn't supported here
     select_module = require('crud.select.compat.select_old')
 else

--- a/crud/select/merger.lua
+++ b/crud/select/merger.lua
@@ -1,20 +1,12 @@
 local buffer = require('buffer')
 local msgpack = require('msgpack')
-local log = require('log')
 local ffi = require('ffi')
 local call = require('crud.common.call')
 
+local compat = require('crud.common.compat')
+local merger_lib = compat.require('tuple.merger', 'merger')
+
 local Keydef = require('crud.compare.keydef')
-
-local merger_lib
-
-if package.search('tuple.merger') then
-    log.info('"tuple.merger" module is used')
-    merger_lib = require('tuple.merger')
-else
-    log.info('"tuple.merger" module is not found. Built-in "merger" is used')
-    merger_lib = require('merger')
-end
 
 local function bswap_u16(num)
     return bit.rshift(bit.bswap(tonumber(num)), 16)

--- a/crud/select/merger.lua
+++ b/crud/select/merger.lua
@@ -8,14 +8,12 @@ local Keydef = require('crud.compare.keydef')
 
 local merger_lib
 
-if pcall(require, 'tuple.merger') then
+if package.search('tuple.merger') then
+    log.info('"tuple.merger" module is used')
     merger_lib = require('tuple.merger')
-elseif pcall(require, 'merger') then
-    log.info('Impossible to load "tuple-merger" module. Built-in "merger" is used')
-    merger_lib = require('merger')
 else
-    error(string.format('Seems your Tarantool version (%q' ..
-            ') does not support "tuple-merger" or "merger" modules', _TARANTOOL))
+    log.info('"tuple.merger" module is not found. Built-in "merger" is used')
+    merger_lib = require('merger')
 end
 
 local function bswap_u16(num)


### PR DESCRIPTION
Before this patch reload wasn't fair - reloading `tuple.merger` 
and `tuple.keydef` modules failed, and crud starting to use
`crud.select.compat.select_old` module with naive merger realization.
 Fair reloading `tuple.merger` and `tuple.keydef` led to the errors [1],[2] that were
  fixed by caching loaded module in the special global variable not cleaned
  on reloading roles.
 Ability of using `tuple.merger` and `tuple.keydef` modules now is checked
 by calling `package.search`, built-in `merger` and `keydef` modules are used
if present in `package.loaded`. It allows to avoid ignoring errors on checking
modules existing via `pcall(require, '<module_name>')`.

[1]: https://github.com/tarantool/tuple-keydef/issues/9
[2]: https://github.com/tarantool/tuple-merger/issues/21