### PR TITLE
fix key_def cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     by calling `package.search`, built-in `merger` and `keydef` modules are used
     if present in `package.loaded`. It allows to avoid ignoring errors on checking
     modules existing via `pcall(require, '<module_name>')`.
+* Fixed some cases when module ignored schema updates.
 
 ### Added
 

--- a/test/entrypoint/srv_update_schema.lua
+++ b/test/entrypoint/srv_update_schema.lua
@@ -18,6 +18,7 @@ package.preload['customers-storage'] = function()
                         {name = 'id', type = 'unsigned'},
                         {name = 'bucket_id', type = 'unsigned'},
                         {name = 'value', type = 'string'},
+                        {name = 'number', type = 'integer', is_nullable = true},
                     },
                     if_not_exists = true,
                     engine = engine,
@@ -62,6 +63,20 @@ package.preload['customers-storage'] = function()
                     parts = { {field = 'value'} },
                     if_not_exists = true,
                     unique = false,
+                })
+            end)
+
+            rawset(_G, 'create_number_value_index', function()
+                box.space.customers:create_index('number_value_index', {
+                    parts = { {field = 'number'}, {field = 'value'} },
+                    if_not_exists = true,
+                    unique = false,
+                })
+            end)
+
+            rawset(_G, 'alter_number_value_index', function()
+                box.space.customers.index.number_value_index:alter({
+                    parts = { {field = 'value'}, {field = 'number'} },
                 })
             end)
         end,


### PR DESCRIPTION
When "fields" feature was introduced we change caching strategy
and started to keep "string" key for index + fields.
This approach led to the cases when nobody could invalidate
key_def cache and if user changes index schema and changes e.g.
fields order in his/her index it won't reflect sort order. Old
value stuck in cache.

This patch fixes such behaviour. We don't consider fields in
key_def cache - yes we should recreate key_def each time. But at
least it's safe.
