### PR TITLE
Update deps

### DIFF
--- a/crud-scm-1.rockspec
+++ b/crud-scm-1.rockspec
@@ -6,8 +6,7 @@ source  = {
 }
 
 dependencies = {
-    'tarantool',
-    'lua >= 5.1',
+    'lua ~> 5.1',
     'checks == 3.1.0-1',
     'errors == 2.1.3-1',
     'vshard == 0.1.16-1',

--- a/crud-scm-1.rockspec
+++ b/crud-scm-1.rockspec
@@ -8,8 +8,8 @@ source  = {
 dependencies = {
     'lua ~> 5.1',
     'checks == 3.1.0-1',
-    'errors == 2.1.3-1',
-    'vshard == 0.1.16-1',
+    'errors == 2.2.0-1',
+    'vshard == 0.1.17-1',
 }
 
 build = {


### PR DESCRIPTION
This patch solves following problems:
  - Before this patch it wasn't possible to install module via `luarocks` (only with `tarantoolctl rocks`). The first commit fixes it.
  - The second commit updates crud dependencies - errors and vshard modules. 
