### PR TITLE
Imply vshard roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     if present in `package.loaded`. It allows to avoid ignoring errors on checking
     modules existing via `pcall(require, '<module_name>')`.
 * Fixed some cases when module ignored schema updates.
+* Preserve "Bootstrap vshard" button in WebUI operable even if vshard
+  roles are hidden explicitly.
 
 ### Added
 

--- a/cartridge/roles/crud-router.lua
+++ b/cartridge/roles/crud-router.lua
@@ -13,5 +13,6 @@ return {
     role_name = 'crud-router',
     init = init,
     stop = stop,
-    dependencies = {'cartridge.roles.vshard-router'}
+    implies_router = true,
+    dependencies = {'cartridge.roles.vshard-router'},
 }

--- a/cartridge/roles/crud-storage.lua
+++ b/cartridge/roles/crud-storage.lua
@@ -12,5 +12,6 @@ return {
     role_name = 'crud-storage',
     init = init,
     stop = stop,
-    dependencies = {'cartridge.roles.vshard-storage'}
+    implies_storage = true,
+    dependencies = {'cartridge.roles.vshard-storage'},
 }


### PR DESCRIPTION
Two new cartridge role properties were introduced in https://github.com/tarantool/cartridge/pull/1217:

```
implies_router = true,
implies_storage = true,
```

They're necessary to preserve Cartridge WebUI operability (bootstrap vshard button visible) even if vshard roles are hidden explicitly.

This patch adds these properties to the crud roles, as they already have corresponding dependencies.