### PR TITLE
fix compatibility with old Tarantool versions

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -38,7 +38,9 @@ jobs:
     if: github.event_name == 'push'
     strategy:
       matrix:
-        bundle_version: [ "1.10.10-0-gaea7ae77a-r399", "2.7.2-0-g4d8c06890-r399" ]
+        # We need 1.10.6 here to check that module works with
+        # old Tarantool versions that don't have "tuple-keydef"/"tuple-merger" support.
+        bundle_version: [ "1.10.6-1-g52c786b", "1.10.10-0-gaea7ae77a-r399", "2.7.2-0-g4d8c06890-r399" ]
       fail-fast: false
     runs-on: [ ubuntu-latest ]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Compatibility with Tarantool versions that don't support key_def and merger modules.
+
 ## [0.7.0] - 2021-05-27
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,9 @@ install(
 # Don't include to rockspec as some Tarantool versions (e.g. 2.2 and 2.3)
 # don't have symbols required by "tuple-merger" and "tuple-keydef" modules.
 execute_process(
+    COMMAND bash "-c" "tarantoolctl rocks install tuple-keydef 0.0.2"
+)
+
+execute_process(
     COMMAND bash "-c" "tarantoolctl rocks install tuple-merger 0.0.1"
 )

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -6,7 +6,8 @@ local dev_checks = require('crud.common.dev_checks')
 local call = require('crud.common.call')
 local utils = require('crud.common.utils')
 local schema = require('crud.common.schema')
-local Keydef = require('crud.compare.keydef')
+local has_keydef, Keydef = pcall(require, 'crud.compare.keydef')
+local select_comparators = require('crud.compare.comparators')
 
 local BorderError = errors.new_class('Border',  {capture_stack = false})
 
@@ -44,14 +45,25 @@ function borders.init()
    _G._crud.get_border_on_storage = get_border_on_storage
 end
 
-local function is_closer(compare_sign, keydef, tuple, res_tuple)
-    if res_tuple == nil then
-        return true
+local is_closer
+
+if has_keydef then
+    is_closer = function (compare_sign, keydef, tuple, res_tuple)
+        if res_tuple == nil then
+            return true
+        end
+
+        local cmp = keydef:compare(tuple, res_tuple)
+
+        return cmp * compare_sign > 0
     end
-
-    local cmp = keydef:compare(tuple, res_tuple)
-
-    return cmp * compare_sign > 0
+else
+    is_closer = function (_, comparator, tuple, res_tuple)
+        if res_tuple == nil then
+            return true
+        end
+        return comparator(tuple, res_tuple)
+    end
 end
 
 local function call_get_border_on_router(border_name, space_name, index_name, opts)
@@ -99,8 +111,21 @@ local function call_get_border_on_router(border_name, space_name, index_name, op
         return nil, BorderError:new("Failed to get %s: %s", border_name, err)
     end
 
-    local keydef = Keydef.new(space, field_names, index.id)
     local compare_sign = border_name == 'max' and 1 or -1
+    local comparator
+    if has_keydef then
+        comparator = Keydef.new(space, field_names, index.id)
+    else
+        local tarantool_iter
+        if compare_sign > 0 then
+            tarantool_iter = box.index.GT
+        else
+            tarantool_iter = box.index.LT
+        end
+        local key_parts = utils.merge_primary_key_parts(index.parts, primary_index.parts)
+        local cmp_operator = select_comparators.get_cmp_operator(tarantool_iter)
+        comparator = select_comparators.gen_tuples_comparator(cmp_operator, key_parts, field_names, space:format())
+    end
 
     local res_tuple = nil
     for _, storage_result in pairs(results) do
@@ -111,7 +136,7 @@ local function call_get_border_on_router(border_name, space_name, index_name, op
         end
 
         local tuple = storage_result.res
-        if tuple ~= nil and is_closer(compare_sign, keydef, tuple, res_tuple) then
+        if tuple ~= nil and is_closer(compare_sign, comparator, tuple, res_tuple) then
             res_tuple = tuple
         end
     end


### PR DESCRIPTION
After a15e77448a1c44a24e4842c5f2b6e4db6447ffd5 (Introduce crud.min and crud.max)
module started to throw an error
```
.../.rocks/share/tarantool/crud/common/compat.lua:20: module 'key_def' not found:
```

Because some 1.10 versions don't have support tuple-keydef module
or they didn't installed it near this module.
This patch adds a fix that fallbacks such lost souls to lua
implemented comparators.

Also 1.10.6 EE is added to test process to be able verify changes.

Closes #163
