### PR TITLE
Refactoring code in select modules

### DIFF
--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -218,12 +218,12 @@ function select_module.pairs(space_name, user_conditions, opts)
 
     local gen = function(_, iter)
         local tuple, err = iter:get()
-        if tuple == nil then
-            return nil
-        end
-
         if err ~= nil then
             error(string.format("Failed to get next object: %s", err))
+        end
+
+        if tuple == nil then
+            return nil
         end
 
         local result = tuple


### PR DESCRIPTION
Checking error in the select_old module when
receiving iterator is now called earlier than
checking tuple. Closes #144