### PR TITLE
Move luacheck to a separate pipeline

### DIFF
--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -1,0 +1,25 @@
+name: Run static analysis
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-static-analysis:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Setup Tarantool
+      uses: tarantool/setup-tarantool@v1
+      with:
+        tarantool-version: '2.6'
+
+    - name: Setup luacheck
+      run: tarantoolctl rocks install luacheck 0.25.0
+
+    - name: Run luacheck
+      run: .rocks/bin/luacheck .

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -8,7 +8,7 @@ jobs:
   run-tests-ce:
     if: |
       github.event_name == 'push' ||
-      github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         tarantool-version: ["1.10", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -21,10 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Setup Tarantool CE
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: ${{ matrix.tarantool-version }}
+
       - name: Install requirements for community
         run: |
-          curl -L https://tarantool.io/installer.sh | sudo VER=${{ matrix.tarantool-version }} bash
-          sudo apt install -y tarantool-dev
           tarantool --version
           ./deps.sh
 

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -39,9 +39,6 @@ jobs:
       - name: Stop Mono server
         run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 
-      - name: Run linter
-        run: .rocks/bin/luacheck .
-
       - name: Run tests
         run: .rocks/bin/luatest -v
 
@@ -70,9 +67,6 @@ jobs:
       # This server starts and listen on 8084 port that is used for tests
       - name: Stop Mono server
         run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
-
-      - name: Run linter
-        run: .rocks/bin/luacheck .
 
       - name: Run tests
         run: .rocks/bin/luatest -v


### PR DESCRIPTION
**PLEASE MERGE IT WITH REBASE** (without squash)


> What has been done?

`luacheck` moved to a separate pipeline in Github Actions

> Why? What problem is being solved?

Imagine we have an unused variable in pushed source code. All tasks in Github Actions will be failed because `luacheck` run in all of them and blocks regression testing in case of fail.

I didn't forget about

- ~~[ ] Tests~~
- ~~[ ] Changelog~~
- ~~[ ] Documentation~~

Closes #???
