### PR TITLE
test: use appropriate asserts

### DIFF
--- a/test/integration/borders_test.lua
+++ b/test/integration/borders_test.lua
@@ -280,7 +280,7 @@ end)
 pgroup:add('test_equal_secondary_keys', function(g)
     local bucket_id = 1
     local other_bucket_id, err = helpers.get_other_storage_bucket_id(g.cluster, bucket_id)
-    t.assert(other_bucket_id ~= nil, err)
+    t.assert_not_equals(other_bucket_id, nil, err)
 
     -- let's insert two tuples on different replicasets to check that
     -- they will be compared by index + primary fields on router

--- a/test/integration/custom_bucket_id_test.lua
+++ b/test/integration/custom_bucket_id_test.lua
@@ -41,7 +41,7 @@ local function get_other_storage_bucket_id(g, key)
 
     local res_bucket_id, err = helpers.get_other_storage_bucket_id(g.cluster, bucket_id)
 
-    t.assert(res_bucket_id ~= nil, err)
+    t.assert_not_equals(res_bucket_id, nil, err)
     return res_bucket_id
 end
 
@@ -51,7 +51,7 @@ local function check_get(g, space_name, id, bucket_id, tuple)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     -- get w/ right bucket_id
@@ -60,7 +60,7 @@ local function check_get(g, space_name, id, bucket_id, tuple)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 end
 
@@ -79,7 +79,7 @@ pgroup:add('test_update', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 1)
 
     -- update w/ default bucket_id
@@ -88,7 +88,7 @@ pgroup:add('test_update', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     -- tuple not found, update returned nil
     t.assert_equals(#result.rows, 0)
 
@@ -98,7 +98,7 @@ pgroup:add('test_update', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 1)
 end)
 
@@ -112,7 +112,7 @@ pgroup:add('test_delete', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 1)
 
     -- delete w/ default bucket_id
@@ -121,7 +121,7 @@ pgroup:add('test_delete', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     -- since delete returns nil for vinyl,
     -- just get tuple to check it wasn't deleted
 
@@ -131,7 +131,7 @@ pgroup:add('test_delete', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     -- tuple wasn't deleted
     t.assert_equals(#result.rows, 1)
 
@@ -141,7 +141,7 @@ pgroup:add('test_delete', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
 
     -- get w/ right bucket_id
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
@@ -149,7 +149,7 @@ pgroup:add('test_delete', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     -- tuple was deleted
     t.assert_equals(#result.rows, 0)
 end)
@@ -167,7 +167,7 @@ pgroup:add('test_insert_object', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -185,7 +185,7 @@ pgroup:add('test_insert_object_bucket_id_opt', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -212,7 +212,7 @@ pgroup:add('test_insert_object_bucket_id_specified_twice', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -229,7 +229,7 @@ pgroup:add('test_insert', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple)
@@ -248,7 +248,7 @@ pgroup:add('test_insert_bucket_id_opt', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple_with_bucket_id})
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple_with_bucket_id)
@@ -273,7 +273,7 @@ pgroup:add('test_insert_bucket_id_specified_twice', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple)
@@ -292,7 +292,7 @@ pgroup:add('test_replace_object', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -310,7 +310,7 @@ pgroup:add('test_replace_object_bucket_id_opt', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -337,7 +337,7 @@ pgroup:add('test_replace_object_bucket_id_specified_twice', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -354,7 +354,7 @@ pgroup:add('test_replace', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple)
@@ -373,7 +373,7 @@ pgroup:add('test_replace_bucket_id_opt', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple_with_bucket_id})
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple_with_bucket_id)
@@ -398,7 +398,7 @@ pgroup:add('test_replace_bucket_id_specified_twice', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {tuple})
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple)
@@ -417,7 +417,7 @@ pgroup:add('test_upsert_object', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -435,7 +435,7 @@ pgroup:add('test_upsert_object_bucket_id_opt', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -462,7 +462,7 @@ pgroup:add('test_upsert_object_bucket_id_specified_twice', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     check_get(g, 'customers', object.id, bucket_id, tuple)
@@ -479,7 +479,7 @@ pgroup:add('test_upsert', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple)
@@ -498,7 +498,7 @@ pgroup:add('test_upsert_bucket_id_opt', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple_with_bucket_id)
@@ -523,7 +523,7 @@ pgroup:add('test_upsert_bucket_id_specified_twice', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 0)
 
     check_get(g, 'customers', tuple[1], bucket_id, tuple)
@@ -539,7 +539,7 @@ pgroup:add('test_select', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(#result.rows, 1)
 
     local conditions = {{'==', 'id', tuple[1]}}
@@ -550,7 +550,7 @@ pgroup:add('test_select', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     -- tuple not found
     t.assert_equals(#result.rows, 0)
 
@@ -560,7 +560,7 @@ pgroup:add('test_select', function(g)
     })
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     -- tuple is found
     t.assert_equals(#result.rows, 1)
 end)

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -111,7 +111,7 @@ pgroup:add('test_insert_object_get', function(g)
     local result, err = g.cluster.main_server.net_box:call('crud.get', {'customers', 1})
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
 
@@ -148,7 +148,7 @@ pgroup:add('test_insert_get', function(g)
     local result, err = g.cluster.main_server.net_box:call('crud.get', {'customers', 2})
 
     t.assert_equals(err, nil)
-    t.assert(result ~= nil)
+    t.assert_not_equals(result, nil)
     t.assert_equals(result.rows, {{2, 401, 'Ivan', 20}})
 
     -- insert again

--- a/test/integration/truncate_test.lua
+++ b/test/integration/truncate_test.lua
@@ -62,7 +62,7 @@ pgroup:add('test_truncate', function(g)
 
     local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil})
     t.assert_equals(err, nil)
-    t.assert(#result.rows > 0)
+    t.assert_gt(#result.rows, 0)
 
     local result, err = g.cluster.main_server.net_box:call('crud.truncate', {'customers'})
     t.assert_equals(err, nil)
@@ -70,5 +70,5 @@ pgroup:add('test_truncate', function(g)
 
     local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil})
     t.assert_equals(err, nil)
-    t.assert(#result.rows == 0)
+    t.assert_equals(#result.rows, 0)
 end)

--- a/test/unit/parse_conditions_test.lua
+++ b/test/unit/parse_conditions_test.lua
@@ -15,7 +15,7 @@ g.test_parse = function()
     }
 
     local conditions, err = compare_conditions.parse(user_conditions)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(conditions, {
         cond_funcs.eq('aaaa', nil),
         cond_funcs.eq('bbb', {12, 'aaaa'}),
@@ -113,7 +113,7 @@ g.test_jsonpath_parse = function()
     }
 
     local conditions, err = compare_conditions.parse(user_conditions)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(conditions, {
         cond_funcs.eq('[\'name\']', 'Alexey'),
         cond_funcs.eq('["name"].a.b', 'Sergey'),

--- a/test/unit/select_comparators_test.lua
+++ b/test/unit/select_comparators_test.lua
@@ -9,7 +9,7 @@ g.test_eq_no_collations = function()
     local func_eq, err = select_comparators.gen_func(operators.EQ, {
         {}, {}, {},
     })
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
 
     -- check that index length is used
     t.assert(func_eq({1, 2, 3}, {1, 2, 3, 4}))
@@ -29,7 +29,7 @@ g.test_lt_no_collations = function()
     local func_lt, err = select_comparators.gen_func(operators.LT, {
         {}, {}, {},
     })
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
 
     t.assert(not func_lt({1}, {1}))
     t.assert(func_lt({1}, {1, 2}))
@@ -64,7 +64,7 @@ g.test_gt_no_collations = function()
     local func_gt, err = select_comparators.gen_func(operators.GT, {
         {}, {}, {},
     })
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
 
     t.assert(not func_gt({1}, {1}))
     t.assert(func_gt({1, 2}, {1}))
@@ -83,7 +83,7 @@ g.test_ge_no_collations = function()
     local func_ge, err = select_comparators.gen_func(operators.GE, {
         {}, {}, {},
     })
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
 
     t.assert(func_ge({1}, {1}))
     t.assert(func_ge({1, 2}, {1}))
@@ -111,9 +111,9 @@ g.test_unicode_collations = function()
     }
 
     local func_eq_unicode, err = select_comparators.gen_func(operators.GE, unicode_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     local func_eq_unicode_ci, err = select_comparators.gen_func(operators.GE, unicode_ci_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
 
     t.assert(func_eq_unicode({'a'}, {'a'}))
     t.assert(func_eq_unicode_ci({'a'}, {'a'}))
@@ -122,24 +122,24 @@ g.test_unicode_collations = function()
     t.assert(func_eq_unicode_ci({'a', 'A', 'a'}, {'A', 'Á', 'Ä'}))
 
     local func_lt_unicode, err = select_comparators.gen_func(operators.LT, unicode_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert(func_lt_unicode({'a', 'A', 'a'}, {'A', 'Á', 'Ä'}, 3))
 
     local func_gt_unicode, err = select_comparators.gen_func(operators.GT, unicode_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert(not func_gt_unicode({'a', 'A', 'a'}, {'A', 'Á', 'Ä'}, 3))
 
     local func_ge_unicode, err = select_comparators.gen_func(operators.GE, unicode_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     local func_ge_unicode_ci, err = select_comparators.gen_func(operators.GE, unicode_ci_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert(not func_ge_unicode({'a', 'A', 'a'}, {'A', 'Á', 'Ä'}, 3))
     t.assert(func_ge_unicode_ci({'a', 'A', 'a'}, {'A', 'Á', 'Ä'}, 3))
 
     local func_le_unicode, err = select_comparators.gen_func(operators.LE, unicode_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     local func_le_unicode_ci, err = select_comparators.gen_func(operators.LE, unicode_ci_parts)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert(not func_le_unicode({'A', 'Á', 'Ä'}, {'a', 'A', 'a'}, 3))
     t.assert(func_le_unicode_ci({'A', 'Á', 'Ä'}, {'a', 'A', 'a'}, 3))
 end

--- a/test/unit/select_dropped_indexes_test.lua
+++ b/test/unit/select_dropped_indexes_test.lua
@@ -65,7 +65,7 @@ g.before_all = function()
     customers.index.index5_dropped:drop()
 
     -- We need this check to make sure that test actually covers a problem.
-    t.assert(#box.space.customers.index ~= table.maxn(box.space.customers.index))
+    t.assert_not_equals(#box.space.customers.index, table.maxn(box.space.customers.index))
 end
 
 g.after_all = function()

--- a/test/unit/serialization_test.lua
+++ b/test/unit/serialization_test.lua
@@ -39,7 +39,7 @@ g.test_flatten = function()
     }
 
     local tuple, err = utils.flatten(object, space_format)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(tuple, {1, 1024, 'Marilyn', 50})
 
 
@@ -51,7 +51,7 @@ g.test_flatten = function()
     }
 
     local tuple, err = utils.flatten(object, space_format, 1025)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(tuple, {1, 1025, 'Marilyn', 50})
 
     -- non-nullable field name is nil
@@ -63,8 +63,8 @@ g.test_flatten = function()
     }
 
     local tuple, err = utils.flatten(object, space_format)
-    t.assert(tuple == nil)
-    t.assert(err ~= nil)
+    t.assert_equals(tuple, nil)
+    t.assert_not_equals(err, nil)
     t.assert_str_contains(err.err, 'Field "name" isn\'t nullable')
 
     -- system field bucket_id is nil
@@ -76,7 +76,7 @@ g.test_flatten = function()
     }
 
     local tuple, err = utils.flatten(object, space_format)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(tuple, {1, nil, 'Marilyn', 50})
 
     -- nullable field is nil
@@ -88,7 +88,7 @@ g.test_flatten = function()
     }
 
     local tuple, err = utils.flatten(object, space_format)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(tuple, {1, 1024, 'Marilyn', nil})
 
     -- unknown field is specififed
@@ -112,7 +112,7 @@ g.test_unflatten = function()
     -- ok
     local tuple = {1, 1024, 'Marilyn', 50}
     local object, err = utils.unflatten(tuple, space_format)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(object, {
         id = 1,
         bucket_id = 1024,
@@ -123,14 +123,14 @@ g.test_unflatten = function()
     -- non-nullable field id nil
     local tuple = {1, nil, 'Marilyn', 50}
     local object, err = utils.unflatten(tuple, space_format)
-    t.assert(object == nil)
-    t.assert(err ~= nil)
+    t.assert_equals(object, nil)
+    t.assert_not_equals(err, nil)
     t.assert_str_contains(err.err, "Field 2 isn't nullable")
 
     -- nullable field is nil
     local tuple = {1, 1024, 'Marilyn', nil}
     local object, err = utils.unflatten(tuple, space_format)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(object, {
         id = 1,
         bucket_id = 1024,
@@ -141,7 +141,7 @@ g.test_unflatten = function()
     -- extra field
     local tuple = {1, 1024, 'Marilyn', 50, 'one-bad-value'}
     local object, err = utils.unflatten(tuple, space_format)
-    t.assert(err == nil)
+    t.assert_equals(err, nil)
     t.assert_equals(object, {
         id = 1,
         bucket_id = 1024,


### PR DESCRIPTION
luatest has a wide range of asserts [1] that checks actual and expected
values. Using these asserts instead of conditions in pure assert()
improves readability and provide more details in log when assert
triggered. This patch replaces asserts with conditions inside to
appropriate luatest's assert function.

1. https://github.com/tarantool/luatest#list-of-luatest-functions

What has been done? Why? What problem is being solved?

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Closes #???
