### PR TITLE
Bump luatest version

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Test dependencies:
-tarantoolctl rocks install luatest 0.5.4
+tarantoolctl rocks install luatest 0.5.5
 tarantoolctl rocks install luacheck 0.25.0
 tarantoolctl rocks install luacov 0.13.0
 


### PR DESCRIPTION
New version 0.5.5 brings:

- Repeat `_each` and `_test` hooks when `--repeat` is specified.
- Add group parametrization.

1. https://github.com/tarantool/luatest/commit/717cf1d03440f1134fbd8010775084878c1c3949


