### PR TITLE
Fix passing timeout option for select/pairs

### DIFF
--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -146,7 +146,6 @@ function select_module.pairs(space_name, user_conditions, opts)
     local iterator_opts = {
         after = opts.after,
         first = opts.first,
-        timeout = opts.timeout,
         batch_size = opts.batch_size,
         bucket_id = opts.bucket_id,
         force_map_call = opts.force_map_call,
@@ -211,7 +210,6 @@ local function select_module_call_xc(space_name, user_conditions, opts)
     local iterator_opts = {
         after = opts.after,
         first = opts.first,
-        timeout = opts.timeout,
         batch_size = opts.batch_size,
         bucket_id = opts.bucket_id,
         force_map_call = opts.force_map_call,

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -46,7 +46,7 @@ local function select_iteration(space_name, plan, opts)
 
     local results, err = call.map(common.SELECT_FUNC_NAME, storage_select_args, {
         replicasets = opts.replicasets,
-        timeout = opts.timeout,
+        timeout = call_opts.timeout,
         mode = call_opts.mode or 'read',
         prefer_replica = call_opts.prefer_replica,
         balance = call_opts.balance,
@@ -194,7 +194,6 @@ function select_module.pairs(space_name, user_conditions, opts)
     local iterator_opts = {
         after = opts.after,
         first = opts.first,
-        timeout = opts.timeout,
         batch_size = opts.batch_size,
         bucket_id = opts.bucket_id,
         force_map_call = opts.force_map_call,
@@ -275,7 +274,6 @@ function select_module.call(space_name, user_conditions, opts)
     local iterator_opts = {
         after = opts.after,
         first = opts.first,
-        timeout = opts.timeout,
         batch_size = opts.batch_size,
         bucket_id = opts.bucket_id,
         force_map_call = opts.force_map_call,


### PR DESCRIPTION
Before this patch passing `timeout` option to `crud.select()`/`crud.pairs()`
had been leading to an error `unexpected argument opts.timeout to func`.
Function `build_select_iterator` accepts `timeout` as a part of `call_opts`
table option. Before this patch function `build_select_iterator` had been
receiving `timeout` as a separate parameter which had been leading to a failure.

Closes #209 