### PR TITLE
Fix merger support recognition on tarantool 2.10+

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,5 @@
 redefined = false
-globals = {'box', 'utf8', 'checkers'}
+globals = {'box', 'utf8', 'checkers', '_TARANTOOL'}
 include_files = {'**/*.lua', '*.luacheckrc', '*.rockspec'}
 exclude_files = {'**/*.rocks/', 'tmp/', 'tarantool-enterprise/'}
 max_line_length = 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Use tuple-merger backed select implementation on tarantool 2.10+ (it gives
+  less pressure on Lua GC).
+
 ## [0.9.0] - 20-10-21
 
 ### Added

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -300,4 +300,27 @@ function helpers.get_other_storage_bucket_id(cluster, bucket_id)
     ]], {bucket_id})
 end
 
+function helpers.tarantool_version_at_least(wanted_major, wanted_minor,
+        wanted_patch)
+    -- Borrowed from `determine_enabled_features()` from
+    -- crud/common/utils.lua.
+    local major_minor_patch = _TARANTOOL:split('-', 1)[1]
+    local major_minor_patch_parts = major_minor_patch:split('.', 2)
+
+    local major = tonumber(major_minor_patch_parts[1])
+    local minor = tonumber(major_minor_patch_parts[2])
+    local patch = tonumber(major_minor_patch_parts[3])
+
+    if major < (wanted_major or 0) then return false end
+    if major > (wanted_major or 0) then return true end
+
+    if minor < (wanted_minor or 0) then return false end
+    if minor > (wanted_minor or 0) then return true end
+
+    if patch < (wanted_patch or 0) then return false end
+    if patch > (wanted_patch or 0) then return true end
+
+    return true
+end
+
 return helpers

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -432,11 +432,11 @@ pgroup.test_intermediate_nullable_fields_update = function(g)
     -- However since 2.8 Tarantool could update intermediate nullable fields
     -- (https://github.com/tarantool/tarantool/issues/3378).
     -- So before 2.8 update returns an error but after it update is correct.
-    if _TARANTOOL > "2.8" then
+    if helpers.tarantool_version_at_least(2, 8) then
         local _, err = g.cluster.main_server.net_box:call('crud.update',
             {'developers', 1, {{'=', '[5].a.b[1]', 3}, {'=', 'extra_5', 'extra_value_5'}}})
         t.assert_equals(err, nil)
-    elseif _TARANTOOL >= "2.3" then
+    elseif helpers.tarantool_version_at_least(2, 3) then
         local _, err = g.cluster.main_server.net_box:call('crud.update',
             {'developers', 1, {{'=', '[5].a.b[1]', 3}, {'=', 'extra_5', 'extra_value_5'}}})
         t.assert_equals(err.err, "Failed to update: Field ''extra_5'' was not found in the tuple")


### PR DESCRIPTION
We cannot use just string comparison as before, because '2.10.0-<...>'
less than, say, '2.3' lexicographically. The module had to use the old
select implementation on tarantool 2.10 due to this problem.

Implemented more accurate checks, whether built-in and external
tuple-merger are supported. Say, it'll not enable the built-in merger on
tarantool 2.4.1, where the module has a known problem (see comments in
the code).

Fixed the problem of the same kind in a test case.