### PR TITLE
Batch operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Batch insert/upsert operation
+  `crud.insert_many()`/`crud.insert_object_many()`/
+  `crud.upsert_many()`/`crud.upsert_object_many()`
+  `crud.replace_many()`/`crud.replace_object_many()`
+  with partial consistency
 
 ### Changed
 

--- a/crud.lua
+++ b/crud.lua
@@ -6,6 +6,7 @@ local cfg = require('crud.cfg')
 local insert = require('crud.insert')
 local insert_many = require('crud.insert_many')
 local replace = require('crud.replace')
+local replace_many = require('crud.replace_many')
 local get = require('crud.get')
 local update = require('crud.update')
 local upsert = require('crud.upsert')
@@ -52,6 +53,14 @@ crud.replace = stats.wrap(replace.tuple, stats.op.REPLACE)
 -- @refer replace.object
 -- @function replace_object
 crud.replace_object = stats.wrap(replace.object, stats.op.REPLACE)
+
+-- @refer replace_many.tuples
+-- @function replace_many
+crud.replace_many = replace_many.tuples
+
+-- @refer replace_many.objects
+-- @function replace_object_many
+crud.replace_object_many = replace_many.objects
 
 -- @refer update.call
 -- @function update
@@ -145,6 +154,7 @@ function crud.init_storage()
     insert_many.init()
     get.init()
     replace.init()
+    replace_many.init()
     update.init()
     upsert.init()
     upsert_many.init()

--- a/crud.lua
+++ b/crud.lua
@@ -9,6 +9,7 @@ local replace = require('crud.replace')
 local get = require('crud.get')
 local update = require('crud.update')
 local upsert = require('crud.upsert')
+local upsert_many = require('crud.upsert_many')
 local delete = require('crud.delete')
 local select = require('crud.select')
 local truncate = require('crud.truncate')
@@ -59,6 +60,14 @@ crud.update = stats.wrap(update.call, stats.op.UPDATE)
 -- @refer upsert.tuple
 -- @function upsert
 crud.upsert = stats.wrap(upsert.tuple, stats.op.UPSERT)
+
+-- @refer upsert_many.tuples
+-- @function upsert_many
+crud.upsert_many = upsert_many.tuples
+
+-- @refer upsert_many.objects
+-- @function upsert_object_many
+crud.upsert_object_many = upsert_many.objects
 
 -- @refer upsert.object
 -- @function upsert
@@ -138,6 +147,7 @@ function crud.init_storage()
     replace.init()
     update.init()
     upsert.init()
+    upsert_many.init()
     delete.init()
     select.init()
     truncate.init()

--- a/crud.lua
+++ b/crud.lua
@@ -4,6 +4,7 @@
 
 local cfg = require('crud.cfg')
 local insert = require('crud.insert')
+local insert_many = require('crud.insert_many')
 local replace = require('crud.replace')
 local get = require('crud.get')
 local update = require('crud.update')
@@ -30,6 +31,14 @@ crud.insert = stats.wrap(insert.tuple, stats.op.INSERT)
 -- @refer insert.object
 -- @function insert_object
 crud.insert_object = stats.wrap(insert.object, stats.op.INSERT)
+
+-- @refer insert_many.tuples
+-- @function insert_many
+crud.insert_many = insert_many.tuples
+
+-- @refer insert_many.objects
+-- @function insert_object_many
+crud.insert_object_many = insert_many.objects
 
 -- @refer get.call
 -- @function get
@@ -124,6 +133,7 @@ function crud.init_storage()
     end
 
     insert.init()
+    insert_many.init()
     get.init()
     replace.init()
     update.init()

--- a/crud.lua
+++ b/crud.lua
@@ -36,11 +36,11 @@ crud.insert_object = stats.wrap(insert.object, stats.op.INSERT)
 
 -- @refer insert_many.tuples
 -- @function insert_many
-crud.insert_many = insert_many.tuples
+crud.insert_many = stats.wrap(insert_many.tuples, stats.op.INSERT_MANY)
 
 -- @refer insert_many.objects
 -- @function insert_object_many
-crud.insert_object_many = insert_many.objects
+crud.insert_object_many = stats.wrap(insert_many.objects, stats.op.INSERT_MANY)
 
 -- @refer get.call
 -- @function get
@@ -56,11 +56,11 @@ crud.replace_object = stats.wrap(replace.object, stats.op.REPLACE)
 
 -- @refer replace_many.tuples
 -- @function replace_many
-crud.replace_many = replace_many.tuples
+crud.replace_many = stats.wrap(replace_many.tuples, stats.op.REPLACE_MANY)
 
 -- @refer replace_many.objects
 -- @function replace_object_many
-crud.replace_object_many = replace_many.objects
+crud.replace_object_many = stats.wrap(replace_many.objects, stats.op.REPLACE_MANY)
 
 -- @refer update.call
 -- @function update
@@ -72,11 +72,11 @@ crud.upsert = stats.wrap(upsert.tuple, stats.op.UPSERT)
 
 -- @refer upsert_many.tuples
 -- @function upsert_many
-crud.upsert_many = upsert_many.tuples
+crud.upsert_many = stats.wrap(upsert_many.tuples, stats.op.UPSERT_MANY)
 
 -- @refer upsert_many.objects
 -- @function upsert_object_many
-crud.upsert_object_many = upsert_many.objects
+crud.upsert_object_many = stats.wrap(upsert_many.objects, stats.op.UPSERT_MANY)
 
 -- @refer upsert.object
 -- @function upsert

--- a/crud/common/batching_utils.lua
+++ b/crud/common/batching_utils.lua
@@ -1,0 +1,38 @@
+local errors = require('errors')
+local dev_checks = require('crud.common.dev_checks')
+local sharding_utils = require('crud.common.sharding.utils')
+
+local NotPerformedError = errors.new_class('NotPerformedError', {capture_stack = false})
+
+local batching_utils = {}
+
+batching_utils.stop_on_error_msg = "Operation with tuple was not performed"
+batching_utils.rollback_on_error_msg = "Operation with tuple was rollback"
+
+function batching_utils.construct_sharding_hash_mismatch_errors(err_msg, tuples)
+    dev_checks('string', 'table')
+
+    local errs = {}
+
+    for _, tuple in ipairs(tuples) do
+        local err_obj = sharding_utils.ShardingHashMismatchError:new(err_msg)
+        err_obj.operation_data = tuple
+        table.insert(errs, err_obj)
+    end
+
+    return errs
+end
+
+function batching_utils.complement_batching_errors(errs, err_msg, tuples)
+    dev_checks('table', 'string', 'table')
+
+    for _, tuple in ipairs(tuples) do
+        local err_obj = NotPerformedError:new(err_msg)
+        err_obj.operation_data = tuple
+        table.insert(errs, err_obj)
+    end
+
+    return errs
+end
+
+return batching_utils

--- a/crud/common/map_call_cases/base_iter.lua
+++ b/crud/common/map_call_cases/base_iter.lua
@@ -1,0 +1,76 @@
+local errors = require('errors')
+local vshard = require('vshard')
+
+local dev_checks = require('crud.common.dev_checks')
+local GetReplicasetsError = errors.new_class('GetReplicasetsError')
+
+local BaseIterator = {}
+
+--- Create new base iterator for map call
+--
+-- @function new
+--
+-- @tparam[opt] table opts
+-- Options of BaseIterator:new
+-- @tparam[opt] table opts.func_args
+-- Function arguments to call
+-- @tparam[opt] table opts.replicasets
+-- Replicasets to call
+--
+-- @return[1] table iterator
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+function BaseIterator:new(opts)
+    dev_checks('table', {
+        func_args = '?table',
+        replicasets = '?table',
+    })
+
+    local replicasets, err
+    if opts.replicasets ~= nil then
+        replicasets = opts.replicasets
+    else
+        replicasets, err = vshard.router.routeall()
+        if replicasets == nil then
+            return nil, GetReplicasetsError:new("Failed to get all replicasets: %s", err.err)
+        end
+    end
+
+    local next_index, next_replicaset = next(replicasets)
+
+    local iter = {
+        func_args = opts.func_args,
+        replicasets = replicasets,
+        next_replicaset = next_replicaset,
+        next_index = next_index
+    }
+
+    setmetatable(iter, self)
+    self.__index = self
+
+    return iter
+end
+
+--- Check there is next replicaset to call
+--
+-- @function has_next
+--
+-- @return[1] boolean
+function BaseIterator:has_next()
+    return self.next_index ~= nil
+end
+
+--- Get function arguments and next replicaset
+--
+-- @function get
+--
+-- @return[1] table func_args
+-- @return[2] table replicaset
+function BaseIterator:get()
+    local replicaset = self.next_replicaset
+    self.next_index, self.next_replicaset = next(self.replicasets, self.next_index)
+
+    return self.func_args, replicaset
+end
+
+return BaseIterator

--- a/crud/common/map_call_cases/base_postprocessor.lua
+++ b/crud/common/map_call_cases/base_postprocessor.lua
@@ -1,0 +1,84 @@
+local dev_checks = require('crud.common.dev_checks')
+
+local BasePostprocessor = {}
+
+--- Create new base postprocessor for map call
+--
+-- @function new
+--
+-- @return[1] table postprocessor
+function BasePostprocessor:new()
+    local postprocessor = {
+        results = {},
+        early_exit = false,
+        errs = nil
+    }
+
+    setmetatable(postprocessor, self)
+    self.__index = self
+
+    return postprocessor
+end
+
+--- Collect data after call
+--
+-- @function collect
+--
+-- @tparam[opt] table result_info
+-- Data of function call result
+-- @tparam[opt] result_info.key
+-- Key for collecting result
+-- @tparam[opt] result_info.value
+-- Value for collecting result by result_info.key
+--
+-- @tparam[opt] table err_info
+-- Data of function call error
+-- @tparam[opt] function|table err_info.err_wrapper
+-- Wrapper for error formatting
+-- @tparam[opt] table|cdata err_info.err
+-- Err of function call
+-- @tparam[opt] table err_info.wrapper_args
+-- Additional args for error wrapper
+--
+-- @return[1] boolean early_exit
+function BasePostprocessor:collect(result_info, err_info)
+    dev_checks('table', {
+        key = '?',
+        value = '?',
+    },{
+        err_wrapper = 'function|table',
+        err = '?table|cdata',
+        wrapper_args = '?table',
+    })
+
+    local err = err_info.err
+    if err == nil and result_info.value[1] == nil then
+        err = result_info.value[2]
+    end
+
+    if err ~= nil then
+        self.results = nil
+        self.errs = err_info.err_wrapper(err, unpack(err_info.wrapper_args))
+        self.early_exit = true
+
+        return self.early_exit
+    end
+
+    if self.early_exit ~= true then
+        self.results[result_info.key] = result_info.value
+    end
+
+    return self.early_exit
+end
+
+--- Get collected data
+--
+-- @function get
+--
+-- @return[1] table results
+-- @return[2] table errs
+function BasePostprocessor:get()
+    return self.results, self.errs
+end
+
+return BasePostprocessor

--- a/crud/common/map_call_cases/batch_postprocessor.lua
+++ b/crud/common/map_call_cases/batch_postprocessor.lua
@@ -1,0 +1,70 @@
+local dev_checks = require('crud.common.dev_checks')
+local utils = require('crud.common.utils')
+local sharding_utils = require('crud.common.sharding.utils')
+
+local BasePostprocessor = require('crud.common.map_call_cases.base_postprocessor')
+
+local BatchPostprocessor = {}
+-- inheritance from BasePostprocessor
+setmetatable(BatchPostprocessor, {__index = BasePostprocessor})
+
+--- Collect data after call
+--
+-- @function collect
+--
+-- @tparam[opt] table result_info
+-- Data of function call result
+-- @tparam[opt] result_info.key
+-- Key for collecting result
+-- @tparam[opt] result_info.value
+-- Value for collecting result by result_info.key
+--
+-- @tparam[opt] table err_info
+-- Data of function call error
+-- @tparam[opt] function|table err_info.err_wrapper
+-- Wrapper for error formatting
+-- @tparam[opt] table|cdata err_info.err
+-- Err of function call
+-- @tparam[opt] table err_info.wrapper_args
+-- Additional args for error wrapper
+--
+-- @return[1] boolean early_exit
+function BatchPostprocessor:collect(result_info, err_info)
+    dev_checks('table', {
+        key = '?',
+        value = '?',
+    },{
+        err_wrapper = 'function|table',
+        err = '?table|cdata',
+        wrapper_args = '?table',
+    })
+
+    local errs = {err_info.err}
+    if err_info.err == nil then
+        errs = result_info.value[2]
+    end
+
+    if errs ~= nil then
+        for _, err in pairs(errs) do
+            local err_to_wrap = err
+            if err.class_name ~= sharding_utils.ShardingHashMismatchError.name and err.err then
+                err_to_wrap = err.err
+            end
+
+            local err_obj = err_info.err_wrapper(err_to_wrap, unpack(err_info.wrapper_args))
+            err_obj.operation_data = err.operation_data
+            err_obj.space_schema_hash = err.space_schema_hash
+
+            self.errs = self.errs or {}
+            table.insert(self.errs, err_obj)
+        end
+    end
+
+    if result_info.value ~= nil and result_info.value[1] ~= nil then
+        self.results = utils.list_extend(self.results, result_info.value[1])
+    end
+
+    return self.early_exit
+end
+
+return BatchPostprocessor

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -244,4 +244,16 @@ function schema.result_needs_reload(space, result)
     return result.space_schema_hash ~= get_space_schema_hash(space)
 end
 
+function schema.batching_result_needs_reload(space, results, tuples_count)
+    local storage_errs_count = 0
+    local space_schema_hash = get_space_schema_hash(space)
+    for _, result in ipairs(results) do
+        if result.space_schema_hash ~= nil and result.space_schema_hash ~= space_schema_hash then
+            storage_errs_count = storage_errs_count + 1
+        end
+    end
+
+    return storage_errs_count == tuples_count
+end
+
 return schema

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -711,4 +711,41 @@ function utils.update_storage_call_error_description(err, func_name, replicaset_
     return err
 end
 
+--- Insert each value from values to list
+--
+-- @function list_extend
+--
+-- @param table list
+--  List to be extended
+--
+-- @param table values
+--  Values to be inserted to list
+--
+-- @return[1] list
+--  List with old values and inserted values
+function utils.list_extend(list, values)
+    dev_checks('table', 'table')
+
+    for _, value in ipairs(values) do
+        table.insert(list, value)
+    end
+
+    return list
+end
+
+function utils.list_slice(list, start_index, end_index)
+    dev_checks('table', 'number', '?number')
+
+    if end_index == nil then
+        end_index = table.maxn(list)
+    end
+
+    local slice = {}
+    for i = start_index, end_index do
+        table.insert(slice, list[i])
+    end
+
+    return slice
+end
+
 return utils

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -1,0 +1,288 @@
+local checks = require('checks')
+local errors = require('errors')
+local vshard = require('vshard')
+
+local call = require('crud.common.call')
+local const = require('crud.common.const')
+local utils = require('crud.common.utils')
+local batching_utils = require('crud.common.batching_utils')
+local sharding = require('crud.common.sharding')
+local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
+
+local BatchInsertIterator = require('crud.common.map_call_cases.batch_insert_iter')
+local BatchPostprocessor = require('crud.common.map_call_cases.batch_postprocessor')
+
+local InsertManyError = errors.new_class('InsertManyError', {capture_stack = false})
+
+local insert_many = {}
+
+local INSERT_MANY_FUNC_NAME = '_crud.insert_many_on_storage'
+
+local function insert_many_on_storage(space_name, tuples, opts)
+    dev_checks('string', 'table', {
+        add_space_schema_hash = '?boolean',
+        fields = '?table',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+        sharding_key_hash = '?number',
+        sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = box.space[space_name]
+    if space == nil then
+        return nil, {InsertManyError:new("Space %q doesn't exist", space_name)}
+    end
+
+    local _, err = sharding.check_sharding_hash(space_name,
+                                                opts.sharding_func_hash,
+                                                opts.sharding_key_hash,
+                                                opts.skip_sharding_hash_check)
+
+    if err ~= nil then
+        return nil, batching_utils.construct_sharding_hash_mismatch_errors(err.err, tuples)
+    end
+
+    local inserted_tuples = {}
+    local errs = {}
+
+    box.begin()
+    for i, tuple in ipairs(tuples) do
+        -- add_space_schema_hash is true only in case of insert_object_many
+        -- the only one case when reloading schema can avoid insert error
+        -- is flattening object on router
+        local insert_result = schema.wrap_box_space_func_result(space, 'insert', {tuple}, {
+            add_space_schema_hash = opts.add_space_schema_hash,
+            field_names = opts.fields,
+        })
+
+        if insert_result.err ~= nil then
+            local err = {
+                err = insert_result.err,
+                space_schema_hash = insert_result.space_schema_hash,
+                operation_data = tuple,
+            }
+
+            table.insert(errs, err)
+
+            if opts.stop_on_error == true then
+                local left_tuples = utils.list_slice(tuples, i + 1)
+                if next(left_tuples) then
+                    errs = batching_utils.complement_batching_errors(errs,
+                            batching_utils.stop_on_error_msg, left_tuples)
+                end
+
+                if opts.rollback_on_error == true then
+                    box.rollback()
+                    if next(inserted_tuples) then
+                        errs = batching_utils.complement_batching_errors(errs,
+                                batching_utils.rollback_on_error_msg, inserted_tuples)
+                    end
+
+                    return nil, errs
+                end
+
+                box.commit()
+
+                return inserted_tuples, errs
+            end
+        end
+
+        table.insert(inserted_tuples, insert_result.res)
+    end
+
+    if next(errs) ~= nil then
+        if opts.rollback_on_error == true then
+            box.rollback()
+            if next(inserted_tuples) then
+                errs = batching_utils.complement_batching_errors(errs,
+                        batching_utils.rollback_on_error_msg, inserted_tuples)
+            end
+
+            return nil, errs
+        end
+
+        box.commit()
+
+        return inserted_tuples, errs
+    end
+
+    box.commit()
+
+    return inserted_tuples
+end
+
+function insert_many.init()
+    _G._crud.insert_many_on_storage = insert_many_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_insert_many_on_router(space_name, original_tuples, opts)
+    dev_checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = utils.get_space(space_name, vshard.router.routeall())
+    if space == nil then
+        return nil, {InsertManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
+    end
+
+    local tuples = table.deepcopy(original_tuples)
+
+    local batch_insert_on_storage_opts = {
+        add_space_schema_hash = opts.add_space_schema_hash,
+        fields = opts.fields,
+        stop_on_error = opts.stop_on_error,
+        rollback_on_error = opts.rollback_on_error,
+    }
+
+    local iter, err = BatchInsertIterator:new({
+        tuples = tuples,
+        space = space,
+        execute_on_storage_opts = batch_insert_on_storage_opts,
+    })
+    if err ~= nil then
+        return nil, {err}, const.NEED_SCHEMA_RELOAD
+    end
+
+    local postprocessor = BatchPostprocessor:new()
+
+    local rows, errs = call.map(INSERT_MANY_FUNC_NAME, nil, {
+        timeout = opts.timeout,
+        mode = 'write',
+        iter = iter,
+        postprocessor = postprocessor,
+    })
+
+    if errs ~= nil then
+        local tuples_count = table.maxn(tuples)
+        if sharding.batching_result_needs_sharding_reload(errs, tuples_count) then
+            return nil, errs, const.NEED_SHARDING_RELOAD
+        end
+
+        if schema.batching_result_needs_reload(space, errs, tuples_count) then
+            return nil, errs, const.NEED_SCHEMA_RELOAD
+        end
+    end
+
+    if next(rows) == nil then
+        return nil, errs
+    end
+
+    local res, err = utils.format_result(rows, space, opts.fields)
+    if err ~= nil then
+        errs = errs or {}
+        table.insert(errs, err)
+        return nil, errs
+    end
+
+    return res, errs
+end
+
+--- Inserts batch of tuples to the specified space
+--
+-- @function tuples
+--
+-- @param string space_name
+--  A space name
+--
+-- @param table tuples
+--  Tuples
+--
+-- @tparam ?table opts
+--  Options of batch_insert.tuples_batch
+--
+-- @return[1] tuples
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+
+function insert_many.tuples(space_name, tuples, opts)
+    checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    return schema.wrap_func_reload(sharding.wrap_method,
+                                   call_insert_many_on_router, space_name, tuples, opts)
+end
+
+--- Inserts batch of objects to the specified space
+--
+-- @function objects
+--
+-- @param string space_name
+--  A space name
+--
+-- @param table objs
+--  Objects
+--
+-- @tparam ?table opts
+--  Options of batch_insert.tuples_batch
+--
+-- @return[1] objects
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+
+function insert_many.objects(space_name, objs, opts)
+    checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    -- insert can fail if router uses outdated schema to flatten object
+    opts = utils.merge_options(opts, {add_space_schema_hash = true})
+
+    local tuples = {}
+    local format_errs = {}
+
+    for _, obj in ipairs(objs) do
+
+        local tuple, err = utils.flatten_obj_reload(space_name, obj)
+        if err ~= nil then
+            local err_obj = InsertManyError:new("Failed to flatten object: %s", err)
+            err_obj.operation_data = obj
+
+            if opts.stop_on_error == true then
+                return nil, {err_obj}
+            end
+
+            table.insert(format_errs, err_obj)
+        end
+
+        table.insert(tuples, tuple)
+    end
+
+    if next(tuples) == nil then
+        return nil, format_errs
+    end
+
+    local res, errs = insert_many.tuples(space_name, tuples, opts)
+
+    if next(format_errs) ~= nil then
+        if errs == nil then
+            errs = format_errs
+        else
+            errs = utils.list_extend(errs, format_errs)
+        end
+    end
+
+    return res, errs
+end
+
+return insert_many

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -1,0 +1,290 @@
+local checks = require('checks')
+local errors = require('errors')
+local vshard = require('vshard')
+
+local call = require('crud.common.call')
+local const = require('crud.common.const')
+local utils = require('crud.common.utils')
+local batching_utils = require('crud.common.batching_utils')
+local sharding = require('crud.common.sharding')
+local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
+
+local BatchInsertIterator = require('crud.common.map_call_cases.batch_insert_iter')
+local BatchPostprocessor = require('crud.common.map_call_cases.batch_postprocessor')
+
+local ReplaceManyError = errors.new_class('ReplaceManyError', {capture_stack = false})
+
+local replace_many = {}
+
+local REPLACE_MANY_FUNC_NAME = '_crud.replace_many_on_storage'
+
+local function replace_many_on_storage(space_name, tuples, opts)
+    dev_checks('string', 'table', {
+        add_space_schema_hash = '?boolean',
+        fields = '?table',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+        sharding_key_hash = '?number',
+        sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = box.space[space_name]
+    if space == nil then
+        return nil, {ReplaceManyError:new("Space %q doesn't exist", space_name)}
+    end
+
+    local _, err = sharding.check_sharding_hash(space_name,
+                                                opts.sharding_func_hash,
+                                                opts.sharding_key_hash,
+                                                opts.skip_sharding_hash_check)
+
+    if err ~= nil then
+        return nil, batching_utils.construct_sharding_hash_mismatch_errors(err.err, tuples)
+    end
+
+    local inserted_tuples = {}
+    local errs = {}
+
+    box.begin()
+    for i, tuple in ipairs(tuples) do
+        -- add_space_schema_hash is true only in case of replace_object_many
+        -- the only one case when reloading schema can avoid replace error
+        -- is flattening object on router
+        local insert_result = schema.wrap_box_space_func_result(space, 'replace', {tuple}, {
+            add_space_schema_hash = opts.add_space_schema_hash,
+            field_names = opts.fields,
+        })
+
+        table.insert(errs, err)
+
+        if insert_result.err ~= nil then
+            local err = {
+                err = insert_result.err,
+                space_schema_hash = insert_result.space_schema_hash,
+                operation_data = tuple,
+            }
+
+            table.insert(errs, err)
+
+            if opts.stop_on_error == true then
+                local left_tuples = utils.list_slice(tuples, i + 1)
+                if next(left_tuples) then
+                    errs = batching_utils.complement_batching_errors(errs,
+                            batching_utils.stop_on_error_msg, left_tuples)
+                end
+
+                if opts.rollback_on_error == true then
+                    box.rollback()
+                    if next(inserted_tuples) then
+                        errs = batching_utils.complement_batching_errors(errs,
+                                batching_utils.rollback_on_error_msg, inserted_tuples)
+                    end
+
+                    return nil, errs
+                end
+
+                box.commit()
+
+                return inserted_tuples, errs
+            end
+        end
+
+        table.insert(inserted_tuples, insert_result.res)
+    end
+
+    if next(errs) ~= nil then
+        if opts.rollback_on_error == true then
+            box.rollback()
+            if next(inserted_tuples) then
+                errs = batching_utils.complement_batching_errors(errs,
+                        batching_utils.rollback_on_error_msg, inserted_tuples)
+            end
+
+            return nil, errs
+        end
+
+        box.commit()
+
+        return inserted_tuples, errs
+    end
+
+    box.commit()
+
+    return inserted_tuples
+end
+
+function replace_many.init()
+    _G._crud.replace_many_on_storage = replace_many_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_replace_many_on_router(space_name, original_tuples, opts)
+    dev_checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = utils.get_space(space_name, vshard.router.routeall())
+    if space == nil then
+        return nil, {ReplaceManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
+    end
+
+    local tuples = table.deepcopy(original_tuples)
+
+    local replace_many_on_storage_opts = {
+        add_space_schema_hash = opts.add_space_schema_hash,
+        fields = opts.fields,
+        stop_on_error = opts.stop_on_error,
+        rollback_on_error = opts.rollback_on_error,
+    }
+
+    local iter, err = BatchInsertIterator:new({
+        tuples = tuples,
+        space = space,
+        execute_on_storage_opts = replace_many_on_storage_opts,
+    })
+    if err ~= nil then
+        return nil, {err}, const.NEED_SCHEMA_RELOAD
+    end
+
+    local postprocessor = BatchPostprocessor:new()
+
+    local rows, errs = call.map(REPLACE_MANY_FUNC_NAME, nil, {
+        timeout = opts.timeout,
+        mode = 'write',
+        iter = iter,
+        postprocessor = postprocessor,
+    })
+
+    if errs ~= nil then
+        local tuples_count = table.maxn(tuples)
+        if sharding.batching_result_needs_sharding_reload(errs, tuples_count) then
+            return nil, errs, const.NEED_SHARDING_RELOAD
+        end
+
+        if schema.batching_result_needs_reload(space, errs, tuples_count) then
+            return nil, errs, const.NEED_SCHEMA_RELOAD
+        end
+    end
+
+    if next(rows) == nil then
+        return nil, errs
+    end
+
+    local res, err = utils.format_result(rows, space, opts.fields)
+    if err ~= nil then
+        errs = errs or {}
+        table.insert(errs, err)
+        return nil, errs
+    end
+
+    return res, errs
+end
+
+--- Replace batch of tuples to the specified space
+--
+-- @function tuples
+--
+-- @param string space_name
+--  A space name
+--
+-- @param table tuples
+--  Tuples
+--
+-- @tparam ?table opts
+--  Options of batch_replace.tuples_batch
+--
+-- @return[1] tuples
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+
+function replace_many.tuples(space_name, tuples, opts)
+    checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    return schema.wrap_func_reload(sharding.wrap_method,
+                                   call_replace_many_on_router, space_name, tuples, opts)
+end
+
+--- Replace batch of objects to the specified space
+--
+-- @function objects
+--
+-- @param string space_name
+--  A space name
+--
+-- @param table objs
+--  Objects
+--
+-- @tparam ?table opts
+--  Options of batch_insert.tuples_batch
+--
+-- @return[1] objects
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+
+function replace_many.objects(space_name, objs, opts)
+    checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    -- insert can fail if router uses outdated schema to flatten object
+    opts = utils.merge_options(opts, {add_space_schema_hash = true})
+
+    local tuples = {}
+    local format_errs = {}
+
+    for _, obj in ipairs(objs) do
+
+        local tuple, err = utils.flatten_obj_reload(space_name, obj)
+        if err ~= nil then
+            local err_obj = ReplaceManyError:new("Failed to flatten object: %s", err)
+            err_obj.operation_data = obj
+
+            if opts.stop_on_error == true then
+                return nil, {err_obj}
+            end
+
+            table.insert(format_errs, err_obj)
+        end
+
+        table.insert(tuples, tuple)
+    end
+
+    if next(tuples) == nil then
+        return nil, format_errs
+    end
+
+    local res, errs = replace_many.tuples(space_name, tuples, opts)
+
+    if next(format_errs) ~= nil then
+        if errs == nil then
+            errs = format_errs
+        else
+            errs = utils.list_extend(errs, format_errs)
+        end
+    end
+
+    return res, errs
+end
+
+return replace_many

--- a/crud/stats/operation.lua
+++ b/crud/stats/operation.lua
@@ -6,12 +6,18 @@
 return {
     -- INSERT identifies both `insert` and `insert_object`.
     INSERT = 'insert',
+    -- INSERT_MANY identifies both `insert_many` and `insert_object_many`.
+    INSERT_MANY = 'insert_many',
     GET = 'get',
     -- REPLACE identifies both `replace` and `replace_object`.
     REPLACE = 'replace',
+    -- REPLACE_MANY identifies both `replace_many` and `replace_object_many`.
+    REPLACE_MANY = 'replace_many',
     UPDATE = 'update',
     -- UPSERT identifies both `upsert` and `upsert_object`.
     UPSERT = 'upsert',
+    -- UPSERT_MANY identifies both `upsert_many` and `upsert_object_many`.
+    UPSERT_MANY = 'upsert_many',
     DELETE = 'delete',
     -- SELECT identifies both `pairs` and `select`.
     SELECT = 'select',

--- a/crud/upsert_many.lua
+++ b/crud/upsert_many.lua
@@ -1,0 +1,305 @@
+local checks = require('checks')
+local errors = require('errors')
+local vshard = require('vshard')
+
+local call = require('crud.common.call')
+local const = require('crud.common.const')
+local utils = require('crud.common.utils')
+local batching_utils = require('crud.common.batching_utils')
+local sharding = require('crud.common.sharding')
+local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
+
+local BatchUpsertIterator = require('crud.common.map_call_cases.batch_upsert_iter')
+local BatchPostprocessor = require('crud.common.map_call_cases.batch_postprocessor')
+
+local UpsertManyError = errors.new_class('UpsertManyError', {capture_stack = false})
+
+local upsert_many = {}
+
+local UPSERT_MANY_FUNC_NAME = '_crud.upsert_many_on_storage'
+
+local function upsert_many_on_storage(space_name, tuples, operations, opts)
+    dev_checks('string', 'table', 'table', {
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+        sharding_key_hash = '?number',
+        sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = box.space[space_name]
+    if space == nil then
+        return nil, UpsertManyError:new("Space %q doesn't exist", space_name)
+    end
+
+    local _, err = sharding.check_sharding_hash(space_name,
+                                                opts.sharding_func_hash,
+                                                opts.sharding_key_hash,
+                                                opts.skip_sharding_hash_check)
+
+    if err ~= nil then
+        return nil, batching_utils.construct_sharding_hash_mismatch_errors(err.err, tuples)
+    end
+
+    local processed_tuples = {}
+    local errs = {}
+
+    box.begin()
+    for i, tuple in ipairs(tuples) do
+        -- add_space_schema_hash is true only in case of upsert_object_many
+        -- the only one case when reloading schema can avoid upsert error
+        -- is flattening object on router
+        local insert_result = schema.wrap_box_space_func_result(space, 'upsert', {tuple, operations[i]}, {
+            add_space_schema_hash = opts.add_space_schema_hash,
+        })
+
+        if insert_result.err ~= nil then
+            local err = {
+                err = insert_result.err,
+                space_schema_hash = insert_result.space_schema_hash,
+                operation_data = tuple,
+            }
+
+            table.insert(errs, err)
+
+            if opts.stop_on_error == true then
+                local left_tuples = utils.list_slice(tuples, i + 1)
+                if next(left_tuples) then
+                    errs = batching_utils.complement_batching_errors(errs,
+                            batching_utils.stop_on_error_msg, left_tuples)
+                end
+
+                if opts.rollback_on_error == true then
+                    box.rollback()
+                    if next(processed_tuples) then
+                        errs = batching_utils.complement_batching_errors(errs,
+                                batching_utils.rollback_on_error_msg, processed_tuples)
+                    end
+
+                    return nil, errs
+                end
+
+                box.commit()
+
+                return nil, errs
+            end
+        else
+            table.insert(processed_tuples, tuple)
+        end
+    end
+
+    if next(errs) ~= nil then
+        if opts.rollback_on_error == true then
+            box.rollback()
+            if next(processed_tuples) then
+                errs = batching_utils.complement_batching_errors(errs,
+                        batching_utils.rollback_on_error_msg, processed_tuples)
+            end
+
+            return nil, errs
+        end
+
+        box.commit()
+
+        return nil, errs
+    end
+
+    box.commit()
+
+    return nil
+end
+
+function upsert_many.init()
+    _G._crud.upsert_many_on_storage = upsert_many_on_storage
+end
+
+-- returns result, err, need_reload
+-- need_reload indicates if reloading schema could help
+-- see crud.common.schema.wrap_func_reload()
+local function call_upsert_many_on_router(space_name, original_tuples_operation_data, opts)
+    dev_checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    opts = opts or {}
+
+    local space = utils.get_space(space_name, vshard.router.routeall())
+    if space == nil then
+        return nil, {UpsertManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
+    end
+
+    local space_format = space:format()
+    local tuples = {}
+    local operations = {}
+    for _, tuple_operation_data in ipairs(original_tuples_operation_data) do
+        local tuple = table.deepcopy(tuple_operation_data[1])
+        local operations_by_tuple = tuple_operation_data[2]
+
+        if not utils.tarantool_supports_fieldpaths() then
+            local converted_operations, err = utils.convert_operations(operations_by_tuple, space_format)
+            if err ~= nil then
+                return nil, {UpsertManyError:new("Wrong operations are specified: %s", err)}, const.NEED_SCHEMA_RELOAD
+            end
+
+            operations_by_tuple = converted_operations
+        end
+
+        table.insert(tuples, tuple)
+        table.insert(operations, operations_by_tuple)
+    end
+
+    local upsert_many_on_storage_opts = {
+        add_space_schema_hash = opts.add_space_schema_hash,
+        stop_on_error = opts.stop_on_error,
+        rollback_on_error = opts.rollback_on_error,
+    }
+
+    local iter, err = BatchUpsertIterator:new({
+        tuples = tuples,
+        space = space,
+        operations = operations,
+        execute_on_storage_opts = upsert_many_on_storage_opts,
+    })
+    if err ~= nil then
+        return nil, {err}, const.NEED_SCHEMA_RELOAD
+    end
+
+    local postprocessor = BatchPostprocessor:new()
+
+    local _, errs = call.map(UPSERT_MANY_FUNC_NAME, nil, {
+        timeout = opts.timeout,
+        mode = 'write',
+        iter = iter,
+        postprocessor = postprocessor,
+    })
+
+    if errs ~= nil then
+        local tuples_count = table.maxn(tuples)
+        if sharding.batching_result_needs_sharding_reload(errs, tuples_count) then
+            return nil, errs, const.NEED_SHARDING_RELOAD
+        end
+
+        if schema.batching_result_needs_reload(space, errs, tuples_count) then
+            return nil, errs, const.NEED_SCHEMA_RELOAD
+        end
+
+        if table.maxn(tuples) == table.maxn(errs) then
+            return nil, errs
+        end
+    end
+
+    local res, err = utils.format_result(nil, space, opts.fields)
+    if err ~= nil then
+        errs = errs or {}
+        table.insert(errs, err)
+        return nil, errs
+    end
+
+    return res, errs
+end
+
+--- Update or insert batch of tuples to the specified space
+--
+-- @function tuples
+--
+-- @param string space_name
+--  A space name
+--
+-- @param table tuples_operation_data
+--  Tuples and operations in format
+--  {{tuple_1, operation_1}, ..., {tuple_n, operation_n}}
+--
+-- @tparam ?table opts
+--  Options of batch_upsert.tuples_batch
+--
+-- @return[1] tuples
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+
+function upsert_many.tuples(space_name, tuples_operation_data, opts)
+    checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        add_space_schema_hash = '?boolean',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    return schema.wrap_func_reload(sharding.wrap_method,
+                                   call_upsert_many_on_router, space_name, tuples_operation_data, opts)
+end
+
+--- Update or insert batch of objects to the specified space
+--
+-- @function objects
+--
+-- @param string space_name
+--  A space name
+--
+-- @param table objs_operation_data
+--  Objects and operations in format
+--  {{obj_1, operation_1}, ..., {obj_n, operation_n}}
+--
+-- @tparam ?table opts
+--  Options of batch_upsert.tuples_batch
+--
+-- @return[1] objects
+-- @treturn[2] nil
+-- @treturn[2] table of tables Error description
+
+function upsert_many.objects(space_name, objs_operation_data, opts)
+    checks('string', 'table', {
+        timeout = '?number',
+        fields = '?table',
+        stop_on_error = '?boolean',
+        rollback_on_error = '?boolean',
+    })
+
+    -- upsert can fail if router uses outdated schema to flatten object
+    opts = utils.merge_options(opts, {add_space_schema_hash = true})
+
+    local tuples_operation_data = {}
+    local format_errs = {}
+
+    for _, obj_operation_data in ipairs(objs_operation_data) do
+        local tuple, err = utils.flatten_obj_reload(space_name, obj_operation_data[1])
+        if err ~= nil then
+            local err_obj = UpsertManyError:new("Failed to flatten object: %s", err)
+            err_obj.operation_data = obj_operation_data[1]
+
+            if opts.stop_on_error == true then
+                return nil, {err_obj}
+            end
+
+            table.insert(format_errs, err_obj)
+        else
+            table.insert(tuples_operation_data, {tuple, obj_operation_data[2]})
+        end
+    end
+
+    if next(tuples_operation_data) == nil then
+        return nil, format_errs
+    end
+
+    local res, errs = upsert_many.tuples(space_name, tuples_operation_data, opts)
+
+    if next(format_errs) ~= nil then
+        if errs == nil then
+            errs = format_errs
+        else
+            errs = utils.list_extend(errs, format_errs)
+        end
+    end
+
+    return res, errs
+end
+
+return upsert_many

--- a/test/entrypoint/srv_batch_operations.lua
+++ b/test/entrypoint/srv_batch_operations.lua
@@ -31,6 +31,31 @@ package.preload['customers-storage'] = function()
                 unique = false,
                 if_not_exists = true,
             })
+
+            local developers_space = box.schema.space.create('developers', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                    {name = 'bucket_id', type = 'unsigned'},
+                    {name = 'name', type = 'string'},
+                    {name = 'login', type = 'string'},
+                },
+                if_not_exists = true,
+                engine = engine,
+            })
+            developers_space:create_index('id', {
+                parts = { {field = 'id'} },
+                if_not_exists = true,
+            })
+            developers_space:create_index('bucket_id', {
+                parts = { {field = 'bucket_id'} },
+                unique = false,
+                if_not_exists = true,
+            })
+            developers_space:create_index('login', {
+                parts = { {field = 'login'} },
+                unique = true,
+                if_not_exists = true,
+            })
         end,
     }
 end

--- a/test/entrypoint/srv_batch_operations.lua
+++ b/test/entrypoint/srv_batch_operations.lua
@@ -1,0 +1,54 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+_G.is_initialized = function() return false end
+
+local log = require('log')
+local errors = require('errors')
+local cartridge = require('cartridge')
+
+package.preload['customers-storage'] = function()
+    return {
+        role_name = 'customers-storage',
+        init = function()
+            local engine = os.getenv('ENGINE') or 'memtx'
+            local customers_space = box.schema.space.create('customers', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                    {name = 'bucket_id', type = 'unsigned'},
+                    {name = 'name', type = 'string'},
+                    {name = 'age', type = 'number'},
+                },
+                if_not_exists = true,
+                engine = engine,
+            })
+            customers_space:create_index('id', {
+                parts = { {field = 'id'} },
+                if_not_exists = true,
+            })
+            customers_space:create_index('bucket_id', {
+                parts = { {field = 'bucket_id'} },
+                unique = false,
+                if_not_exists = true,
+            })
+        end,
+    }
+end
+
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+    advertise_uri = 'localhost:3301',
+    http_port = 8081,
+    bucket_count = 3000,
+    roles = {
+        'customers-storage',
+        'cartridge.roles.crud-router',
+        'cartridge.roles.crud-storage',
+    },
+})
+
+if not ok then
+    log.error('%s', err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -522,4 +522,14 @@ function helpers.fflush_main_server_stdout(cluster, capture)
     return captured
 end
 
+function helpers.complement_tuples_batch_with_operations(tuples, operations)
+
+    local tuples_operation_data = {}
+    for i, tuple in ipairs(tuples) do
+        table.insert(tuples_operation_data, {tuple, operations[i]})
+    end
+
+    return tuples_operation_data
+end
+
 return helpers

--- a/test/integration/ddl_sharding_func_test.lua
+++ b/test/integration/ddl_sharding_func_test.lua
@@ -245,6 +245,74 @@ pgroup.test_replace = function(g)
     t.assert_equals(result, {71, 1, 'Augustus', 21})
 end
 
+pgroup.test_replace_object_many = function(g)
+    -- bucket_id is 596, storage is s-2
+    local tuple = {8, 596, 'Dimitrion', 20}
+
+    -- Put tuple to s1 replicaset.
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space[g.params.space_name]:insert(tuple)
+    t.assert_not_equals(result, nil)
+
+    -- Put tuple to s2 replicaset.
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space[g.params.space_name]:insert(tuple)
+    t.assert_not_equals(result, nil)
+
+    -- Replace an object.
+    local result, err = g.cluster.main_server.net_box:call(
+            'crud.replace_object_many', {g.params.space_name, {{id = 8, name = 'John Doe', age = 25}}})
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 8, bucket_id = 8, name = 'John Doe', age = 25}})
+
+    -- There is no replaced tuple on s1 replicaset.
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space[g.params.space_name]:get({8, 'John Doe'})
+    t.assert_equals(result, nil)
+
+    -- There is replaced tuple on s2 replicaset.
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space[g.params.space_name]:get({8, 'John Doe'})
+    t.assert_equals(result, {8, 8, 'John Doe', 25})
+end
+
+pgroup.test_replace_many = function(g)
+    -- bucket_id is 596, storage is s-2
+    local tuple = {71, 596, 'Dimitrion', 20}
+
+    -- Put tuple to s1 replicaset.
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space[g.params.space_name]:insert(tuple)
+    t.assert_not_equals(result, nil)
+
+    -- Put tuple to s2 replicaset.
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space[g.params.space_name]:insert(tuple)
+    t.assert_not_equals(result, nil)
+
+    local tuple = {71, box.NULL, 'Augustus', 21}
+
+    -- Replace a tuple.
+    local result, err = g.cluster.main_server.net_box:call('crud.replace_many', {
+        g.params.space_name, {tuple}
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    t.assert_equals(#result.rows, 1)
+    t.assert_equals(result.rows[1], {71, 1, 'Augustus', 21})
+
+    -- There is no replaced tuple on s1 replicaset.
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space[g.params.space_name]:get({71, 'Augustus'})
+    t.assert_equals(result, nil)
+
+    -- There is replaced tuple on s2 replicaset.
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space[g.params.space_name]:get({71, 'Augustus'})
+    t.assert_equals(result, {71, 1, 'Augustus', 21})
+end
+
 pgroup.test_upsert_object = function(g)
     -- Upsert an object first time.
     local result, err = g.cluster.main_server.net_box:call(

--- a/test/integration/ddl_sharding_info_reload_test.lua
+++ b/test/integration/ddl_sharding_info_reload_test.lua
@@ -353,6 +353,16 @@ local new_space_cases = {
         input = {'customers_new', test_object},
         result = test_customers_new_result,
     },
+    replace_many = {
+        func = 'crud.replace_many',
+        input = {'customers_new', test_tuples_batch},
+        result = test_customers_new_batching_result,
+    },
+    replace_object_many = {
+        func = 'crud.replace_object_many',
+        input = {'customers_new', test_objects_batch},
+        result = test_customers_new_batching_result,
+    },
     upsert = {
         func = 'crud.upsert',
         input = {'customers_new', test_tuple, {}},
@@ -456,6 +466,16 @@ local schema_change_sharding_key_cases = {
         func = 'crud.replace_object',
         input = {'customers', test_object},
         result = test_customers_age_result,
+    },
+    replace_many = {
+        func = 'crud.replace_many',
+        input = {'customers', test_tuples_batch},
+        result = test_customers_age_batching_result,
+    },
+    replace_object_many = {
+        func = 'crud.replace_object_many',
+        input = {'customers', test_objects_batch},
+        result = test_customers_age_batching_result,
     },
     upsert = {
         func = 'crud.upsert',
@@ -639,6 +659,16 @@ local schema_change_sharding_func_cases = {
         func = 'crud.replace_object',
         input = {'customers_pk', test_object},
         result = test_customers_pk_func,
+    },
+    replace_many = {
+        func = 'crud.replace_many',
+        input = {'customers_pk', test_tuples_batch},
+        result = test_customers_pk_batching_func,
+    },
+    replace_object_many = {
+        func = 'crud.replace_object_many',
+        input = {'customers_pk', test_objects_batch},
+        result = test_customers_pk_batching_func,
     },
     upsert = {
         func = 'crud.upsert',

--- a/test/integration/ddl_sharding_info_reload_test.lua
+++ b/test/integration/ddl_sharding_info_reload_test.lua
@@ -303,6 +303,14 @@ local test_objects_batch = {
     { id = 3, bucket_id = box.NULL, name = 'Petra', age = 27 },
 }
 
+local upsert_many_operations = { {}, {}, {} }
+local test_tuples_operation_batch = helpers.complement_tuples_batch_with_operations(
+        test_tuples_batch,
+        upsert_many_operations)
+local test_objects_operation_batch = helpers.complement_tuples_batch_with_operations(
+        test_objects_batch,
+        upsert_many_operations)
+
 -- Sharded by "name" and computed with custom sharding function.
 local test_customers_new_result = {
     s1 = {{1, 2861, 'Emma', 22}},
@@ -354,6 +362,16 @@ local new_space_cases = {
         func = 'crud.upsert_object',
         input = {'customers_new', test_object, {}},
         result = test_customers_new_result,
+    },
+    upsert_many = {
+        func = 'crud.upsert_many',
+        input = {'customers_new', test_tuples_operation_batch},
+        result = test_customers_new_batching_result,
+    },
+    upsert_object_many = {
+        func = 'crud.upsert_object_many',
+        input = {'customers_new', test_objects_operation_batch},
+        result = test_customers_new_batching_result,
     },
 }
 
@@ -448,6 +466,16 @@ local schema_change_sharding_key_cases = {
         func = 'crud.upsert_object',
         input = {'customers', test_object, {}},
         result = test_customers_age_result,
+    },
+    upsert_many = {
+        func = 'crud.upsert_many',
+        input = {'customers', test_tuples_operation_batch},
+        result = test_customers_age_batching_result,
+    },
+    upsert_object_many = {
+        func = 'crud.upsert_object_many',
+        input = {'customers', test_objects_operation_batch},
+        result = test_customers_age_batching_result,
     },
 }
 
@@ -621,6 +649,16 @@ local schema_change_sharding_func_cases = {
         func = 'crud.upsert_object',
         input = {'customers_pk', test_object, {}},
         result = test_customers_pk_func,
+    },
+    upsert_many = {
+        func = 'crud.upsert_many',
+        input = {'customers_pk', test_tuples_operation_batch},
+        result = test_customers_pk_batching_func,
+    },
+    upsert_object_many = {
+        func = 'crud.upsert_object_many',
+        input = {'customers_pk', test_objects_operation_batch},
+        result = test_customers_pk_batching_func,
     },
     delete = {
         before_test = setup_customers_pk_migrated_data,

--- a/test/integration/insert_many_test.lua
+++ b/test/integration/insert_many_test.lua
@@ -1,0 +1,1954 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local crud = require('crud')
+
+local helpers = require('test.helper')
+
+local batching_utils = require('crud.common.batching_utils')
+
+local pgroup = t.group('insert_many', {
+    {engine = 'memtx'},
+    {engine = 'vinyl'},
+})
+
+pgroup.before_all(function(g)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_batch_operations'),
+        use_vshard = true,
+        replicasets = helpers.get_test_replicasets(),
+        env = {
+            ['ENGINE'] = g.params.engine,
+        },
+    })
+
+    g.cluster:start()
+end)
+
+pgroup.after_all(function(g) helpers.stop_cluster(g.cluster) end)
+
+pgroup.before_each(function(g)
+    helpers.truncate_space_on_cluster(g.cluster, 'customers')
+end)
+
+pgroup.test_non_existent_space = function(g)
+    -- insert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'non_existent_space',
+        {
+            {1, box.NULL, 'Alex', 59},
+            {2, box.NULL, 'Anna', 23},
+            {3, box.NULL, 'Daria', 18}
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+
+    -- insert_object_many
+    -- default: stop_on_error == false
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'non_existent_space',
+        {
+            {id = 1, name = 'Fedor', age = 59},
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18}
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+
+    -- we got 3 errors about non existent space, because it caused by flattening objects
+    t.assert_equals(#errs, 3)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+    t.assert_str_contains(errs[2].err, 'Space "non_existent_space" doesn\'t exist')
+    t.assert_str_contains(errs[3].err, 'Space "non_existent_space" doesn\'t exist')
+
+    -- insert_object_many
+    -- stop_on_error == true
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'non_existent_space',
+        {
+            {id = 1, name = 'Fedor', age = 59},
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+
+    -- we got 1 error about non existent space, because stop_on_error == true
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+end
+
+pgroup.test_object_bad_format = function(g)
+    -- bad format
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Fedor', age = 59},
+            {id = 2, name = 'Anna'},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 2, name = 'Anna'})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', age = 59, bucket_id = 477},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- bad format
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Fedor', age = 59},
+            {id = 2, name = 'Anna'},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {1, 477, "Fedor", 59})
+
+    t.assert_str_contains(errs[2].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[2].operation_data, {id = 2, name = 'Anna'})
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- bad format
+    -- two errors, default: stop_on_error == false
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Fedor'},
+            {id = 2, name = 'Anna'},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data.id < err2.operation_data.id end)
+
+    t.assert_str_contains(errs[1].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 1, name = 'Fedor'})
+
+    t.assert_str_contains(errs[2].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[2].operation_data, {id = 2, name = 'Anna'})
+end
+
+pgroup.test_all_success = function(g)
+    -- insert_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {1, box.NULL, 'Fedor', 59},
+            {2, box.NULL, 'Anna', 23},
+            {3, box.NULL, 'Daria', 18}
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', age = 59, bucket_id = 477},
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_all_success = function(g)
+    -- batch_insert_object
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Fedor', age = 59},
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18}
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', age = 59, bucket_id = 477},
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_one_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- insert_many
+    -- default: stop_on_error = false, rollback_on_error = false
+    -- one error on one storage without rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {22, box.NULL, 'Alex', 34},
+            {3, box.NULL, 'Anastasia', 22},
+            {5, box.NULL, 'Sergey', 25},
+            {9, box.NULL, 'Anna', 30},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 9, name = 'Anna', age = 30, bucket_id = 1644},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Anna', 30})
+end
+
+pgroup.test_object_one_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- batch_insert_object again
+    -- default: stop_on_error = false, rollback_on_error = false
+    -- one error on one storage without rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 22, name = 'Alex', age = 34},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 5, name = 'Sergey', age = 25},
+            {id = 9, name = 'Anna', age = 30},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 9, name = 'Anna', age = 30, bucket_id = 1644},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Anna', 30})
+end
+
+pgroup.test_many_errors = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- insert_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, one success on each storage
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {2, box.NULL, 'Alex', 34},
+            {3, box.NULL, 'Anastasia', 22},
+            {10, box.NULL, 'Sergey', 25},
+            {92, box.NULL, 'Artur', 29},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 10, name = 'Sergey', age = 25, bucket_id = 569},
+        {id = 92, name = 'Artur', age = 29, bucket_id = 2040},
+    })
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, {10, 569, 'Sergey', 25})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_object_many_errors = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- batch_insert_object again
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, one success on each storage
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 2, name = 'Alex', age = 34},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 10, name = 'Sergey', age = 25},
+            {id = 92, name = 'Artur', age = 29},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 10, name = 'Sergey', age = 25, bucket_id = 569},
+        {id = 92, name = 'Artur', age = 29, bucket_id = 2040},
+    })
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, {10, 569, 'Sergey', 25})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_no_success = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({10, 569, 'Sergey', 25})
+    t.assert_equals(result, {10, 569, 'Sergey', 25})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({92, 2040, 'Artur', 29})
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- insert_many again
+    -- fails for both: s1-master s2-master
+    -- no success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {2, box.NULL, 'Alex', 34},
+            {3, box.NULL, 'Anastasia', 22},
+            {10, box.NULL, 'Vlad', 25},
+            {92, box.NULL, 'Mark', 29},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {10, 569, 'Vlad', 25})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {92, 2040, 'Mark', 29})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, {10, 569, 'Sergey', 25})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_object_no_success = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({10, 569, 'Sergey', 25})
+    t.assert_equals(result, {10, 569, 'Sergey', 25})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({92, 2040, 'Artur', 29})
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- batch_insert_object again
+    -- fails for both: s1-master s2-master
+    -- no success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 2, name = 'Alex', age = 34},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 10, name = 'Vlad', age = 25},
+            {id = 92, name = 'Mark', age = 29},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {10, 569, 'Vlad', 25})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {92, 2040, 'Mark', 29})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, {10, 569, 'Sergey', 25})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_object_bad_format_stop_on_error = function(g)
+    -- bad format
+    -- two errors, stop_on_error == true
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Fedor'},
+            {id = 2, name = 'Anna'},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+
+    t.assert_str_contains(errs[1].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 1, name = 'Fedor'})
+end
+
+pgroup.test_all_success_stop_on_error = function(g)
+    -- insert_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {2, box.NULL, 'Anna', 23},
+            {3, box.NULL, 'Daria', 18},
+            {71, box.NULL, 'Oleg', 32}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+        {id = 71, name = 'Oleg', age = 32, bucket_id = 1802},
+    })
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_all_success_stop_on_error = function(g)
+    -- batch_insert_object
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18},
+            {id = 71, name = 'Oleg', age = 32}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+        {id = 71, name = 'Oleg', age = 32, bucket_id = 1802},
+    })
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_partial_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- insert_many
+    -- stop_on_error = true, rollback_on_error = false
+    -- one error on one storage without rollback, inserts stop by error on this storage
+    -- inserts before error are successful
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {22, box.NULL, 'Alex', 34},
+            {92, box.NULL, 'Artur', 29},
+            {3, box.NULL, 'Anastasia', 22},
+            {5, box.NULL, 'Sergey', 25},
+            {9, box.NULL, 'Anna', 30},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+        {id = 92, name = 'Artur', age = 29, bucket_id = 2040},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_object_partial_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- insert_object_many
+    -- stop_on_error = true, rollback_on_error = false
+    -- one error on one storage without rollback, inserts stop by error on this storage
+    -- inserts before error are successful
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 22, name = 'Alex', age = 34},
+            {id = 92, name = 'Artur', age = 29},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 5, name = 'Sergey', age = 25},
+            {id = 9, name = 'Anna', age = 30},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+        {id = 92, name = 'Artur', age = 29, bucket_id = 2040},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_no_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({92, 2040, 'Artur', 29})
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- insert_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, all inserts stop by error
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {2, box.NULL, 'Alex', 34},
+            {3, box.NULL, 'Anastasia', 22},
+            {10, box.NULL, 'Sergey', 25},
+            {9, box.NULL, 'Anna', 30},
+            {92, box.NULL, 'Leo', 29},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 5)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[4].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {10, 569, "Sergey", 25})
+
+    t.assert_str_contains(errs[5].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[5].operation_data, {92, 2040, "Leo", 29})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_object_no_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({92, 2040, 'Artur', 29})
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- insert_object_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, all inserts stop by error
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 2, name = 'Alex', age = 34},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 10, name = 'Sergey', age = 25},
+            {id = 9, name = 'Anna', age = 30},
+            {id = 92, name = 'Leo', age = 29},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 5)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[4].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {10, 569, "Sergey", 25})
+
+    t.assert_str_contains(errs[5].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[5].operation_data, {92, 2040, "Leo", 29})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_all_success_rollback_on_error = function(g)
+    -- insert_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {2, box.NULL, 'Anna', 23},
+            {3, box.NULL, 'Daria', 18},
+            {71, box.NULL, 'Oleg', 32}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+        {id = 71, name = 'Oleg', age = 32, bucket_id = 1802},
+    })
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_all_success_rollback_on_error = function(g)
+    -- insert_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18},
+            {id = 71, name = 'Oleg', age = 32}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+        {id = 71, name = 'Oleg', age = 32, bucket_id = 1802},
+    })
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_partial_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- insert_many
+    -- stop_on_error = false, rollback_on_error = true
+    -- two error on one storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {22, box.NULL, 'Alex', 34},
+            {92, box.NULL, 'Artur', 29},
+            {3, box.NULL, 'Anastasia', 22},
+            {5, box.NULL, 'Sergey', 25},
+            {9, box.NULL, 'Anna', 30},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {9, 1644, 'Anna', 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {92, 2040, 'Artur', 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_object_partial_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- insert_object_many
+    -- stop_on_error = false, rollback_on_error = true
+    -- two error on one storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 22, name = 'Alex', age = 34},
+            {id = 92, name = 'Artur', age = 29},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 5, name = 'Sergey', age = 25},
+            {id = 9, name = 'Anna', age = 30},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {9, 1644, 'Anna', 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_no_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 25})
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- insert_many
+    -- fails for both: s1-master s2-master
+    -- two errors on each storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {1, box.NULL, 'Olga', 27},
+            {92, box.NULL, 'Oleg', 32},
+            {71, box.NULL, 'Sergey', 25},
+            {5, box.NULL, 'Anna', 30},
+            {2, box.NULL, 'Alex', 34},
+            {3, box.NULL, 'Anastasia', 22},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 6)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {1, 477, "Olga", 27})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {5, 1172, "Anna", 30})
+
+    t.assert_str_contains(errs[5].err, 'Duplicate key exists')
+    t.assert_equals(errs[5].operation_data, {71, 1802, "Sergey", 25})
+
+    t.assert_str_contains(errs[6].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[6].operation_data, {92, 2040, "Oleg", 32})
+
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_no_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 25})
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- insert_object_many
+    -- fails for both: s1-master s2-master
+    -- two errors on each storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Olga', age = 27},
+            {id = 92, name = 'Oleg', age = 32},
+            {id = 71, name = 'Sergey', age = 25},
+            {id = 5, name = 'Anna', age = 30},
+            {id = 2, name = 'Alex', age = 34},
+            {id = 3, name = 'Anastasia', age = 22},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 6)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {1, 477, "Olga", 27})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {2, 401, 'Alex', 34})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {5, 1172, "Anna", 30})
+
+    t.assert_str_contains(errs[5].err, 'Duplicate key exists')
+    t.assert_equals(errs[5].operation_data, {71, 1802, "Sergey", 25})
+
+    t.assert_str_contains(errs[6].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[6].operation_data, {92, 2040, "Oleg", 32})
+
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_all_success_rollback_and_stop_on_error = function(g)
+    -- insert_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {2, box.NULL, 'Anna', 23},
+            {3, box.NULL, 'Daria', 18},
+            {71, box.NULL, 'Oleg', 32}
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+        {id = 71, name = "Oleg", age = 32, bucket_id = 1802}
+    })
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_all_success_rollback_and_stop_on_error = function(g)
+    -- insert_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18},
+            {id = 71, name = 'Oleg', age = 32}
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', age = 23, bucket_id = 401},
+        {id = 3, name = 'Daria', age = 18, bucket_id = 2804},
+        {id = 71, name = "Oleg", age = 32, bucket_id = 1802}
+    })
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_partial_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- insert_many
+    -- stop_on_error = true, rollback_on_error = true
+    -- two error on one storage with rollback, inserts stop by error on this storage
+    -- inserts before error are rollbacked
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {22, box.NULL, 'Alex', 34},
+            {92, box.NULL, 'Artur', 29},
+            {3, box.NULL, 'Anastasia', 22},
+            {5, box.NULL, 'Sergey', 25},
+            {9, box.NULL, 'Anna', 30},
+            {71, box.NULL, 'Oksana', 29},
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {71, 1802, "Oksana", 29})
+
+    t.assert_str_contains(errs[4].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_partial_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- insert_object_many
+    -- stop_on_error = true, rollback_on_error = true
+    -- two error on one storage with rollback, inserts stop by error on this storage
+    -- inserts before error are rollbacked
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 22, name = 'Alex', age = 34},
+            {id = 92, name = 'Artur', age = 29},
+            {id = 3, name = 'Anastasia', age = 22},
+            {id = 5, name = 'Sergey', age = 25},
+            {id = 9, name = 'Anna', age = 30},
+            {id = 71, name = 'Oksana', age = 29},
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {71, 1802, "Oksana", 29})
+
+    t.assert_str_contains(errs[4].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', age = 25, bucket_id = 1172},
+        {id = 22, name = 'Alex', age = 34, bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_partial_result = function(g)
+    -- bad fields format
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {15, box.NULL, 'Fedor', 59},
+            {25, box.NULL, 'Anna', 23},
+        },
+        {fields = {'id', 'invalid'}},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space format doesn\'t contain field named "invalid"')
+
+    -- insert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_many', {
+        'customers',
+        {
+            {1, box.NULL, 'Fedor', 59},
+            {2, box.NULL, 'Anna', 23},
+            {3, box.NULL, 'Daria', 18}
+        },
+        {fields = {'id', 'name'}},
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {{id = 1, name = 'Fedor'}, {id = 2, name = 'Anna'}, {id = 3, name = 'Daria'}})
+end
+
+pgroup.test_object_partial_result = function(g)
+    -- bad fields format
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 15, name = 'Fedor', age = 59},
+            {id = 25, name = 'Anna', age = 23},
+        },
+        {fields = {'id', 'invalid'}},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space format doesn\'t contain field named "invalid"')
+
+    -- insert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.insert_object_many', {
+        'customers',
+        {
+            {id = 1, name = 'Fedor', age = 59},
+            {id = 2, name = 'Anna', age = 23},
+            {id = 3, name = 'Daria', age = 18}
+        },
+        {fields = {'id', 'name'}},
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {{id = 1, name = 'Fedor'}, {id = 2, name = 'Anna'}, {id = 3, name = 'Daria'}})
+end
+
+pgroup.test_opts_not_damaged = function(g)
+    -- insert_many
+    local batch_insert_opts = {timeout = 1, fields = {'name', 'age'}}
+    local new_batch_insert_opts, err = g.cluster.main_server:eval([[
+        local crud = require('crud')
+
+        local batch_insert_opts = ...
+
+        local _, err = crud.insert_many('customers', {
+            {1, box.NULL, 'Alex', 59}
+        }, batch_insert_opts)
+
+        return batch_insert_opts, err
+    ]], {batch_insert_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_batch_insert_opts, batch_insert_opts)
+
+    -- insert_object_many
+    local batch_insert_opts = {timeout = 1, fields = {'name', 'age'}}
+    local new_batch_insert_opts, err = g.cluster.main_server:eval([[
+        local crud = require('crud')
+
+        local batch_insert_opts = ...
+
+        local _, err = crud.insert_object_many('customers', {
+            {id = 2, name = 'Fedor', age = 59}
+        }, batch_insert_opts)
+
+        return batch_insert_opts, err
+    ]], {batch_insert_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_batch_insert_opts, batch_insert_opts)
+end

--- a/test/integration/replace_many_test.lua
+++ b/test/integration/replace_many_test.lua
@@ -1,0 +1,1964 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local crud = require('crud')
+
+local helpers = require('test.helper')
+
+local batching_utils = require('crud.common.batching_utils')
+
+local pgroup = t.group('replace_many', {
+    {engine = 'memtx'},
+    {engine = 'vinyl'},
+})
+
+pgroup.before_all(function(g)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_batch_operations'),
+        use_vshard = true,
+        replicasets = helpers.get_test_replicasets(),
+        env = {
+            ['ENGINE'] = g.params.engine,
+        },
+    })
+
+    g.cluster:start()
+end)
+
+pgroup.after_all(function(g) helpers.stop_cluster(g.cluster) end)
+
+pgroup.before_each(function(g)
+    helpers.truncate_space_on_cluster(g.cluster, 'developers')
+end)
+
+pgroup.test_non_existent_space = function(g)
+    -- replace_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'non_existent_space',
+        {
+            {1, box.NULL, 'Alex', 'alexpushkin'},
+            {2, box.NULL, 'Anna', 'AnnaKar'},
+            {3, box.NULL, 'Daria', 'mongendor'}
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+
+    -- replace_object_many
+    -- default: stop_on_error == false
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'non_existent_space',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongendor'}
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+
+    -- we got 3 errors about non existent space, because it caused by flattening objects
+    t.assert_equals(#errs, 3)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+    t.assert_str_contains(errs[2].err, 'Space "non_existent_space" doesn\'t exist')
+    t.assert_str_contains(errs[3].err, 'Space "non_existent_space" doesn\'t exist')
+
+    -- replace_object_many
+    -- stop_on_error == true
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'non_existent_space',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongendor'}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+
+    -- we got 1 error about non existent space, because stop_on_error == true
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+end
+
+pgroup.test_object_bad_format = function(g)
+    -- bad format
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna'},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Field \"login\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 2, name = 'Anna'})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- bad format
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 4, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna'},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Fedor", "FDost"})
+
+    t.assert_str_contains(errs[2].err, 'Field \"login\" isn\'t nullable')
+    t.assert_equals(errs[2].operation_data, {id = 2, name = 'Anna'})
+
+    -- get
+    -- primary key = 4 -> bucket_id = 1161 -> s1-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- bad format
+    -- two errors, default: stop_on_error == false
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor'},
+            {id = 2, name = 'Anna'},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data.id < err2.operation_data.id end)
+
+    t.assert_str_contains(errs[1].err, 'Field \"login\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 1, name = 'Fedor'})
+
+    t.assert_str_contains(errs[2].err, 'Field \"login\" isn\'t nullable')
+    t.assert_equals(errs[2].operation_data, {id = 2, name = 'Anna'})
+end
+
+pgroup.test_all_success = function(g)
+    -- replace_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Fedor', 'FDost'},
+            {2, box.NULL, 'Anna', 'AnnaKar'},
+            {3, box.NULL, 'Daria', 'mongend'}
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_object_all_success = function(g)
+    -- insert
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({1, 477, 'Alex', 'alexpushkin'})
+    t.assert_equals(result, {1, 477, 'Alex', 'alexpushkin'})
+
+    -- replace_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongend'}
+        },
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_one_error = function(g)
+    -- insert
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({1, 477, 'Alex', 'alexpushkin'})
+    t.assert_equals(result, {1, 477, 'Alex', 'alexpushkin'})
+
+    -- replace_many
+    -- failed for s1-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {4, box.NULL, 'Fedor', 'alexpushkin'},
+            {2, box.NULL, 'Anna', 'AnnaKar'},
+            {3, box.NULL, 'Daria', 'mongend'}
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Fedor", "alexpushkin"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_object_one_error = function(g)
+    -- insert
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({1, 477, 'Alex', 'alexpushkin'})
+    t.assert_equals(result, {1, 477, 'Alex', 'alexpushkin'})
+
+    -- replace_object_many
+    -- failed for s1-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 4, name = 'Fedor', login = 'alexpushkin'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongend'}
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Fedor", "alexpushkin"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_object_many_errors = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'a.petrova'})
+    t.assert_equals(result, {2, 401, 'Anna', 'a.petrova'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'd.petrenko'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'd.petrenko'})
+
+    -- replace_object_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, one success on each storage
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 4, name = 'Sergey', login = 's.ivanov'},
+            {id = 71, name = 'Artur', login = 'a.orlov'},
+            {id = 10, name = 'Anastasia', login = 'a.petrova'},
+            {id = 92, name = 'Dmitriy', login = 'd.petrenko'},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {10, 569, "Anastasia", "a.petrova"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {92, 2040, "Dmitriy", "d.petrenko"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 4, login = "s.ivanov", bucket_id = 1161, name = "Sergey"},
+        {id = 71, login = "a.orlov", bucket_id = 1802, name = "Artur"},
+    })
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, {4, 1161, 'Sergey', 's.ivanov'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Artur', 'a.orlov'})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_many_errors = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'a.petrova'})
+    t.assert_equals(result, {2, 401, 'Anna', 'a.petrova'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'd.petrenko'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'd.petrenko'})
+
+    -- replace_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, one success on each storage
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {4, box.NULL, 'Sergey', 's.ivanov'},
+            {71, box.NULL, 'Artur', 'a.orlov'},
+            {10, box.NULL, 'Anastasia', 'a.petrova'},
+            {92, box.NULL, 'Dmitriy', 'd.petrenko'},
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {10, 569, "Anastasia", "a.petrova"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {92, 2040, "Dmitriy", "d.petrenko"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 4, login = "s.ivanov", bucket_id = 1161, name = "Sergey"},
+        {id = 71, login = "a.orlov", bucket_id = 1802, name = "Artur"},
+    })
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, {4, 1161, 'Sergey', 's.ivanov'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Artur', 'a.orlov'})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_no_success = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'a.smith'})
+    t.assert_equals(result, {2, 401, 'Anna', 'a.smith'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'd.petrenko'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'd.petrenko'})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({10, 569, 'Sergey', 's.serenko'})
+    t.assert_equals(result, {10, 569, 'Sergey', 's.serenko'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({92, 2040, 'Artur', 'a.smirnov'})
+    t.assert_equals(result, {92, 2040, 'Artur', 'a.smirnov'})
+
+    -- replace_many
+    -- fails for both: s1-master s2-master
+    -- no success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {4, box.NULL, 'Alex', 'a.smith'},
+            {71, box.NULL, 'Dmitriy', 'd.petrenko'},
+            {6, box.NULL, 'Semen', 's.serenko'},
+            {9, box.NULL, 'Anton', 'a.smirnov'},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Alex", "a.smith"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {6, 1064, "Semen", "s.serenko"})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {9, 1644, "Anton", "a.smirnov"})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {71, 1802, "Dmitriy", "d.petrenko"})
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 6 -> bucket_id = 1064 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(6)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_object_no_success = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'a.smith'})
+    t.assert_equals(result, {2, 401, 'Anna', 'a.smith'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'd.petrenko'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'd.petrenko'})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({10, 569, 'Sergey', 's.serenko'})
+    t.assert_equals(result, {10, 569, 'Sergey', 's.serenko'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({92, 2040, 'Artur', 'a.smirnov'})
+    t.assert_equals(result, {92, 2040, 'Artur', 'a.smirnov'})
+
+    -- replace_object_many
+    -- fails for both: s1-master s2-master
+    -- no success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 4, name = 'Alex', login = 'a.smith'},
+            {id = 71, name = 'Dmitriy', login = 'd.petrenko'},
+            {id = 6, name = 'Semen', login = 's.serenko'},
+            {id = 9, name = 'Anton', login = 'a.smirnov'},
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Alex", "a.smith"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {6, 1064, "Semen", "s.serenko"})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {9, 1644, "Anton", "a.smirnov"})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {71, 1802, "Dmitriy", "d.petrenko"})
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 6 -> bucket_id = 1064 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(6)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_object_bad_format_stop_on_error = function(g)
+    -- bad format
+    -- two errors, stop_on_error == true
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor'},
+            {id = 2, name = 'Anna'},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+
+    t.assert_str_contains(errs[1].err, 'Field \"login\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 1, name = 'Fedor'})
+end
+
+pgroup.test_all_success_stop_on_error = function(g)
+    -- replace_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Fedor', 'FDost'},
+            {2, box.NULL, 'Anna', 'AnnaKar'},
+            {3, box.NULL, 'Daria', 'mongend'}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_object_all_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({1, 477, 'Alex', 'alexpushkin'})
+    t.assert_equals(result, {1, 477, 'Alex', 'alexpushkin'})
+
+    -- replace_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongend'}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_partial_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({9, 1644, 'Eren', 'e.smith'})
+    t.assert_equals(result, {9, 1644, 'Eren', 'e.smith'})
+
+    -- replace_many
+    -- stop_on_error = true, rollback_on_error = false
+    -- one error on one storage without rollback, inserts stop by error on this storage
+    -- inserts before error are successful
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {22, box.NULL, 'Alex', 'alexpushkin'},
+            {92, box.NULL, 'Artur', 'AGolden'},
+            {71, box.NULL, 'Erwin', 'e.smith'},
+            {5, box.NULL, 'Sergey', 's.petrenko'},
+            {11, box.NULL, 'Anna', 'mongend'},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {11, 2652, "Anna", "mongend"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {71, 1802, "Erwin", "e.smith"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 22, bucket_id = 655, login = "alexpushkin", name = "Alex"},
+        {id = 5, bucket_id = 1172, login = "s.petrenko", name = "Sergey"},
+        {id = 92, bucket_id = 2040, login = "AGolden", name = "Artur"},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 'alexpushkin'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 'AGolden'})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_object_partial_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({9, 1644, 'Eren', 'e.smith'})
+    t.assert_equals(result, {9, 1644, 'Eren', 'e.smith'})
+
+    -- replace_object_many
+    -- stop_on_error = true, rollback_on_error = false
+    -- one error on one storage without rollback, inserts stop by error on this storage
+    -- inserts before error are successful
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 22, name = 'Alex', login = 'alexpushkin'},
+            {id = 92, name = 'Artur', login = 'AGolden'},
+            {id = 71, name = 'Erwin', login = 'e.smith'},
+            {id = 5, name = 'Sergey', login = 's.petrenko'},
+            {id = 11, name = 'Anna', login = 'mongend'},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {11, 2652, "Anna", "mongend"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {71, 1802, "Erwin", "e.smith"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 22, bucket_id = 655, login = "alexpushkin", name = "Alex"},
+        {id = 5, bucket_id = 1172, login = "s.petrenko", name = "Sergey"},
+        {id = 92, bucket_id = 2040, login = "AGolden", name = "Artur"},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 'alexpushkin'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 'AGolden'})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_no_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'AnnaKar'})
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({92, 2040, 'Artur', 'AGolden'})
+    t.assert_equals(result, {92, 2040, 'Artur', 'AGolden'})
+
+    -- replace_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, all inserts stop by error
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {71, box.NULL, 'Alex', 'AGolden'},
+            {4, box.NULL, 'Anastasia', 'AnnaKar'},
+            {10, box.NULL, 'Sergey', 's.petrenko'},
+            {9, box.NULL, 'Anna', 'a.smirnova'},
+            {92, box.NULL, 'Leo', 'tolstoy_leo'},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 5)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Anastasia", "AnnaKar"})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", "a.smirnova"})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {10, 569, "Sergey", "s.petrenko"})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {71, 1802, "Alex", "AGolden"})
+
+    t.assert_str_contains(errs[5].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[5].operation_data, {92, 2040, "Leo", "tolstoy_leo"})
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 'AGolden'})
+end
+
+pgroup.test_object_no_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'AnnaKar'})
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({92, 2040, 'Artur', 'AGolden'})
+    t.assert_equals(result, {92, 2040, 'Artur', 'AGolden'})
+
+    -- replace_object_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, all inserts stop by error
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 71, name = 'Alex', login = 'AGolden'},
+            {id = 4, name = 'Anastasia', login = 'AnnaKar'},
+            {id = 10, name = 'Sergey', login = 's.petrenko'},
+            {id = 9, name = 'Anna', login = 'a.smirnova'},
+            {id = 92, name = 'Leo', login = 'tolstoy_leo'},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 5)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {4, 1161, "Anastasia", "AnnaKar"})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", "a.smirnova"})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {10, 569, "Sergey", "s.petrenko"})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {71, 1802, "Alex", "AGolden"})
+
+    t.assert_str_contains(errs[5].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[5].operation_data, {92, 2040, "Leo", "tolstoy_leo"})
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 'AGolden'})
+end
+
+pgroup.test_all_success_rollback_on_error = function(g)
+    -- replace_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Fedor', 'FDost'},
+            {2, box.NULL, 'Anna', 'AnnaKar'},
+            {3, box.NULL, 'Daria', 'mongend'}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_object_all_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({1, 477, 'Alex', 'alexpushkin'})
+    t.assert_equals(result, {1, 477, 'Alex', 'alexpushkin'})
+
+    -- replace_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongend'}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_partial_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({9, 1644, 'Nicolo', 'n.black'})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 'n.black'})
+
+    -- replace_many
+    -- stop_on_error = false, rollback_on_error = true
+    -- two error on one storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {22, box.NULL, 'Alex', 'alexpushkin'},
+            {92, box.NULL, 'Artur', 'AGolden'},
+            {71, box.NULL, 'Anastasia', 'n.black'},
+            {5, box.NULL, 'Sergey', 's.petrenko'},
+            {11, box.NULL, 'Anna', 'mongend'},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {11, 2652, "Anna", "mongend"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {71, 1802, "Anastasia", "n.black"})
+
+    t.assert_str_contains(errs[3].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {92, 2040, "Artur", "AGolden"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', login = "s.petrenko", bucket_id = 1172},
+        {id = 22, name = 'Alex', login = "alexpushkin", bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 'alexpushkin'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_object_partial_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({9, 1644, 'Nicolo', 'n.black'})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 'n.black'})
+
+    -- replace_object_many
+    -- stop_on_error = false, rollback_on_error = true
+    -- two error on one storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 22, name = 'Alex', login = 'alexpushkin'},
+            {id = 92, name = 'Artur', login = 'AGolden'},
+            {id = 71, name = 'Anastasia', login = 'n.black'},
+            {id = 5, name = 'Sergey', login = 's.petrenko'},
+            {id = 11, name = 'Anna', login = 'mongend'},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, 'Duplicate key exists')
+    t.assert_equals(errs[1].operation_data, {11, 2652, "Anna", "mongend"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {71, 1802, "Anastasia", "n.black"})
+
+    t.assert_str_contains(errs[3].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {92, 2040, "Artur", "AGolden"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', login = "s.petrenko", bucket_id = 1172},
+        {id = 22, name = 'Alex', login = "alexpushkin", bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 'alexpushkin'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(71)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_no_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'a.leonhart'})
+    t.assert_equals(result, {2, 401, 'Anna', 'a.leonhart'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({5, 1172, 'Sergey', 's.petrenko'})
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({71, 1802, 'Oleg', 'OKonov'})
+    t.assert_equals(result, {71, 1802, 'Oleg', 'OKonov'})
+
+    -- replace_many
+    -- fails for both: s1-master s2-master
+    -- two errors on each storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Eren', 'e.eger'},
+            {92, box.NULL, 'Alexey', 'black_alex'},
+            {11, box.NULL, 'Olga', 'OKonov'},
+            {6, box.NULL, 'Anastasia', 'a.leonhart'},
+            {4, box.NULL, 'Semen', 's.petrenko'},
+            {9, box.NULL, 'Leo', 'mongend'},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 6)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {1, 477, "Eren", "e.eger"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {4, 1161, "Semen", "s.petrenko"})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {6, 1064, "Anastasia", "a.leonhart"})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {9, 1644, "Leo", "mongend"})
+
+    t.assert_str_contains(errs[5].err, 'Duplicate key exists')
+    t.assert_equals(errs[5].operation_data, {11, 2652, "Olga", "OKonov"})
+
+    t.assert_str_contains(errs[6].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[6].operation_data, {92, 2040, "Alexey", "black_alex"})
+
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 6 -> bucket_id = 1064 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(6)
+    t.assert_equals(result, nil)
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_object_no_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({2, 401, 'Anna', 'a.leonhart'})
+    t.assert_equals(result, {2, 401, 'Anna', 'a.leonhart'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Daria', 'mongend'})
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({5, 1172, 'Sergey', 's.petrenko'})
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({71, 1802, 'Oleg', 'OKonov'})
+    t.assert_equals(result, {71, 1802, 'Oleg', 'OKonov'})
+
+    -- replace_object_many
+    -- fails for both: s1-master s2-master
+    -- two errors on each storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Eren', login = 'e.eger'},
+            {id = 92, name = 'Alexey', login = 'black_alex'},
+            {id = 11, name = 'Olga', login = 'OKonov'},
+            {id = 6, name = 'Anastasia', login = 'a.leonhart'},
+            {id = 4, name = 'Semen', login = 's.petrenko'},
+            {id = 9, name = 'Leo', login = 'mongend'},
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 6)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {1, 477, "Eren", "e.eger"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {4, 1161, "Semen", "s.petrenko"})
+
+    t.assert_str_contains(errs[3].err, 'Duplicate key exists')
+    t.assert_equals(errs[3].operation_data, {6, 1064, "Anastasia", "a.leonhart"})
+
+    t.assert_str_contains(errs[4].err, 'Duplicate key exists')
+    t.assert_equals(errs[4].operation_data, {9, 1644, "Leo", "mongend"})
+
+    t.assert_str_contains(errs[5].err, 'Duplicate key exists')
+    t.assert_equals(errs[5].operation_data, {11, 2652, "Olga", "OKonov"})
+
+    t.assert_str_contains(errs[6].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[6].operation_data, {92, 2040, "Alexey", "black_alex"})
+
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 4 -> bucket_id = 1161 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(4)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 6 -> bucket_id = 1064 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(6)
+    t.assert_equals(result, nil)
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_all_success_rollback_and_stop_on_error = function(g)
+    -- replace_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Fedor', 'FDost'},
+            {2, box.NULL, 'Anna', 'AnnaKar'},
+            {3, box.NULL, 'Daria', 'mongend'}
+        },
+        {
+            rollback_on_error = true,
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_object_all_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:insert({1, 477, 'Alex', 'alexpushkin'})
+    t.assert_equals(result, {1, 477, 'Alex', 'alexpushkin'})
+
+    -- replace_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'AnnaKar'},
+            {id = 3, name = 'Daria', login = 'mongend'}
+        },
+        {
+            rollback_on_error = true,
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 1, name = 'Fedor', login = 'FDost', bucket_id = 477},
+        {id = 2, name = 'Anna', login = 'AnnaKar', bucket_id = 401},
+        {id = 3, name = 'Daria', login = 'mongend', bucket_id = 2804},
+    })
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 'FDost'})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 'AnnaKar'})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 'mongend'})
+end
+
+pgroup.test_partial_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Anna', 'a.leonhart'})
+    t.assert_equals(result, {3, 2804, 'Anna', 'a.leonhart'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({71, 1802, 'Oleg', 'OKonov'})
+    t.assert_equals(result, {71, 1802, 'Oleg', 'OKonov'})
+
+    -- replace_many
+    -- stop_on_error = true, rollback_on_error = true
+    -- two error on one storage with rollback, inserts stop by error on this storage
+    -- inserts before error are rollbacked
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {22, box.NULL, 'Alex', 'alexpushkin'},
+            {92, box.NULL, 'Artur', 'AGolden'},
+            {11, box.NULL, 'Anastasia', 'a.leonhart'},
+            {5, box.NULL, 'Sergey', 's.petrenko'},
+            {9, box.NULL, 'Anna', 'AnnaBlack'},
+            {17, box.NULL, 'Oksana', 'OKonov'},
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {9, 1644, "Anna", "AnnaBlack"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {11, 2652, "Anastasia", "a.leonhart"})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {17, 2900, "Oksana", "OKonov"})
+
+    t.assert_str_contains(errs[4].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {92, 2040, "Artur", "AGolden"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', login = "s.petrenko", bucket_id = 1172},
+        {id = 22, name = 'Alex', login = "alexpushkin", bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 'alexpushkin'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 17 -> bucket_id = 2900 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(17)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_object_partial_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({3, 2804, 'Anna', 'a.leonhart'})
+    t.assert_equals(result, {3, 2804, 'Anna', 'a.leonhart'})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:insert({71, 1802, 'Oleg', 'OKonov'})
+    t.assert_equals(result, {71, 1802, 'Oleg', 'OKonov'})
+
+    -- replace_object_many
+    -- stop_on_error = true, rollback_on_error = true
+    -- two error on one storage with rollback, inserts stop by error on this storage
+    -- inserts before error are rollbacked
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 22, name = 'Alex', login = 'alexpushkin'},
+            {id = 92, name = 'Artur', login = 'AGolden'},
+            {id = 11, name = 'Anastasia', login = 'a.leonhart'},
+            {id = 5, name = 'Sergey', login = 's.petrenko'},
+            {id = 9, name = 'Anna', login = 'AnnaBlack'},
+            {id = 17, name = 'Oksana', login = 'OKonov'},
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {9, 1644, "Anna", "AnnaBlack"})
+
+    t.assert_str_contains(errs[2].err, 'Duplicate key exists')
+    t.assert_equals(errs[2].operation_data, {11, 2652, "Anastasia", "a.leonhart"})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {17, 2900, "Oksana", "OKonov"})
+
+    t.assert_str_contains(errs[4].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {92, 2040, "Artur", "AGolden"})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'login', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {
+        {id = 5, name = 'Sergey', login = "s.petrenko", bucket_id = 1172},
+        {id = 22, name = 'Alex', login = "alexpushkin", bucket_id = 655},
+    })
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 'alexpushkin'})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['developers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 's.petrenko'})
+
+    -- primary key = 11 -> bucket_id = 2652 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(11)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 17 -> bucket_id = 2900 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['developers']:get(17)
+    t.assert_equals(result, nil)
+end
+
+pgroup.test_partial_result = function(g)
+    -- bad fields format
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Fedor', 'FDost'},
+            {2, box.NULL, 'Anna', 'a.leonhart'},
+        },
+        {fields = {'id', 'invalid'}},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space format doesn\'t contain field named "invalid"')
+
+    -- replace_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_many', {
+        'developers',
+        {
+            {1, box.NULL, 'Fedor', 'FDost'},
+            {2, box.NULL, 'Anna', 'a.leonhart'},
+            {3, box.NULL, 'Daria', 'mongen'}
+        },
+        {fields = {'id', 'name'}},
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {{id = 1, name = 'Fedor'}, {id = 2, name = 'Anna'}, {id = 3, name = 'Daria'}})
+end
+
+pgroup.test_object_partial_result = function(g)
+    -- bad fields format
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'a.leonhart'},
+        },
+        {fields = {'id', 'invalid'}},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space format doesn\'t contain field named "invalid"')
+
+    -- replace_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.replace_object_many', {
+        'developers',
+        {
+            {id = 1, name = 'Fedor', login = 'FDost'},
+            {id = 2, name = 'Anna', login = 'a.leonhart'},
+            {id = 3, name = 'Daria', login = 'mongen'}
+        },
+        {fields = {'id', 'name'}},
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    })
+
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_items_equals(objects, {{id = 1, name = 'Fedor'}, {id = 2, name = 'Anna'}, {id = 3, name = 'Daria'}})
+end
+
+pgroup.test_opts_not_damaged = function(g)
+    -- replace_many
+    local batch_replace_opts = {timeout = 1, fields = {'name', 'login'}}
+    local new_batch_replace_opts, err = g.cluster.main_server:eval([[
+        local crud = require('crud')
+
+        local batch_replace_opts = ...
+
+        local _, err = crud.replace_many('developers', {
+            {1, box.NULL, 'Alex', "alexpushkin"}
+        }, batch_replace_opts)
+
+        return batch_replace_opts, err
+    ]], {batch_replace_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_batch_replace_opts, batch_replace_opts)
+
+    -- replace_object_many
+    local batch_replace_opts = {timeout = 1, fields = {'name', 'login'}}
+    local new_batch_replace_opts, err = g.cluster.main_server:eval([[
+        local crud = require('crud')
+
+        local batch_replace_opts = ...
+
+        local _, err = crud.replace_object_many('developers', {
+            {id = 2, name = 'Fedor', login = 'FDost'}
+        }, batch_replace_opts)
+
+        return batch_replace_opts, err
+    ]], {batch_replace_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_batch_replace_opts, batch_replace_opts)
+end

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -175,6 +175,28 @@ local simple_operation_cases = {
         },
         op = 'insert',
     },
+    insert_many = {
+        func = 'crud.insert_many',
+        args = {
+            space_name,
+            {
+                { 21, box.NULL, 'Ivan', 'Ivanov', 20, 'Moscow' },
+                { 31, box.NULL, 'Oleg', 'Petrov', 25, 'Moscow' },
+            }
+        },
+        op = 'insert_many',
+    },
+    insert_object_many = {
+        func = 'crud.insert_object_many',
+        args = {
+            space_name,
+            {
+                { id = 22, name = 'Ivan', last_name = 'Ivanov', age = 20, city = 'Moscow' },
+                { id = 32, name = 'Oleg', last_name = 'Petrov', age = 25, city = 'Moscow' },
+            }
+        },
+        op = 'insert_many',
+    },
     get = {
         func = 'crud.get',
         args = { space_name, { 12 } },
@@ -206,6 +228,28 @@ local simple_operation_cases = {
         },
         op = 'replace',
     },
+    replace_many = {
+        func = 'crud.replace_many',
+        args = {
+            space_name,
+            {
+                { 21, box.NULL, 'Peter', 'Ivanov', 40, 'Moscow' },
+                { 31, box.NULL, 'Ivan', 'Petrov', 35, 'Moscow' },
+            }
+        },
+        op = 'replace_many',
+    },
+    replace_object_many = {
+        func = 'crud.replace_object_many',
+        args = {
+            space_name,
+            {
+                { id = 22, name = 'Peter', last_name = 'Ivanov', age = 40, city = 'Moscow' },
+                { id = 32, name = 'Ivan', last_name = 'Petrov', age = 35, city = 'Moscow' },
+            }
+        },
+        op = 'replace_many',
+    },
     update = {
         prepare = function(g)
             helpers.insert_objects(g, space_name, {{
@@ -234,6 +278,28 @@ local simple_operation_cases = {
             {{'+', 'age', 1}}
         },
         op = 'upsert',
+    },
+    upsert_many = {
+        func = 'crud.upsert_many',
+        args = {
+            space_name,
+            {
+                {{ 26, box.NULL, 'Ivan', 'Ivanov', 20, 'Moscow' }, {{'+', 'age', 1}}},
+                {{ 36, box.NULL, 'Oleg', 'Petrov', 25, 'Moscow' }, {{'+', 'age', 1}}},
+            },
+        },
+        op = 'upsert_many',
+    },
+    upsert_object_many = {
+        func = 'crud.upsert_object_many',
+        args = {
+            space_name,
+            {
+                {{ id = 27, name = 'Ivan', last_name = 'Ivanov', age = 20, city = 'Moscow' }, {{'+', 'age', 1}}},
+                {{ id = 37, name = 'Oleg', last_name = 'Petrov', age = 25, city = 'Moscow' }, {{'+', 'age', 1}}},
+            },
+        },
+        op = 'upsert_many',
     },
     delete = {
         func = 'crud.delete',
@@ -277,6 +343,18 @@ local simple_operation_cases = {
         op = 'insert',
         expect_error = true,
     },
+    insert_many_error = {
+        func = 'crud.insert_many',
+        args = { space_name, {{ 'id' }} },
+        op = 'insert_many',
+        expect_error = true,
+    },
+    insert_object_many_error = {
+        func = 'crud.insert_object_many',
+        args = { space_name, {{ 'id' }} },
+        op = 'insert_many',
+        expect_error = true,
+    },
     get_error = {
         func = 'crud.get',
         args = { space_name, { 'id' } },
@@ -308,6 +386,18 @@ local simple_operation_cases = {
         op = 'replace',
         expect_error = true,
     },
+    replace_many_error = {
+        func = 'crud.replace_many',
+        args = { space_name, {{ 'id' }} },
+        op = 'replace_many',
+        expect_error = true,
+    },
+    replace_object_many_error = {
+        func = 'crud.replace_object_many',
+        args = { space_name, {{ 'id' }} },
+        op = 'replace_many',
+        expect_error = true,
+    },
     update_error = {
         func = 'crud.update',
         args = { space_name, { 'id' }, {{'+', 'age', 1}} },
@@ -324,6 +414,18 @@ local simple_operation_cases = {
         func = 'crud.upsert_object',
         args = { space_name, { 'id' }, {{'+', 'age', 1}} },
         op = 'upsert',
+        expect_error = true,
+    },
+    upsert_many_error = {
+        func = 'crud.upsert_many',
+        args = { space_name, { {{ 'id' }, {{'+', 'age', 1}}} }, },
+        op = 'upsert_many',
+        expect_error = true,
+    },
+    upsert_object_many_error = {
+        func = 'crud.upsert_object_many',
+        args = { space_name, { {{ 'id' }, {{'+', 'age', 1}}} } },
+        op = 'upsert_many',
         expect_error = true,
     },
     delete_error = {
@@ -800,8 +902,8 @@ local function validate_metrics(g, metrics)
     t.assert_type(stats_sum, 'table', '`tnt_crud_stats` summary metrics found')
 
 
-    local expected_operations = { 'insert', 'get', 'replace', 'update',
-        'upsert', 'delete', 'select', 'truncate', 'len', 'count', 'borders' }
+    local expected_operations = { 'insert', 'insert_many', 'get', 'replace', 'replace_many', 'update',
+        'upsert', 'upsert_many', 'delete', 'select', 'truncate', 'len', 'count', 'borders' }
 
     if g.params.quantiles == true then
         t.assert_items_equals(get_unique_label_values(quantile_stats, 'operation'), expected_operations,

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -119,6 +119,10 @@ local function create_new_space(g)
     end)
 end
 
+local function truncate_space_on_cluster(g)
+    helpers.truncate_space_on_cluster(g.cluster, space_name)
+end
+
 -- If there weren't any operations, space stats is {}.
 -- To compute stats diff, this helper return real stats
 -- if they're already present or default stats if
@@ -446,6 +450,8 @@ local function generate_stats(g)
         else
             t.assert_not_equals(err, nil)
         end
+
+        helpers.truncate_space_on_cluster(g.cluster, space_name)
     end
 
     -- Generate non-null select details.
@@ -559,6 +565,8 @@ for name, case in pairs(simple_operation_cases) do
 
         t.assert_equals(unchanged_before, unchanged_after, 'Other stats remained the same')
     end
+
+    pgroup.after_test(test_name, truncate_space_on_cluster)
 end
 
 

--- a/test/integration/upsert_many_test.lua
+++ b/test/integration/upsert_many_test.lua
@@ -1,0 +1,1966 @@
+local fio = require('fio')
+
+local t = require('luatest')
+
+local helpers = require('test.helper')
+
+local batching_utils = require('crud.common.batching_utils')
+
+local pgroup = t.group('upsert_many', {
+    {engine = 'memtx'},
+    {engine = 'vinyl'},
+})
+
+pgroup.before_all(function(g)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_batch_operations'),
+        use_vshard = true,
+        replicasets = helpers.get_test_replicasets(),
+        env = {
+            ['ENGINE'] = g.params.engine,
+        },
+    })
+
+    g.cluster:start()
+end)
+
+pgroup.after_all(function(g) helpers.stop_cluster(g.cluster) end)
+
+pgroup.before_each(function(g)
+    helpers.truncate_space_on_cluster(g.cluster, 'customers')
+end)
+
+pgroup.test_non_existent_space = function(g)
+    -- upsert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'non_existent_space',
+        {
+            {{1, box.NULL, 'Alex', 59}, {{'+', 'age', 1}}},
+            {{2, box.NULL, 'Anna', 23}, {{'+', 'age', 1}}},
+            {{3, box.NULL, 'Daria', 18}, {{'+', 'age', 1}}}
+        },
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+
+    -- upsert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'non_existent_space',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 1}}},
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 1}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'+', 'age', 1}}},
+        },
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+
+    -- we got 3 errors about non existent space, because it caused by flattening objects
+    t.assert_equals(#errs, 3)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+    t.assert_str_contains(errs[2].err, 'Space "non_existent_space" doesn\'t exist')
+    t.assert_str_contains(errs[3].err, 'Space "non_existent_space" doesn\'t exist')
+
+    -- upsert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'non_existent_space',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 1}}},
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 1}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'+', 'age', 1}}},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+
+    -- we got 1 error about non existent space, because stop_on_error == true
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space "non_existent_space" doesn\'t exist')
+end
+
+pgroup.test_object_bad_format = function(g)
+    -- bad format
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 12}}},
+            {{id = 2, name = 'Anna'}, {{'+', 'age', 12}}},
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 2, name = 'Anna'})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- bad format
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', '1'}}},
+            {{id = 2, name = 'Anna'}, {{'+', 'age', 12}}}
+        },
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {1, 477, "Fedor", 59})
+
+    t.assert_str_contains(errs[2].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[2].operation_data, {id = 2, name = 'Anna'})
+
+    -- bad format
+    -- two errors, default: stop_on_error == false
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 2, name = 'Anna'}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 3, name = 'Inga'}, {{'+', 'age', 12}}}
+        },
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    t.assert_str_contains(errs[1].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 2, name = 'Anna'})
+
+    t.assert_str_contains(errs[2].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[2].operation_data, {id = 3, name = 'Inga'})
+end
+
+pgroup.test_all_success = function(g)
+    -- upsert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{1, box.NULL, 'Fedor', 59}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{2, box.NULL, 'Anna', 23}, {{'+', 'age', 12}}},
+            {{3, box.NULL, 'Daria', 18}, {{'=', 'name', 'Jane'}}}
+        },
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_all_success = function(g)
+    -- upsert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 12}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'=', 'name', 'Jane'}}}
+        },
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_one_error = function(g)
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 20})
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- upsert_many
+    -- failed for s1-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{22, box.NULL, 'Alex', 34}, {{'=', 'name', 'Peter'},}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'=', 'age', 'invalid type'}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{5, box.NULL, 'Peter', 27}, {{'+', 'age', 5}}}
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 (age) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 type does not match one required by operation')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_one_error = function(g)
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 20})
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- upsert_object_many
+    -- failed for s1-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 22, name = 'Alex', age = 34}, {{'=', 'name', 'Peter'},}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'=', 'age', 'invalid type'}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 5, name = 'Peter', age = 27}, {{'+', 'age', 5}}}
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 (age) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 type does not match one required by operation')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_many_errors = function(g)
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 20})
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- upsert_many
+    -- failed for both: s1-master s2-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{22, box.NULL, 'Alex', 34}, {{'=', 'name', 'Peter'},}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'=', 'age', 'invalid type'}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{5, box.NULL, 'Peter', 27}, {{'+', 'age', '5'}}}
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 (age) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 type does not match one required by operation')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {5, 1172, 'Peter', 27})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_many_errors = function(g)
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 20})
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- upsert_object_many
+    -- failed for both: s1-master s2-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 22, name = 'Alex', age = 34}, {{'=', 'name', 'Peter'},}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'=', 'age', 'invalid type'}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 5, name = 'Peter', age = 27}, {{'+', 'age', '5'}}}
+        },
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 (age) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 type does not match one required by operation')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {5, 1172, 'Peter', 27})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_no_success = function(g)
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({22, 655, 'Roman', 30})
+    t.assert_equals(result, {22, 655, 'Roman', 30})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 20})
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- upsert_many
+    -- failed for both: s1-master s2-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{22, box.NULL, 'Alex', 34}, {{'=', 'name', 5},}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'=', 'age', 'invalid type'}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{5, box.NULL, 'Peter', 27}, {{'+', 'age', '5'}}}
+        },
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 (age) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 type does not match one required by operation')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {5, 1172, 'Peter', 27})
+
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[3].err, 'Tuple field 3 (name) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[3].err, 'Tuple field 3 type does not match one required by operation')
+    end
+    t.assert_equals(errs[3].operation_data, {22, 655, 'Alex', 34})
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Roman', 30})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+end
+
+pgroup.test_object_no_success = function(g)
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({22, 655, 'Roman', 30})
+    t.assert_equals(result, {22, 655, 'Roman', 30})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 20})
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+
+    -- upsert_object_many
+    -- failed for both: s1-master s2-master
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 22, name = 'Alex', age = 34}, {{'=', 'name', 5},}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'=', 'age', 'invalid type'}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 5, name = 'Peter', age = 27}, {{'+', 'age', '5'}}}
+        },
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 (age) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[1].err, 'Tuple field 4 type does not match one required by operation')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {5, 1172, 'Peter', 27})
+
+    if helpers.tarantool_version_at_least(2, 8) then
+        t.assert_str_contains(errs[3].err, 'Tuple field 3 (name) type does not match one required by operation')
+    else
+        t.assert_str_contains(errs[3].err, 'Tuple field 3 type does not match one required by operation')
+    end
+    t.assert_equals(errs[3].operation_data, {22, 655, 'Alex', 34})
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Roman', 30})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 20})
+end
+
+pgroup.test_object_bad_format_stop_on_error = function(g)
+    -- bad format
+    -- two errors, stop_on_error == true
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor'}, {{'+', 'age', 12}}},
+            {{id = 2, name = 'Anna'}, {{'+', 'age', 12}}}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Field \"age\" isn\'t nullable')
+    t.assert_equals(errs[1].operation_data, {id = 1, name = 'Fedor'})
+end
+
+pgroup.test_all_success_stop_on_error = function(g)
+    -- upsert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{1, box.NULL, 'Fedor', 59}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{2, box.NULL, 'Anna', 23}, {{'+', 'age', 12}}},
+            {{3, box.NULL, 'Daria', 18}, {{'=', 'name', 'Jane'}}}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_all_success_stop_on_error = function(g)
+    -- upsert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 12}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'=', 'name', 'Jane'}}}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_partial_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- upsert_object_many
+    -- stop_on_error = true, rollback_on_error = false
+    -- one error on one storage without rollback, inserts stop by error on this storage
+    -- inserts before error are successful
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 22, name = 'Alex', age = 34}, {{'+', 'age', 1}}},
+            {{id = 92, name = 'Artur', age = 29}, {{'+', 'age', 2}}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'+', 'age', '3'}}},
+            {{id = 5, name = 'Sergey', age = 25}, {{'+', 'age', 4}}},
+            {{id = 9, name = 'Anna', age = 30}, {{'+', 'age', '5'}}}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_partial_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- upsert_many
+    -- stop_on_error = true, rollback_on_error = false
+    -- one error on one storage without rollback, inserts stop by error on this storage
+    -- inserts before error are successful
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{22, box.NULL, 'Alex', 34}, {{'+', 'age', 1}}},
+            {{92, box.NULL, 'Artur', 29}, {{'+', 'age', 2}}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'+', 'age', '3'}}},
+            {{5, box.NULL, 'Sergey', 25}, {{'+', 'age', 4}}},
+            {{9, box.NULL, 'Anna', 30}, {{'+', 'age', '5'}}}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(#errs, 2)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_no_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({92, 2040, 'Artur', 29})
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- upsert_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, all inserts stop by error
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{2, box.NULL, 'Alex', 34}, {{'+', 'age', '1'}}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'+', 'age', '2'}}},
+            {{10, box.NULL, 'Sergey', 25}, {{'+', 'age', 3}}},
+            {{9, box.NULL, 'Anna', 30}, {{'+', 'age', '4'}}},
+            {{92, box.NULL, 'Leo', 29}, {{'+', 'age', 5}}}
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 5)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[4].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {10, 569, "Sergey", 25})
+
+    t.assert_str_contains(errs[5].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[5].operation_data, {92, 2040, "Leo", 29})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_object_no_success_stop_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({92, 2040, 'Artur', 29})
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+
+    -- upsert_object_many
+    -- fails for both: s1-master s2-master
+    -- one error on each storage, all inserts stop by error
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 2, name = 'Alex', age = 34}, {{'+', 'age', '1'}}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'+', 'age', '2'}}},
+            {{id = 10, name = 'Sergey', age = 25}, {{'+', 'age', 3}}},
+            {{id = 9, name = 'Anna', age = 30}, {{'+', 'age', '4'}}},
+            {{id = 92, name = 'Leo', age = 29}, {{'+', 'age', 5}}},
+        },
+        {
+            stop_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 5)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {2, 401, 'Alex', 34})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[4].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {10, 569, "Sergey", 25})
+
+    t.assert_str_contains(errs[5].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[5].operation_data, {92, 2040, "Leo", 29})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 10 -> bucket_id = 569 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(10)
+    t.assert_equals(result, nil)
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, {92, 2040, 'Artur', 29})
+end
+
+pgroup.test_all_success_rollback_on_error = function(g)
+    -- upsert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{1, box.NULL, 'Fedor', 59}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{2, box.NULL, 'Anna', 23}, {{'+', 'age', 12}}},
+            {{3, box.NULL, 'Daria', 18}, {{'=', 'name', 'Jane'}}}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_all_success_rollback_on_error = function(g)
+    -- upsert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 25}, {'=', 'name', 'Leo Tolstoy'},}},
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 12}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'=', 'name', 'Jane'}}}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, {1, 477, 'Fedor', 59})
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+end
+
+pgroup.test_object_partial_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({22, 655, 'Alex', 34})
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- upsert_object_many
+    -- stop_on_error = false, rollback_on_error = true
+    -- two error on one storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 22, name = 'Alex', age = 34}, {{'+', 'age', 1}}},
+            {{id = 92, name = 'Artur', age = 29}, {{'+', 'age', 2}}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'+', 'age', '3'}}},
+            {{id = 5, name = 'Sergey', age = 25}, {{'+', 'age', 4}}},
+            {{id = 9, name = 'Anna', age = 30}, {{'+', 'age', '5'}}}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {9, 1644, 'Anna', 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 35})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_partial_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({22, 655, 'Alex', 34})
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({9, 1644, 'Nicolo', 35})
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+
+    -- upsert_many
+    -- stop_on_error = false, rollback_on_error = true
+    -- two error on one storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{22, box.NULL, 'Peter', 24}, {{'+', 'age', 1}}},
+            {{92, box.NULL, 'Artur', 29}, {{'+', 'age', 2}}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'+', 'age', '3'}}},
+            {{5, box.NULL, 'Sergey', 25}, {{'+', 'age', 4}}},
+            {{9, box.NULL, 'Anna', 30}, {{'+', 'age', '5'}}}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 3)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {9, 1644, 'Anna', 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 35})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, {9, 1644, 'Nicolo', 35})
+end
+
+pgroup.test_no_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 25})
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- upsert_many
+    -- fails for both: s1-master s2-master
+    -- two errors on each storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{1, box.NULL, 'Olga', 27}, {{'+', 'age', 1}}},
+            {{92, box.NULL, 'Oleg', 32}, {{'+', 'age', 2}}},
+            {{71, box.NULL, 'Sergey', 25}, {{'+', 'age', '3'}}},
+            {{5, box.NULL, 'Anna', 30}, {{'+', 'age', '4'}}},
+            {{2, box.NULL, 'Alex', 34}, {{'+', 'age', '5'}}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'+', 'age', '6'}}}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 6)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {1, 477, "Olga", 27})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {2, 401, 'Alex', 34})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[3].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[3].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[3].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[4].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[4].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[4].operation_data, {5, 1172, "Anna", 30})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[5].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[5].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[5].operation_data, {71, 1802, "Sergey", 25})
+
+    t.assert_str_contains(errs[6].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[6].operation_data, {92, 2040, "Oleg", 32})
+
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_no_success_rollback_on_error = function(g)
+    -- insert
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({2, 401, 'Anna', 23})
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:insert({5, 1172, 'Sergey', 25})
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- upsert_object_many
+    -- fails for both: s1-master s2-master
+    -- two errors on each storage with rollback
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Olga', age = 27}, {{'+', 'age', 1}}},
+            {{id = 92, name = 'Oleg', age = 32}, {{'+', 'age', 2}}},
+            {{id = 71, name = 'Sergey', age = 25}, {{'+', 'age', '3'}}},
+            {{id = 5, name = 'Anna', age = 30}, {{'+', 'age', '4'}}},
+            {{id = 2, name = 'Alex', age = 34}, {{'+', 'age', '5'}}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'+', 'age', '6'}}}
+        },
+        {
+            rollback_on_error = true,
+        }
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 6)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    t.assert_str_contains(errs[1].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[1].operation_data, {1, 477, "Olga", 27})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[2].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[2].operation_data, {2, 401, 'Alex', 34})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[3].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[3].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[3].operation_data, {3, 2804, 'Anastasia', 22})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[4].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[4].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[4].operation_data, {5, 1172, "Anna", 30})
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[5].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[5].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[5].operation_data, {71, 1802, "Sergey", 25})
+
+    t.assert_str_contains(errs[6].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[6].operation_data, {92, 2040, "Oleg", 32})
+
+    -- primary key = 1 -> bucket_id = 477 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(1)
+    t.assert_equals(result, nil)
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_all_success_rollback_and_stop_on_error = function(g)
+    -- upsert_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{2, box.NULL, 'Anna', 23}, {{'+', 'age', 1}}},
+            {{3, box.NULL, 'Daria', 18}, {{'+', 'age', 1}}},
+            {{71, box.NULL, 'Oleg', 32}, {{'+', 'age', 1}}}
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_all_success_rollback_and_stop_on_error = function(g)
+    -- upsert_object_many
+    -- all success
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 1}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'+', 'age', 1}}},
+            {{id = 71, name = 'Oleg', age = 32}, {{'+', 'age', 1}}}
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 2 -> bucket_id = 401 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(2)
+    t.assert_equals(result, {2, 401, 'Anna', 23})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_partial_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- upsert_many
+    -- stop_on_error = true, rollback_on_error = true
+    -- two error on one storage with rollback, inserts stop by error on this storage
+    -- inserts before error are rollbacked
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{22, box.NULL, 'Alex', 34}, {{'+', 'age', 1}}},
+            {{92, box.NULL, 'Artur', 29}, {{'+', 'age', 2}}},
+            {{3, box.NULL, 'Anastasia', 22}, {{'+', 'age', '3'}}},
+            {{5, box.NULL, 'Sergey', 25}, {{'+', 'age', 4}}},
+            {{9, box.NULL, 'Anna', 30}, {{'+', 'age', 5}}},
+            {{71, box.NULL, 'Oksana', 29}, {{'+', 'age', '6'}}},
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {71, 1802, "Oksana", 29})
+
+    t.assert_str_contains(errs[4].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_object_partial_success_rollback_and_stop_on_error = function(g)
+    -- insert
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({3, 2804, 'Daria', 18})
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:insert({71, 1802, 'Oleg', 32})
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+
+    -- upsert_object_many
+    -- stop_on_error = true, rollback_on_error = true
+    -- two error on one storage with rollback, inserts stop by error on this storage
+    -- inserts before error are rollbacked
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 22, name = 'Alex', age = 34}, {{'+', 'age', 1}}},
+            {{id = 92, name = 'Artur', age = 29}, {{'+', 'age', 2}}},
+            {{id = 3, name = 'Anastasia', age = 22}, {{'+', 'age', '3'}}},
+            {{id = 5, name = 'Sergey', age = 25}, {{'+', 'age', 4}}},
+            {{id = 9, name = 'Anna', age = 30}, {{'+', 'age', 5}}},
+            {{id = 71, name = 'Oksana', age = 29}, {{'+', 'age', '6'}}},
+        },
+        {
+            stop_on_error = true,
+            rollback_on_error  = true,
+        }
+    })
+
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 4)
+
+    table.sort(errs, function(err1, err2) return err1.operation_data[1] < err2.operation_data[1] end)
+
+    if helpers.tarantool_version_at_least(2, 3) then
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field \'age\' does not match field type')
+    else
+        t.assert_str_contains(errs[1].err,
+                'Argument type in operation \'+\' on field 4 does not match field type')
+    end
+    t.assert_equals(errs[1].operation_data, {3, 2804, 'Anastasia', 22})
+
+    t.assert_str_contains(errs[2].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[2].operation_data, {9, 1644, "Anna", 30})
+
+    t.assert_str_contains(errs[3].err, batching_utils.stop_on_error_msg)
+    t.assert_equals(errs[3].operation_data, {71, 1802, "Oksana", 29})
+
+    t.assert_str_contains(errs[4].err, batching_utils.rollback_on_error_msg)
+    t.assert_equals(errs[4].operation_data, {92, 2040, "Artur", 29})
+
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    t.assert_equals(result.rows, nil)
+
+    -- get
+    -- primary key = 22 -> bucket_id = 655 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(22)
+    t.assert_equals(result, {22, 655, 'Alex', 34})
+
+    -- primary key = 92 -> bucket_id = 2040 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(92)
+    t.assert_equals(result, nil)
+
+    -- primary key = 5 -> bucket_id = 1172 -> s2-master
+    local conn_s2 = g.cluster:server('s2-master').net_box
+    local result = conn_s2.space['customers']:get(5)
+    t.assert_equals(result, {5, 1172, 'Sergey', 25})
+
+    -- primary key = 3 -> bucket_id = 2804 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(3)
+    t.assert_equals(result, {3, 2804, 'Daria', 18})
+
+    -- primary key = 9 -> bucket_id = 1644 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(9)
+    t.assert_equals(result, nil)
+
+    -- primary key = 71 -> bucket_id = 1802 -> s1-master
+    local conn_s1 = g.cluster:server('s1-master').net_box
+    local result = conn_s1.space['customers']:get(71)
+    t.assert_equals(result, {71, 1802, 'Oleg', 32})
+end
+
+pgroup.test_partial_result = function(g)
+    -- bad fields format
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{15, box.NULL, 'Fedor', 59}, {{'+', 'age', 1}}},
+            {{25, box.NULL, 'Anna', 23}, {{'+', 'age', 1}}},
+        },
+        {fields = {'id', 'invalid'}},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space format doesn\'t contain field named "invalid"')
+
+    -- upsert_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_many', {
+        'customers',
+        {
+            {{1, box.NULL, 'Fedor', 59}, {{'+', 'age', 1}}},
+            {{2, box.NULL, 'Anna', 23}, {{'+', 'age', 1}}},
+            {{3, box.NULL, 'Daria', 18}, {{'+', 'age', 1}}},
+        },
+        {fields = {'id', 'name'}},
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    })
+    t.assert_equals(result.rows, nil)
+end
+
+pgroup.test_object_partial_result = function(g)
+    -- bad fields format
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 15, name = 'Fedor', age = 59}, {{'+', 'age', 1}}},
+            {{id = 25, name = 'Anna', age = 23}, {{'+', 'age', 1}}},
+        },
+        {fields = {'id', 'invalid'}},
+    })
+
+    t.assert_equals(result, nil)
+    t.assert_not_equals(errs, nil)
+    t.assert_equals(#errs, 1)
+    t.assert_str_contains(errs[1].err, 'Space format doesn\'t contain field named "invalid"')
+
+    -- upsert_object_many
+    local result, errs = g.cluster.main_server.net_box:call('crud.upsert_object_many', {
+        'customers',
+        {
+            {{id = 1, name = 'Fedor', age = 59}, {{'+', 'age', 1}}},
+            {{id = 2, name = 'Anna', age = 23}, {{'+', 'age', 1}}},
+            {{id = 3, name = 'Daria', age = 18}, {{'+', 'age', 1}}},
+        },
+        {fields = {'id', 'name'}},
+    })
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    })
+    t.assert_equals(result.rows, nil)
+end
+
+pgroup.test_opts_not_damaged = function(g)
+    -- upsert_many
+    local batch_upsert_opts = {timeout = 1, fields = {'name', 'age'}}
+    local new_batch_upsert_opts, err = g.cluster.main_server:eval([[
+        local crud = require('crud')
+
+        local batch_upsert_opts = ...
+
+        local _, err = crud.upsert_many('customers', {
+            {{1, box.NULL, 'Alex', 59}, {{'+', 'age', 1}},}
+        }, batch_upsert_opts)
+
+        return batch_upsert_opts, err
+    ]], {batch_upsert_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_batch_upsert_opts, batch_upsert_opts)
+
+    -- upsert_object_many
+    local batch_upsert_opts = {timeout = 1, fields = {'name', 'age'}}
+    local new_batch_upsert_opts, err = g.cluster.main_server:eval([[
+        local crud = require('crud')
+
+        local batch_upsert_opts = ...
+
+        local _, err = crud.upsert_object_many('customers', {
+            {{id = 2, name = 'Fedor', age = 59}, {{'+', 'age', 1}},}
+        }, batch_upsert_opts)
+
+        return batch_upsert_opts, err
+    ]], {batch_upsert_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_batch_upsert_opts, batch_upsert_opts)
+end


### PR DESCRIPTION
Right now CRUD cannot provide batch insert/upsert/replace with full consistency.
CRUD offers batch insert/upsert with partial consistency. That means
that full consistency can be provided only on single replicaset
using `box` transactions.

Proposed API is the following:

```lua
-- Batch insert tuples
local result, err = crud.insert_many(space_name, tuples, opts)
-- Batch insert objects
local result, err = crud.insert_object_many(space_name, objects, opts)
-- Batch upsert tuples
local result, err = crud.upsert_many(space_name, tuples, operations, opts)
-- Batch upsert objects
local result, err = crud.upsert_object_many(space_name, objects, operations, opts)
-- Batch replace tuples
local result, err = crud.replace_many(space_name, tuples, opts)
-- Batch replace objects
local result, err = crud.replace_object_many(space_name, objects, opts)
```

For `insert_many`/`insert_object_many`:

Returns metadata and array contains inserted rows, array of errors (
one error corresponds to one replicaset for which the error occurred).
Error object can contain `tuple` field. This field contains the tuple
for which the error occurred.

For `upsert_many`/`upsert_object_many`:

Returns metadata and array of empty arrays, array of errors (
one error corresponds to one replicaset for which the error occurred).
Error object can contain `tuple` field. This field contains the tuple
for which the error occurred.

For `replace_many`/`replace_object_many`:

Returns metadata and array contains inserted/replaced rows, array of errors (
one error corresponds to one replicaset for which the error occurred).
Error object can contain `tuple` field. This field contains the tuple
for which the error occurred.

Perf test run on **MacBook Pro (2017) i7/16Gb/512SSD**
According to results as the number of inserted tuples increases
the average call time grows faster for `insert()` then
for `batch_insert()`. For example with batch size == 10000 tuples
`insert()` is ~26 times slower then `batch_insert()`.

==== BATCH COMPARISON PERFORMANCE REPORT ====


== SUCCESS REQUESTS ==
(The higher the better)

|                                   |            1 |           10 |          100 |         1000 |        10000 |
| --------------------------------- | ------------ | ------------ | ------------ | ------------ | ------------ |
|                            insert |        68892 |        11171 |         1205 |          120 |           13 |
|                      batch_insert |        76141 |        46159 |        16627 |         2276 |          317 |



== SUCCESS REQUESTS PER SECOND ==
(The higher the better)

|                                   |            1 |           10 |          100 |         1000 |        10000 |
| --------------------------------- | ------------ | ------------ | ------------ | ------------ | ------------ |
|                            insert |      2296.39 |       372.33 |        40.15 |         4.00 |         0.40 |
|                      batch_insert |      2538.01 |      1538.62 |       554.22 |        75.84 |        10.56 |



== ERRORS ==
(Bad if higher than zero)

|                                   |            1 |           10 |          100 |         1000 |        10000 |
| --------------------------------- | ------------ | ------------ | ------------ | ------------ | ------------ |
|                            insert |            0 |            0 |            0 |            0 |            0 |
|                      batch_insert |            0 |            0 |            0 |            0 |            0 |



== AVERAGE CALL TIME ==
(The lower the better)

|                                   |            1 |           10 |          100 |         1000 |        10000 |
| --------------------------------- | ------------ | ------------ | ------------ | ------------ | ------------ |
|                            insert |     0.434 ms |     2.684 ms |    24.907 ms |   250.079 ms |  2484.446 ms |
|                      batch_insert |     0.393 ms |     0.649 ms |     1.803 ms |    13.183 ms |    94.658 ms |



== MAX CALL TIME ==
(The lower the better)

|                                   |            1 |           10 |          100 |         1000 |        10000 |
| --------------------------------- | ------------ | ------------ | ------------ | ------------ | ------------ |
|                            insert |    10.472 ms |     8.554 ms |    49.886 ms |   294.954 ms |  2540.472 ms |
|                      batch_insert |    10.572 ms |     5.614 ms |    10.994 ms |    31.748 ms |   130.214 ms |



"insert" was planned for 30 seconds with 1 connections and 1 fibers total.
"batch_insert" was planned for 30 seconds with 1 connections and 1 fibers total.

<img width="438" alt="image" src="https://user-images.githubusercontent.com/63649739/162741902-9b3f23b1-79bb-4bc9-9fc4-b375233a6439.png">

Closes #193 
