### PR TITLE
Extract sharding key from conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Use tuple-merger backed select implementation on tarantool 2.10+ (it gives
   less pressure on Lua GC).
+* DDL sharding key now can be extracted from select conditions even if
+  there are no separate index.
 
 ## [0.9.0] - 20-10-21
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ Current limitations for using custom sharding key:
   updated on storages, see
   [#212](https://github.com/tarantool/crud/issues/212). However it is possible
   to do it manually with `require('crud.sharding_key').update_cache()`.
-- CRUD select may lead map reduce in some cases, see
-  [#213](https://github.com/tarantool/crud/issues/213).
 - No support of JSON path for sharding key, see
   [#219](https://github.com/tarantool/crud/issues/219).
 - `primary_index_fieldno_map` is not cached, see

--- a/test/entrypoint/srv_ddl.lua
+++ b/test/entrypoint/srv_ddl.lua
@@ -61,6 +61,14 @@ package.preload['customers-storage'] = function()
                     {path = 'name', is_nullable = false, type = 'string'},
                 },
             }
+            local age_index = {
+                name = 'age',
+                type = 'TREE',
+                unique = false,
+                parts = {
+                    {path = 'age', is_nullable = false, type = 'number'},
+                },
+            }
             local secondary_index = {
                 name = 'secondary',
                 type = 'TREE',
@@ -68,6 +76,17 @@ package.preload['customers-storage'] = function()
                 parts = {
                     {path = 'id', is_nullable = false, type = 'unsigned'},
                     {path = 'name', is_nullable = false, type = 'string'},
+                },
+            }
+
+            local three_fields_index = {
+                name = 'three_fields',
+                type = 'TREE',
+                unique = false,
+                parts = {
+                    {path = 'age', is_nullable = false, type = 'number'},
+                    {path = 'name', is_nullable = false, type = 'string'},
+                    {path = 'id', is_nullable = false, type = 'unsigned'},
                 },
             }
 
@@ -100,6 +119,18 @@ package.preload['customers-storage'] = function()
             table.insert(customers_age_key_schema.indexes, primary_index)
             table.insert(customers_age_key_schema.indexes, bucket_id_index)
 
+            local customers_name_age_key_different_indexes_schema = table.deepcopy(customers_schema)
+            customers_name_age_key_different_indexes_schema.sharding_key = {'name', 'age'}
+            table.insert(customers_name_age_key_different_indexes_schema.indexes, primary_index)
+            table.insert(customers_name_age_key_different_indexes_schema.indexes, bucket_id_index)
+            table.insert(customers_name_age_key_different_indexes_schema.indexes, age_index)
+
+            local customers_name_age_key_three_fields_index_schema = table.deepcopy(customers_schema)
+            customers_name_age_key_three_fields_index_schema.sharding_key = {'name', 'age'}
+            table.insert(customers_name_age_key_three_fields_index_schema.indexes, primary_index_id)
+            table.insert(customers_name_age_key_three_fields_index_schema.indexes, bucket_id_index)
+            table.insert(customers_name_age_key_three_fields_index_schema.indexes, three_fields_index)
+
             local schema = {
                 spaces = {
                     customers_name_key = customers_name_key_schema,
@@ -107,6 +138,8 @@ package.preload['customers-storage'] = function()
                     customers_name_key_non_uniq_index = customers_name_key_non_uniq_index_schema,
                     customers_secondary_idx_name_key = customers_secondary_idx_name_key_schema,
                     customers_age_key = customers_age_key_schema,
+                    customers_name_age_key_different_indexes = customers_name_age_key_different_indexes_schema,
+                    customers_name_age_key_three_fields_index = customers_name_age_key_three_fields_index_schema,
                 }
             }
 

--- a/test/helpers/storage_stat.lua
+++ b/test/helpers/storage_stat.lua
@@ -95,4 +95,16 @@ function storage_stat.diff(a, b)
     return diff
 end
 
+-- Accepts collect (or diff) return value and returns
+-- total number of select requests across all storages.
+function storage_stat.total(stats)
+    local total = 0
+
+    for _, stat in pairs(stats) do
+        total = total + (stat.select_requests or 0)
+    end
+
+    return total
+end
+
 return storage_stat


### PR DESCRIPTION
PR #181 introduced support of DDL sharding keys. But if sharding key hasn't got a separate index in schema, select with equal conditions for all required sharding key fields still led to map-reduce instead of a single storage call. This patch introduces impoved support of sharding keys extraction and fixes the issue.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #213
