### PR TITLE
Add performance tests to compare crud and vshard

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -476,4 +476,8 @@ function helpers.get_map_reduces_stat(router, space_name)
     ]], { space_name })
 end
 
+function helpers.disable_dev_checks()
+    os.setenv('DEV', 'OFF')
+end
+
 return helpers


### PR DESCRIPTION
This patch adds new cases for performance tests: select for equal
conditions for primary and secondary indexes (including known bucket_id
case from #220), and adds corresponding vshard test cases to compare
performance. Comparison may be not exactly precise since vshard test
functions use naive mergers, but should at least estimate basic
differences.

Test run on HP ProBook 440 G7 i7/16Gb/256SSD shows that CRUD module is
3-6 times slower than vshard calls for prepared functions for select and
1.6 times slower for insert.

### HP ProBook 440 G7 i7/16Gb/256SSD

#### SUCCESS REQUESTS PER SECOND
(The higher the better)

|                                   |       vshard | crud (stats disabled) | crud (stats disabled, known bucket_id) |
| --------------------------------- | ------------ | --------------------- | -------------------------------------- |
|                      select by pk |     81824.72 |              23936.52 |                               23992.12 |
|        select gt by pk (limit 10) |     15201.35 |               4305.91 |                                        |
| select eq by secondary (limit 10) |     14783.89 |               4835.79 |                                        |
|   select eq by sharding secondary |     79791.30 |              13689.91 |                               18376.29 |
|                            insert |     84113.60 |              51847.18 |                                        |


#### AVERAGE CALL TIME
(The lower the better)

|                                   |       vshard | crud (stats disabled) | crud (stats disabled, known bucket_id) |
| --------------------------------- | ------------ | --------------------- | -------------------------------------- |
|                      select by pk |     2.444 ms |              8.355 ms |                               8.335 ms |
|        select gt by pk (limit 10) |    13.156 ms |             46.446 ms |                                        |
| select eq by secondary (limit 10) |    13.528 ms |             41.357 ms |                                        |
|   select eq by sharding secondary |     2.506 ms |             14.604 ms |                              10.881 ms |
|                            insert |     7.132 ms |             11.571 ms |                                        |


#### MAX CALL TIME
(The lower the better)

|                                   |       vshard | crud (stats disabled) | crud (stats disabled, known bucket_id) |
| --------------------------------- | ------------ | --------------------- | -------------------------------------- |
|                      select by pk |    17.277 ms |             37.793 ms |                              36.457 ms |
|        select gt by pk (limit 10) |    41.015 ms |            103.195 ms |                                        |
| select eq by secondary (limit 10) |    43.169 ms |             98.459 ms |                                        |
|   select eq by sharding secondary |    15.934 ms |             71.610 ms |                              58.771 ms |
|                            insert |    66.039 ms |             72.328 ms |                                        |


### CI Runner

See https://github.com/tarantool/crud/runs/5421561722?check_suite_focus=true

Several minor fixes also was introduced.

Fix replicaset alias in test cluster. Disable checks for perf tests.
Return tuples from pairs perf case.

Fix running separate tests. After this patch, developer can run luatest
with -p flag for perf tests to get results only for requested tests.
Example:
```bash
PERF_MODE_ON=true ./.rocks/bin/luatest -c -p perf.test_crud_pairs_gt_with_stats_disabled
```

- [x] Tests
- Changelog (I don't think it should bother users)
- Documentation (There's nothing to document)

Closes #225
