### PR TITLE
Optimize select with known bucket_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Integrate CRUD statistics with [`metrics`](https://github.com/tarantool/metrics) (#224).
 
 ### Changed
+* Optimize select with known bucket_id (#234).
 
 ### Fixed
 

--- a/crud/compare/plan.lua
+++ b/crud/compare/plan.lua
@@ -168,6 +168,7 @@ function plan.new(space, conditions, opts)
         field_names = '?table',
         force_map_call = '?boolean',
         sharding_key_as_index_obj = '?table',
+        bucket_id = '?number|cdata',
     })
 
     conditions = conditions ~= nil and conditions or {}
@@ -274,14 +275,16 @@ function plan.new(space, conditions, opts)
         end
     end
 
-    local sharding_index = opts.sharding_key_as_index_obj or primary_index
+    local sharding_key = nil
+    if opts.bucket_id == nil then
+        local sharding_index = opts.sharding_key_as_index_obj or primary_index
 
-    -- get sharding key value
-    local sharding_key = get_sharding_key_from_scan_value(scan_value, scan_index, scan_iter, sharding_index)
+        sharding_key = get_sharding_key_from_scan_value(scan_value, scan_index, scan_iter, sharding_index)
 
-    if sharding_key == nil then
-        sharding_key = extract_sharding_key_from_conditions(conditions, sharding_index,
-                                                            space_indexes, fieldno_map)
+        if sharding_key == nil then
+            sharding_key = extract_sharding_key_from_conditions(conditions, sharding_index,
+                                                                space_indexes, fieldno_map)
+        end
     end
 
     local plan = {

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -52,9 +52,14 @@ local function build_select_iterator(space_name, user_conditions, opts)
         return nil, SelectError:new("Space %q doesn't exist", space_name), true
     end
     local space_format = space:format()
-    local sharding_key_as_index_obj, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
-    if err ~= nil then
-        return nil, err
+
+    local sharding_key_as_index_obj = nil
+    -- We don't need sharding info if bucket_id specified.
+    if opts.bucket_id == nil then
+        sharding_key_as_index_obj, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        if err ~= nil then
+            return nil, err
+        end
     end
 
     -- plan select
@@ -63,6 +68,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
         after_tuple = opts.after,
         field_names = opts.field_names,
         sharding_key_as_index_obj = sharding_key_as_index_obj,
+        bucket_id = opts.bucket_id,
     })
 
     if err ~= nil then

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -112,9 +112,14 @@ local function build_select_iterator(space_name, user_conditions, opts)
         return nil, SelectError:new("Space %q doesn't exist", space_name), true
     end
     local space_format = space:format()
-    local sharding_key_as_index_obj, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
-    if err ~= nil then
-        return nil, err
+
+    local sharding_key_as_index_obj = nil
+    -- We don't need sharding info if bucket_id specified.
+    if opts.bucket_id == nil then
+        sharding_key_as_index_obj, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        if err ~= nil then
+            return nil, err
+        end
     end
 
     -- plan select
@@ -124,6 +129,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
         field_names = opts.field_names,
         force_map_call = opts.force_map_call,
         sharding_key_as_index_obj = sharding_key_as_index_obj,
+        bucket_id = opts.bucket_id,
     })
 
     if err ~= nil then


### PR DESCRIPTION
Merge after #251.

After this patch, select and pairs requests will no longer fetch
sharding key info and extract sharding key info if bucket_id specified.
Since calls with specified bucket_id already ignore sharding key
values, behavior will not change. Other crud operations already have
this optimization.

Based on test runs on HP ProBook 440 G7 i7/16Gb, performance had
increased by 6-7%.

I didn't forget about

- Tests (see #251)
- [x] Changelog
- Documentation (don't think there is something to describe)

Part of #234
