### PR TITLE
readme: fix update_cache() recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Current limitations for using custom sharding key:
 - It's not possible to update sharding keys automatically when schema is
   updated on storages, see
   [#212](https://github.com/tarantool/crud/issues/212). However it is possible
-  to do it manually with `require('crud.sharding_key').update_cache()`.
+  to do it manually with `require('crud.common.sharding_key').update_cache()`.
 - No support of JSON path for sharding key, see
   [#219](https://github.com/tarantool/crud/issues/219).
 - `primary_index_fieldno_map` is not cached, see


### PR DESCRIPTION
When a sharding key is updated on storages a user should call this
function on routers to re-fetch the new sharding keys. I would highlight
that even if we add a space that was never seen before, we should call
the function on routers. Otherwise crud will assume that the new space
has the sharding key equal to the primary key and will calculate
`bucket_id` incorrectly.

Follows up #166
Related to #212
Related to TNT-462