### PR TITLE
Fix fail of select when there are no indexes in space

### DIFF
--- a/crud/select/plan.lua
+++ b/crud/select/plan.lua
@@ -16,6 +16,7 @@ local select_plan = {}
 
 local IndexTypeError = errors.new_class('IndexTypeError', {capture_stack = false})
 local FilterFieldsError = errors.new_class('FilterFieldsError', {capture_stack = false})
+local NoIndexesError = errors.new_class('NoIndexesError', {capture_stack = false})
 
 local function index_is_allowed(index)
     return index.type == 'TREE'
@@ -172,6 +173,10 @@ function select_plan.new(space, conditions, opts)
     local space_name = space.name
     local space_indexes = space.index
     local space_format = space:format()
+
+    if space_indexes == nil or next(space_indexes) == nil then
+        return nil, NoIndexesError:new('Space %q has no indexes, space should have primary index', space_name)
+    end
 
     if conditions == nil then -- also cdata<NULL>
         conditions = {}

--- a/test/entrypoint/srv_select.lua
+++ b/test/entrypoint/srv_select.lua
@@ -13,6 +13,16 @@ package.preload['customers-storage'] = function()
     return {
         role_name = 'customers-storage',
         init = function()
+            box.schema.space.create('no_index_space', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                    {name = 'bucket_id', type = 'unsigned'},
+                    {name = 'name', type = 'string'},
+                },
+                if_not_exists = true,
+                engine = engine,
+            })
+
             local customers_space = box.schema.space.create('customers', {
                 format = {
                     {name = 'id', type = 'unsigned'},

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -55,6 +55,15 @@ pgroup.test_non_existent_space = function(g)
     t.assert_str_contains(err.err, "Space \"non_existent_space\" doesn't exist")
 end
 
+pgroup.test_select_no_index = function(g)
+    local obj, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'no_index_space'}
+    )
+
+    t.assert_equals(obj, nil)
+    t.assert_str_contains(err.err, "Space \"no_index_space\" has no indexes, space should have primary index")
+end
+
 pgroup.test_not_valid_value_type = function(g)
     local conditions = {
         {'=', 'id', 'not_number'}


### PR DESCRIPTION
This fix checks if space contains indexes and if there are
no indexes in space `select` returns error
`NoIndexesError:new('Space %q has no indexes, space should have primary index', space_name)`.

Closes #257
