### PR TITLE
Add check for incorrect call mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,21 @@ crud.len('customers')
 ...
 ```
 
+### Call options for crud methods
+
+Combinations of `mode`, `prefer_replica` and `balance` options lead to:
+
+* `mode` == `write` - method performed on master with vshard call `callrw`
+* `mode` == `read`
+  * not prefer_replica, not balance -
+    [vshard call `callro`](https://www.tarantool.io/en/doc/latest/reference/reference_rock/vshard/vshard_api/#router-api-callro)
+  * not prefer_replica, balance -
+    [vshard call `callbro`](https://www.tarantool.io/en/doc/latest/reference/reference_rock/vshard/vshard_api/#router-api-callbro)
+  * prefer_replica, not balance -
+    [vshard call `callre`](https://www.tarantool.io/en/doc/latest/reference/reference_rock/vshard/vshard_api/#router-api-callre)
+  * prefer_replica, balance -
+    [vshard call `callbre`](https://www.tarantool.io/en/doc/latest/reference/reference_rock/vshard/vshard_api/#router-api-callbre)
+
 ## Cartridge roles
 
 `cartridge.roles.crud-storage` is a Tarantool Cartridge role that depends on the

--- a/crud/common/call.lua
+++ b/crud/common/call.lua
@@ -15,6 +15,10 @@ call.DEFAULT_VSHARD_CALL_TIMEOUT = 2
 function call.get_vshard_call_name(mode, prefer_replica, balance)
     dev_checks('string', '?boolean', '?boolean')
 
+    if mode ~= 'write' and mode ~= 'read' then
+        return nil, CallError:new("Unknown call mode: %s", mode)
+    end
+
     if mode == 'write' then
         return 'callrw'
     end
@@ -74,7 +78,10 @@ function call.map(func_name, func_args, opts)
     })
     opts = opts or {}
 
-    local vshard_call_name = call.get_vshard_call_name(opts.mode, opts.prefer_replica, opts.balance)
+    local vshard_call_name, err = call.get_vshard_call_name(opts.mode, opts.prefer_replica, opts.balance)
+    if err ~= nil then
+        return nil, err
+    end
 
     local timeout = opts.timeout or call.DEFAULT_VSHARD_CALL_TIMEOUT
 
@@ -126,7 +133,10 @@ function call.single(bucket_id, func_name, func_args, opts)
         timeout = '?number',
     })
 
-    local vshard_call_name = call.get_vshard_call_name(opts.mode, opts.prefer_replica, opts.balance, opts.mode)
+    local vshard_call_name, err = call.get_vshard_call_name(opts.mode, opts.prefer_replica, opts.balance)
+    if err ~= nil then
+        return nil, err
+    end
 
     local timeout = opts.timeout or call.DEFAULT_VSHARD_CALL_TIMEOUT
 

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -81,6 +81,26 @@ g.test_single_non_existent_func = function()
     t.assert_str_contains(err.err, "Function non_existent_func is not registered")
 end
 
+g.test_map_invalid_mode = function()
+    local results, err = g.cluster.main_server.net_box:eval([[
+        local call = require('crud.common.call')
+        return call.map('say_hi_politely', nil, {mode = 'invalid'})
+    ]])
+
+    t.assert_equals(results, nil)
+    t.assert_str_contains(err.err, "Unknown call mode: invalid")
+end
+
+g.test_single_invalid_mode = function()
+    local results, err = g.cluster.main_server.net_box:eval([[
+        local call = require('crud.common.call')
+        return call.single(1, 'say_hi_politely', nil, {mode = 'invalid'})
+    ]])
+
+    t.assert_equals(results, nil)
+    t.assert_str_contains(err.err, "Unknown call mode: invalid")
+end
+
 g.test_map_no_args = function()
     local results_map, err  = g.cluster.main_server.net_box:eval([[
         local call = require('crud.common.call')


### PR DESCRIPTION
In README highlights that `mode` parameter for CRUD
methods should be string with `read` or `write`
value but if user mistypes and sets invalid `mode`
value like `wriite` `call` returns no error
and `call` method is called with read mode.

Closes #259
