### PR TITLE
deps: update cartridge to 2.7.3

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -15,5 +15,5 @@ tarantoolctl rocks install https://raw.githubusercontent.com/keplerproject/luafi
 tarantoolctl rocks install https://raw.githubusercontent.com/moteus/lua-path/master/rockspecs/lua-path-scm-0.rockspec
 tarantoolctl rocks install https://raw.githubusercontent.com/moteus/luacov-coveralls/master/rockspecs/luacov-coveralls-scm-0.rockspec
 
-tarantoolctl rocks install cartridge 2.7.1
+tarantoolctl rocks install cartridge 2.7.3
 tarantoolctl rocks make


### PR DESCRIPTION
I use more or less fresh head of tarantool for local development:
2.10.0-beta2-5-gdc19be406 at the moment. This tarantool revision
contains net.box changes, which break cartridge 2.7.1 and below. So I
need a fix from cartridge 2.7.2. See cartridge's [release notes][1],
'fixed' section.

[1]: https://github.com/tarantool/cartridge/releases/tag/2.7.2
