### PR TITLE
ci: workaround luacov-coveralls installation fail

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -13,7 +13,18 @@ tarantoolctl rocks install https://raw.githubusercontent.com/mpeterv/cluacov/mas
 tarantoolctl rocks install https://raw.githubusercontent.com/LuaDist/dkjson/master/dkjson-2.5-2.rockspec
 tarantoolctl rocks install https://raw.githubusercontent.com/keplerproject/luafilesystem/master/luafilesystem-scm-1.rockspec
 tarantoolctl rocks install https://raw.githubusercontent.com/moteus/lua-path/master/rockspecs/lua-path-scm-0.rockspec
-tarantoolctl rocks install https://raw.githubusercontent.com/moteus/luacov-coveralls/master/rockspecs/luacov-coveralls-scm-0.rockspec
+
+# Most of this code is the workaround for
+# https://github.com/moteus/luacov-coveralls/pull/30
+# Remove it, when the pull request will be merged.
+TMPDIR="$(mktemp -d)"
+LUACOV_COVERALLS_ROCKSPEC_URL="https://raw.githubusercontent.com/moteus/luacov-coveralls/master/rockspecs/luacov-coveralls-scm-0.rockspec"
+LUACOV_COVERALLS_ROCKSPEC_FILE="${TMPDIR}/luacov-coveralls-scm-0.rockspec"
+curl -fsSL "${LUACOV_COVERALLS_ROCKSPEC_URL}" > "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+sed -i -e 's@git://@git+https://@' "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+tarantoolctl rocks install "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+rm "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+rmdir "${TMPDIR}"
 
 tarantoolctl rocks install cartridge 2.7.3
 tarantoolctl rocks install ddl 1.6.0


### PR DESCRIPTION
GitHub had disabled insecure git clone (see https://github.blog/2021-09-01-improving-git-protocol-security-github/), so we should use `git+https://` in the rockspec instead of `git://`. The fix is proposed to the upstream in https://github.com/moteus/luacov-coveralls/pull/30, but is not merged at the moment of writting this. This patch workarounds the problem on our side.

Recent luarocks (3.8.0) autoreplaces `git://` with `git+https://`, but we have older luarocks version shipped with tarantool. See https://github.com/tarantool/tarantool/issues/6597 for details.