### PR TITLE
select: fix processing storage error for tuple-merger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Optimize select with known bucket_id (#234).
 
 ### Fixed
+* Fix processing storage error for tuple-merger implementation of
+  select/pairs (#271).
 
 ## [0.10.0] - 01-12-21
 


### PR DESCRIPTION
Storage select/pairs method responds with `nil, err` if something went
wrong. tuple-merger implementation of select/pairs do not support this
type of response, resulting in fail while trying to subscribe nil value.
The patch fixes this behavior by extracting second return value in case
of `nil, err` and wrapping it with errors wrapper to restore errors
metatable.

Closes #271

I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation (it is a fix)
