### PR TITLE
changelog: fix 0.10.0 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* `crud.count()` function to calculate the number of tuples
+  in the space according to conditions.
+* Support bucket id calculating using sharding func specified in
+  DDL schema or in `_ddl_sharding_func` space.
 * Statistics for CRUD operations on router (#224).
 * Integrate CRUD statistics with [`metrics`](https://github.com/tarantool/metrics) (#224).
 * Added LICENSE file into the repository (BSD-2-Clause).
@@ -25,10 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   key specified with DDL schema or in `_ddl_sharding_key` space.
   NOTE: CRUD methods delete(), get() and update() requires that sharding key
   must be a part of primary key.
-* `crud.count()` function to calculate the number of tuples
-  in the space according to conditions.
-* Support bucket id calculating using sharding func specified in
-  DDL schema or in `_ddl_sharding_func` space.
 
 ### Fixed
 


### PR DESCRIPTION
Several "0.10.0" section changelog entries (see PRs #230 and #239) were
added after 0.10.0 release. This patch fixes the inconsistency by moving
them to "Unreleased" section.

Follows up #74, #237

I didn't forget about

- Tests (not needed here)
- [x] Changelog
- Documentation (not needed here)
