### PR TITLE
Log empty or nil select calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * Optimize `crud.select()` without conditions and with `after`.
+* Behaviour of potentially long `select` calls: a critical log entry containing
+  the current stack traceback is created upon such function calls — an user can
+  explicitly request a full scan through by passing `fullscan=true` to `select`
+  options table argument in which a case a log entry will not be created (#276).
 
 ### Fixed
 * `crud.select()` if a condition is '<=' and it's value < `after`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * Optimize `crud.select()` without conditions and with `after`.
-* Behaviour of potentially long `select` calls: a critical log entry containing
-  the current stack traceback is created upon such function calls — an user can
-  explicitly request a full scan through by passing `fullscan=true` to `select`
-  options table argument in which a case a log entry will not be created (#276).
+* Behaviour of potentially long `select` and `count` calls: a critical log entry
+  containing the current stack traceback is created upon such function calls —
+  an user can explicitly request a full scan through by passing `fullscan=true`
+  to `select` or `count` options table argument in which a case a log entry will
+  not be created (#276).
 
 ### Fixed
 * `crud.select()` if a condition is '<=' and it's value < `after`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ It can be used to convert received tuples to objects via `crud.unflatten_rows` f
 For example:
 
 ```lua
-res, err = crud.select('customers')
+res, err = crud.select('customers', nil, {first = 2})
 res
 ---
 - metadata:
@@ -450,6 +450,8 @@ where:
      if full primary key equal condition is specified
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `fullscan` (`?boolean`) - if `true` then a critical log entry will be skipped
+    on potentially long `select`, see [avoiding full scan](doc/select.md#avoiding-full-scan).
   * `mode` (`?string`, `read` or `write`) - if `write` is specified then `select` is
     performed on master
   * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
@@ -472,7 +474,7 @@ Each condition is a table `{operator, field-identifier, value}`:
 **Example:**
 
 ```lua
-crud.select('customers', {{'<=', 'age', 35}})
+crud.select('customers', {{'<=', 'age', 35}}, {first = 10})
 ---
 - metadata:
   - {'name': 'id', 'type': 'unsigned'}
@@ -496,8 +498,10 @@ See more examples of select queries [here.](https://github.com/tarantool/crud/bl
 ### Pairs
 
 You can iterate across a distributed space using the `crud.pairs` function.
-Its arguments are the same as [`crud.select`](#select) arguments,
-but negative `first` values aren't allowed.
+Its arguments are the same as [`crud.select`](#select) arguments except
+`fullscan` (it does not exist because `crud.pairs` does not generate a critical
+log entry on potentially long requests) and negative `first` values aren't
+allowed.
 User could pass use_tomap flag (false by default) to iterate over flat tuples or objects.
 
 **Example:**
@@ -597,7 +601,7 @@ Returns true or nil with error.
 **Example:**
 
 ```lua
-#crud.select('customers', {{'<=', 'age', 35}})
+#crud.select('customers', {{'<=', 'age', 35}}, {first = 10})
 ---
 - 1
 ...
@@ -605,7 +609,7 @@ crud.truncate('customers', {timeout = 2})
 ---
 - true
 ...
-#crud.select('customers', {{'<=', 'age', 35}})
+#crud.select('customers', {{'<=', 'age', 35}}, {first = 10})
 ---
 - 0
 ...
@@ -633,7 +637,7 @@ Returns number or nil with error.
 Using `memtx`:
 
 ```lua
-#crud.select('customers')
+#crud.select('customers', nil, {fullscan = true})
 ---
 - 5
 ...

--- a/README.md
+++ b/README.md
@@ -690,6 +690,8 @@ where:
   * `force_map_call` (`?boolean`) - if `true`
     then the map call is performed without any optimizations even,
     default value is `false`
+  * `fullscan` (`?boolean`) - if `true` then a critical log entry will be skipped
+    on potentially long `count`, see [avoiding full scan](doc/select.md#avoiding-full-scan).
   * `mode` (`?string`, `read` or `write`) - if `write` is specified then `count` is
     performed on master, default value is `read`
   * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
@@ -699,9 +701,9 @@ where:
     default value is `false`
 
 ```lua
-crud.count('customers', {{'<=', 'age', 35}})
+crud.count('customers', {{'==', 'age', 35}})
 ---
-- 5
+- 1
 ...
 ```
 

--- a/crud/ratelimit.lua
+++ b/crud/ratelimit.lua
@@ -1,0 +1,125 @@
+-- Mostly it's a copy-paste from tarantool/tarantool log.lua:
+-- https://github.com/tarantool/tarantool/blob/29654ffe3638e5a218dd32f1788830ff05c1c05c/src/lua/log.lua
+--
+-- We have three reasons for the copy-paste:
+-- 1. Tarantool has not log.crit() (a function for logging with CRIT level).
+-- 2. Only new versions of Tarantool have Ratelimit type.
+-- 3. We want own copy of Ratelimit in case the implementation in Tarantool
+-- changes. Less pain between Tarantool versions.
+local ffi = require('ffi')
+
+local S_CRIT = ffi.C.S_CRIT
+local S_WARN = ffi.C.S_WARN
+
+local function say(level, fmt, ...)
+    if ffi.C.log_level < level then
+        -- don't waste cycles on debug.getinfo()
+        return
+    end
+    local type_fmt = type(fmt)
+    local format = "%s"
+    if select('#', ...) ~= 0 then
+        local stat
+        stat, fmt = pcall(string.format, fmt, ...)
+        if not stat then
+            error(fmt, 3)
+        end
+    elseif type_fmt == 'table' then
+        -- An implementation in tarantool/tarantool supports encoding a table in
+        -- JSON, but it requires more dependencies from FFI. So we just deleted
+        -- it because we don't need such encoding in the module.
+        error("table not supported", 3)
+    elseif type_fmt ~= 'string' then
+        fmt = tostring(fmt)
+    end
+
+    local debug = require('debug')
+    local frame = debug.getinfo(3, "Sl")
+    local line, file = 0, 'eval'
+    if type(frame) == 'table' then
+        line = frame.currentline or 0
+        file = frame.short_src or frame.src or 'eval'
+    end
+
+    ffi.C._say(level, file, line, nil, format, fmt)
+end
+
+local ratelimit_enabled = true
+
+local function ratelimit_enable()
+    ratelimit_enabled = true
+end
+
+local function ratelimit_disable()
+    ratelimit_enabled = false
+end
+
+local Ratelimit = {
+    interval = 60,
+    burst = 10,
+    emitted = 0,
+    suppressed = 0,
+    start = 0,
+}
+
+local function ratelimit_new(object)
+    return Ratelimit:new(object)
+end
+
+function Ratelimit:new(object)
+    object = object or {}
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+function Ratelimit:check()
+    if not ratelimit_enabled then
+        return 0, true
+    end
+
+    local clock = require('clock')
+    local now = clock.monotonic()
+    local saved_suppressed = 0
+    if now > self.start + self.interval then
+        saved_suppressed = self.suppressed
+        self.suppressed = 0
+        self.emitted = 0
+        self.start = now
+    end
+
+    if self.emitted < self.burst then
+        self.emitted = self.emitted + 1
+        return saved_suppressed, true
+    end
+    self.suppressed = self.suppressed + 1
+    return saved_suppressed, false
+end
+
+function Ratelimit:log_check(lvl)
+    local suppressed, ok = self:check()
+    if lvl >= S_WARN and suppressed > 0 then
+        say(S_WARN, '%d messages suppressed due to rate limiting', suppressed)
+    end
+    return ok
+end
+
+function Ratelimit:log(lvl, fmt, ...)
+    if self:log_check(lvl) then
+        say(lvl, fmt, ...)
+    end
+end
+
+local function log_ratelimited_closure(lvl)
+    return function(self, fmt, ...)
+        self:log(lvl, fmt, ...)
+    end
+end
+
+Ratelimit.log_crit = log_ratelimited_closure(S_CRIT)
+
+return {
+    new = ratelimit_new,
+    enable = ratelimit_enable,
+    disable = ratelimit_disable,
+}

--- a/crud/select/compat/common.lua
+++ b/crud/select/compat/common.lua
@@ -1,6 +1,28 @@
+local ratelimit = require('crud.ratelimit')
+local check_select_safety_rl = ratelimit.new()
+
 local common = {}
 
 common.SELECT_FUNC_NAME = '_crud.select_on_storage'
 common.DEFAULT_BATCH_SIZE = 100
+
+common.check_select_safety = function(space_name, plan, opts)
+    if opts.fullscan == true then
+        return
+    end
+
+    if opts.first ~= nil and math.abs(opts.first) <= 1000 then
+        return
+    end
+
+    local iter = plan.tarantool_iter
+    if iter == box.index.EQ or iter == box.index.REQ then
+        return
+    end
+
+    local rl = check_select_safety_rl
+    local traceback = debug.traceback()
+    rl:log_crit("Potentially long select from space '%s'\n %s", space_name, traceback)
+end
 
 return common

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -180,6 +180,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
     return {
         tuples_limit = tuples_limit,
         merger = merger,
+        plan = plan,
         space_format = filtered_space_format,
     }
 end
@@ -252,14 +253,16 @@ local function select_module_call_xc(space_name, user_conditions, opts)
     checks('string', '?table', {
         after = '?table|cdata',
         first = '?number',
-        timeout = '?number',
         batch_size = '?number',
         bucket_id = '?number|cdata',
         force_map_call = '?boolean',
         fields = '?table',
+        fullscan = '?boolean',
+
+        mode = '?vshard_call_mode',
         prefer_replica = '?boolean',
         balance = '?boolean',
-        mode = '?vshard_call_mode',
+        timeout = '?number',
     })
 
     opts = opts or {}
@@ -292,6 +295,7 @@ local function select_module_call_xc(space_name, user_conditions, opts)
     if err ~= nil then
         return nil, err
     end
+    common.check_select_safety(space_name, iter.plan, opts)
 
     local tuples = {}
 

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -332,6 +332,7 @@ local function select_module_call_xc(space_name, user_conditions, opts)
     if err ~= nil then
         return nil, err
     end
+    common.check_select_safety(space_name, iter.plan, opts)
 
     local tuples = {}
 
@@ -366,14 +367,16 @@ function select_module.call(space_name, user_conditions, opts)
     checks('string', '?table', {
         after = '?table',
         first = '?number',
-        timeout = '?number',
         batch_size = '?number',
         bucket_id = '?number|cdata',
         force_map_call = '?boolean',
         fields = '?table',
+        fullscan = '?boolean',
+
+        mode = '?vshard_call_mode',
         prefer_replica = '?boolean',
         balance = '?boolean',
-        mode = '?vshard_call_mode',
+        timeout = '?number',
     })
 
     return sharding.wrap_method(select_module_call_xc, space_name, user_conditions, opts)

--- a/doc/pairs.md
+++ b/doc/pairs.md
@@ -1,7 +1,8 @@
 # Pairs examples
 
 With ``crud.pairs``, you can iterate across a distributed space.  
-The arguments are the same as [``crud.select``](https://github.com/tarantool/crud/blob/master/doc/select.md), except of the ``use_tomap`` parameter.  
+The arguments are the same as [``crud.select``](https://github.com/tarantool/crud/blob/master/doc/select.md) arguments except ``fullscan`` (it does not exist because ``crud.pairs`` does not generate a critical log entry on potentially long requests) and negative ``first`` values aren't allowed.
+User could pass ``use_tomap`` flag (false by default) to iterate over flat tuples or objects.
 Below are examples that may help you.
 Examples schema is similar to the [select documentation](select.md/#examples-space-format)
 

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -509,4 +509,17 @@ function helpers.assert_timeout_error(value, message)
     error(err, 2)
 end
 
+function helpers.fflush_main_server_stdout(cluster, capture)
+    -- Sometimes we have a delay here. This hack helps to wait for the end of
+    -- the output. It shouldn't take much time.
+    cluster.main_server.net_box:eval([[
+        require('log').error("crud fflush stdout message")
+    ]])
+    local captured = ""
+    while not string.find(captured, "crud fflush stdout message", 1, true) do
+        captured = captured .. (capture:flush().stdout or "")
+    end
+    return captured
+end
+
 return helpers

--- a/test/integration/read_calls_strategies_test.lua
+++ b/test/integration/read_calls_strategies_test.lua
@@ -111,7 +111,8 @@ pgroup.test_count = function(g)
     local _, err = g.cluster.main_server.net_box:call('crud.count', {'customers', nil, {
         mode = g.params.mode,
         balance = g.params.balance,
-        prefer_replica = g.params.prefer_replica
+        prefer_replica = g.params.prefer_replica,
+        fullscan = true
     }})
     t.assert_equals(err, nil)
     local vshard_calls = g.get_vshard_calls('call_impl')

--- a/test/integration/read_calls_strategies_test.lua
+++ b/test/integration/read_calls_strategies_test.lua
@@ -78,7 +78,8 @@ pgroup.test_select = function(g)
     local _, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil, {
         mode = g.params.mode,
         balance = g.params.balance,
-        prefer_replica = g.params.prefer_replica
+        prefer_replica = g.params.prefer_replica,
+        fullscan = true
     }})
     t.assert_equals(err, nil)
     local vshard_calls = g.get_vshard_calls('call_impl')

--- a/test/integration/reload_test.lua
+++ b/test/integration/reload_test.lua
@@ -93,7 +93,7 @@ function g.test_router()
 
     g.highload_fiber:cancel()
 
-    local result, err = g.router.net_box:call('crud.select', {'customers'})
+    local result, err = g.router.net_box:call('crud.select', {'customers', nil, {fullscan = true}})
     t.assert_equals(err, nil)
     t.assert_items_include(result.rows, g.insertions_passed)
 end
@@ -122,7 +122,7 @@ function g.test_storage()
 
     g.highload_fiber:cancel()
 
-    local result, err = g.router.net_box:call('crud.select', {'customers'})
+    local result, err = g.router.net_box:call('crud.select', {'customers', nil, {fullscan = true}})
     t.assert_equals(err, nil)
     t.assert_items_include(result.rows, g.insertions_passed)
 end

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -174,15 +174,7 @@ for name, case in pairs(select_safety_cases) do
         local _, err = g.cluster.main_server.net_box:call('crud.select', {space, uc, opts})
         t.assert_equals(err, nil)
 
-        -- We have a delay here. This hack helps to wait for the end of the output.
-        -- It shouldn't take much time.
-        g.cluster:server('router').net_box:eval([[
-            require('log').error("end of test_select_nil case")
-        ]])
-        local captured = ""
-        while not string.find(captured, "end of test_select_nil case", 1, true) do
-            captured = captured .. (capture:flush().stdout or "")
-        end
+        local captured = helpers.fflush_main_server_stdout(g.cluster, capture)
 
         if case.has_crit then
             t.assert_str_contains(captured, crit_log)

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -394,6 +394,7 @@ local select_cases = {
         map_reduces = 1,
         tuples_fetched = 0,
         tuples_lookup = 4,
+        opts = {fullscan = true},
     },
     pairs_by_primary_index = {
         eval = eval.pairs,
@@ -452,9 +453,9 @@ local function generate_stats(g)
     for _, case in pairs(select_cases) do
         local _, err
         if case.eval ~= nil then
-            _, err = g.router:eval(case.eval, { space_name, case.conditions })
+            _, err = g.router:eval(case.eval, { space_name, case.conditions, case.opts })
         else
-            _, err = g.router:call(case.func, { space_name, case.conditions })
+            _, err = g.router:call(case.func, { space_name, case.conditions, case.opts })
         end
 
         t.assert_equals(err, nil)

--- a/test/integration/truncate_test.lua
+++ b/test/integration/truncate_test.lua
@@ -61,7 +61,7 @@ pgroup.test_truncate = function(g)
 
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
-    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil})
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil, {fullscan = true}})
     t.assert_equals(err, nil)
     t.assert_gt(#result.rows, 0)
 
@@ -69,7 +69,7 @@ pgroup.test_truncate = function(g)
     t.assert_equals(err, nil)
     t.assert_equals(result, true)
 
-    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil})
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', nil, {fullscan = true}})
     t.assert_equals(err, nil)
     t.assert_equals(#result.rows, 0)
 end

--- a/test/integration/updated_shema_test.lua
+++ b/test/integration/updated_shema_test.lua
@@ -283,7 +283,7 @@ end
 pgroup.test_select_non_existent_space = function(g)
     -- non-existent space err
     local obj, err = g.cluster.main_server.net_box:call(
-        'crud.select', {'customers'}
+        'crud.select', {'customers', nil, {fullscan = true}}
     )
 
     t.assert_equals(obj, nil)
@@ -298,7 +298,7 @@ pgroup.test_select_non_existent_space = function(g)
 
     -- check that schema changes were applied
     local obj, err = g.cluster.main_server.net_box:call(
-        'crud.select', {'customers'}
+        'crud.select', {'customers', nil, {fullscan = true}}
     )
 
     t.assert_is_not(obj, nil)
@@ -599,7 +599,7 @@ pgroup.test_select_field_added = function(g)
 
     -- unknown field (no results)
     local obj, err = g.cluster.main_server.net_box:call(
-        'crud.select', {'customers', {{'==', 'extra', 'EXTRRRRA'}}}
+        'crud.select', {'customers', {{'==', 'extra', 'EXTRRRRA'}}, {fullscan = true}}
     )
 
     t.assert_equals(obj.rows, {})
@@ -612,7 +612,7 @@ pgroup.test_select_field_added = function(g)
 
     -- check that schema changes were applied
     local obj, err = g.cluster.main_server.net_box:call(
-        'crud.select', {'customers', {{'==', 'extra', 'EXTRRRRA'}}}
+        'crud.select', {'customers', {{'==', 'extra', 'EXTRRRRA'}}, {fullscan = true}}
     )
 
     t.assert_is_not(obj, nil)
@@ -763,7 +763,7 @@ pgroup.test_alter_index_parts = function(g)
 
     -- Check sort order before alter
     local result, err = g.cluster.main_server.net_box:call(
-        'crud.select', {'customers', {{'>=', 'number_value_index', {0, "0"}}}}
+        'crud.select', {'customers', {{'>=', 'number_value_index', {0, "0"}}}, {fullscan = true}}
     )
     t.assert_equals(err, nil)
     t.assert_equals(#result.rows, 10)
@@ -784,7 +784,7 @@ pgroup.test_alter_index_parts = function(g)
 
     -- Sort order should be new
     local result, err = g.cluster.main_server.net_box:call(
-        'crud.select', {'customers', {{'>=', 'number_value_index', {"0", 0}}}}
+        'crud.select', {'customers', {{'>=', 'number_value_index', {"0", 0}}}, {fullscan = true}}
     )
     t.assert_equals(err, nil)
     t.assert_equals(#result.rows, 10)


### PR DESCRIPTION
Empty or nil select calls on user spaces tend to be dangerous.
   
A critical log entry containing the current stack traceback is created
upon empty or nil select calls — a user can explicitly request a full
scan though by passing fullscan = true to select's options table
argument in which a case a log entry will not be created.
    
Tarantool has a similar implementation[1].
    
1. https://github.com/tarantool/tarantool/pull/7064
    
Closes #276