### PR TITLE
ddl: fix error on explicit bucket_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+* Requests no more fail with "Sharding hash mismatch" error
+  if ddl set and bucket_id is explicitly specified (#278).
 
 ## [0.11.0] - 20-04-22
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ with sharding func definition as a part of
 or insert manually to the space `_ddl_sharding_func`.
 
 Automatic sharding key and function reload is supported since version 0.11.0.
+Version 0.11.0 contains critical bug that causes some CRUD methods to fail
+with "Sharding hash mismatch" error if ddl is set and bucket_id is provided
+explicitly ([#278](https://github.com/tarantool/crud/issues/278)). Please,
+upgrade to 0.11.1 instead.
 
 CRUD uses `strcrc32` as sharding function by default.
 The reason why using of `strcrc32` is undesirable is that

--- a/crud/common/sharding/init.lua
+++ b/crud/common/sharding/init.lua
@@ -100,6 +100,8 @@ function sharding.tuple_set_and_return_bucket_id(tuple, space, specified_bucket_
             return nil, err
         end
         tuple[bucket_id_fieldno] = sharding_data.bucket_id
+    else
+        sharding_data.skip_sharding_hash_check = true
     end
 
     return sharding_data

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -21,6 +21,7 @@ local function insert_on_storage(space_name, tuple, opts)
         fields = '?table',
         sharding_key_hash = '?number',
         sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
     })
 
     opts = opts or {}
@@ -82,6 +83,7 @@ local function call_insert_on_router(space_name, original_tuple, opts)
         fields = opts.fields,
         sharding_func_hash = sharding_data.sharding_func_hash,
         sharding_key_hash = sharding_data.sharding_key_hash,
+        skip_sharding_hash_check = sharding_data.skip_sharding_hash_check,
     }
 
     local call_opts = {

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -21,6 +21,7 @@ local function replace_on_storage(space_name, tuple, opts)
         fields = '?table',
         sharding_key_hash = '?number',
         sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
     })
 
     opts = opts or {}
@@ -86,6 +87,7 @@ local function call_replace_on_router(space_name, original_tuple, opts)
         fields = opts.fields,
         sharding_func_hash = sharding_data.sharding_func_hash,
         sharding_key_hash = sharding_data.sharding_key_hash,
+        skip_sharding_hash_check = sharding_data.skip_sharding_hash_check,
     }
 
     local call_opts = {

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -20,6 +20,7 @@ local function upsert_on_storage(space_name, tuple, operations, opts)
         add_space_schema_hash = '?boolean',
         sharding_key_hash = '?number',
         sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
     })
 
     opts = opts or {}
@@ -93,6 +94,7 @@ local function call_upsert_on_router(space_name, original_tuple, user_operations
         fields = opts.fields,
         sharding_func_hash = sharding_data.sharding_func_hash,
         sharding_key_hash = sharding_data.sharding_key_hash,
+        skip_sharding_hash_check = sharding_data.skip_sharding_hash_check,
     }
 
     local call_opts = {


### PR DESCRIPTION
After introducing sharding hash info comparison, requests with ddl and
explicit bucket_id in options started to fail with
"Sharding hash mismatch" error. It affects the following methods:
- insert
- insert_object
- replace
- replace_object
- upsert
- upsert_object
- count

The situation is as follows. Due to a code mistake, router hasn't passed
a sharding hash with a request if bucket_id was specified. If there was
any ddl information for a space on storage, it has caused a hash
mismatch error. Since sharding info reload couldn't fix broken hash
extraction, request failed after a number of retries. This patch fixes
this behavior by skipping hash comparison if sharding info wasn't used
(we already do it in other methods).


- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #278
