### PR TITLE
stats: make quantile tolerated error configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Make metrics quantile collector tolerated error configurable (#281).
 
 ### Changed
+* Change metrics quantile collector default tolerated error
+  from 1e-2 to 1e-3 (#281).
 
 ### Fixed
 * Requests no more fail with "Sharding hash mismatch" error

--- a/README.md
+++ b/README.md
@@ -793,6 +793,13 @@ metrics:collect()
     metric_name: tnt_crud_stats
 ...
 ```
+If you see `-Inf` value in quantile metrics, try to decrease the tolerated error:
+```lua
+crud.cfg{stats_quantile_tolerated_error = 1e-4}
+```
+See [tarantool/metrics#189](https://github.com/tarantool/metrics/issues/189) for
+details about the issue.
+
 
 `select` section additionally contains `details` collectors.
 ```lua

--- a/crud/stats/local_registry.lua
+++ b/crud/stats/local_registry.lua
@@ -25,10 +25,16 @@ local StatsLocalError = errors.new_class('StatsLocalError', {capture_stack = fal
 -- @bool opts.quantiles
 --  Quantiles is not supported for local, only `false` is valid.
 --
+-- @number opts.quantile_tolerated_error
+--  Quantiles is not supported for local, so the value is ignored.
+--
 -- @treturn boolean Returns `true`.
 --
 function registry.init(opts)
-    dev_checks({ quantiles = 'boolean' })
+    dev_checks({
+        quantiles = 'boolean',
+        quantile_tolerated_error = 'number',
+    })
 
     StatsLocalError:assert(opts.quantiles == false,
         "Quantiles are not supported for 'local' statistics registry")

--- a/test/integration/cfg_test.lua
+++ b/test/integration/cfg_test.lua
@@ -26,6 +26,7 @@ group.test_defaults = function(g)
         stats = false,
         stats_driver = stats.get_default_driver(),
         stats_quantiles = false,
+        stats_quantile_tolerated_error = 1e-3,
     })
 end
 


### PR DESCRIPTION
Make metrics quantile collector tolerated error [1] configurable. Change
metrics quantile collector default tolerated error from 1e-2 to 1e-3.

The motivation of this patch is a tarantool/metrics bug [2]. Sometimes
quantile values turn to `-Inf` under high load when observations are
small. It was reproduced in process of developing Grafana dashboard
panels for CRUD stats [3].

Quantile tolerated error could be changed with crud.cfg:
```lua
  crud.cfg{stats_quantile_tolerated_error = 1e-4}
```

1. https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary
2. https://github.com/tarantool/metrics/issues/189
3. https://github.com/tarantool/grafana-dashboard/tree/DifferentialOrange/crud-report

- [x] Tests
- [x] Changelog
- [x] Documentation
