### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.11.1] - 06-05-22
+
+### Added
 * Make metrics quantile collector tolerated error configurable (#281).
 
 ### Changed
@@ -19,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   if ddl set and bucket_id is explicitly specified (#278).
 
 ## [0.11.0] - 20-04-22
+
+**Caution**: Use CRUD 0.11.1 instead of 0.11.0. It fixes
+critical bug for some requests (see #278).
 
 ### Added
 * `crud.count()` function to calculate the number of tuples


### PR DESCRIPTION

### Overview

This release fixes critical bug introduced in 0.11.0. It is
recommended to use 0.11.1 instead of 0.11.0.

It also adds an ability to configure quantile collector tolerated
error and changes its default value.

### Breaking changes

There are no breaking changes in the release.

### New features

Set quantile collector tolerated error with crud.cfg (#281):
```
crud.cfg{ stats_quantile_tolerated_error = 1e-4 }
```
Decreasing tolerated error may fix getting `-Inf` values in
quantiles. Increasing tolerated error may improve performance a bit.

### Bugfixes

Requests no more fail with "Sharding hash mismatch" error
if ddl set and bucket_id is explicitly specified (#278).

- [x] Changelog
