### PR TITLE
readme: remove sharding info duplicate entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ Table below describe what operations supports custom sharding key:
 | `select()` / `pairs()`           | Yes                        |
 | `count()`                        | Yes                        |
 | `update()`                       | Yes                        |
-| `upsert()` / `upsert_object()`   | Yes                        |
-| `replace() / replace_object()`   | Yes                        |
 | `min()` / `max()`                | No (not required)          |
 | `cut_rows()` / `cut_objects()`   | No (not required)          |
 | `truncate()`                     | No (not required)          |


### PR DESCRIPTION
Replace and upsert entries in sharding info table have duplicate entries now.
![image](https://user-images.githubusercontent.com/20455996/168069200-85c036a2-9a67-4a76-a010-5f6168a880df.png)
![image](https://user-images.githubusercontent.com/20455996/168069234-047ab921-7b9c-469f-afcc-63a50159d7a6.png)


I didn't forget about

- Tests
- Changelog
- [x] Documentation