### PR TITLE
cfg: fix losing stats parameter on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+* Preset `stats_quantile_tolerated_error` `crud.cfg` parameter is no
+  more lost on configuration update (#284).
 
 ## [0.11.1] - 06-05-22
 

--- a/crud/cfg.lua
+++ b/crud/cfg.lua
@@ -54,7 +54,7 @@ local function configure_stats(cfg, opts)
         opts.stats_quantiles = cfg.stats_quantiles
     end
 
-    if opts.stats_quantiles == nil then
+    if opts.stats_quantile_tolerated_error == nil then
         opts.stats_quantile_tolerated_error = cfg.stats_quantile_tolerated_error
     end
 

--- a/test/integration/cfg_test.lua
+++ b/test/integration/cfg_test.lua
@@ -78,3 +78,25 @@ group.test_role_reload_preserves_values = function(g)
     local cfg = router:eval("return require('crud').cfg")
     t.assert_equals(cfg.stats, true)
 end
+
+group.test_gh_284_preset_stats_quantile_tolerated_error_is_preserved = function(g)
+    -- Arrange some cfg values so test case will not depend on defaults.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats = false }})
+    t.assert_equals(cfg.stats, false)
+
+    -- Set stats_quantile_tolerated_error.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats_quantile_tolerated_error = 1e-4 }})
+    t.assert_equals(cfg.stats_quantile_tolerated_error, 1e-4)
+
+    -- Set another cfg parameter, assert preset stats_quantile_tolerated_error presents.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats = true }})
+    t.assert_equals(cfg.stats, true)
+    t.assert_equals(cfg.stats_quantile_tolerated_error, 1e-4,
+        'Preset stats_quantile_tolerated_error presents')
+end


### PR DESCRIPTION
Before this patch, stats_quantile_tolerated_error configuration
parameter value could be lost in the following sequence of separate
crud.cfg calls:
1. Set up stats_quantile_tolerated_error (maybe together with other
   parameters).
2. Set up any other cfg parameter, do not set
   stats_quantile_tolerated_error in call explicitly.

It was expected that stats_quantile_tolerated_error from the first step
will be preserved after the second one, but it was lost. This patch
fixes the behavior.


I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation

Follows up PR #281, closes #284
