### PR TITLE
Fix nan crud.stats latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Make metrics quantile collector age params configurable (#286).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * Make metrics quantile collector age params configurable (#286).
+* Add separate `latency_average` and `latency_quantile_recent`
+  fields to `crud.stats()` output (#286).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -721,11 +721,15 @@ crud.stats()
     my_space:
       insert:
         ok:
-          latency: 0.002
+          latency: 0.0015
+          latency_average: 0.002
+          latency_quantile_recent: 0.0015
           count: 19800
           time: 39.6
         error:
-          latency: 0.000001
+          latency: 0.0000008
+          latency_average: 0.000001
+          latency_quantile_recent: 0.0000008
           count: 4
           time: 0.000004
 ...
@@ -733,11 +737,15 @@ crud.stats('my_space')
 ---
 - insert:
     ok:
-      latency: 0.002
+      latency: 0.0015
+      latency_average: 0.002
+      latency_quantile_recent: 0.0015
       count: 19800
       time: 39.6
     error:
-      latency: 0.000001
+      latency: 0.0000008
+      latency_average: 0.000001
+      latency_quantile_recent: 0.0000008
       count: 4
       time: 0.000004
 ...
@@ -759,10 +767,17 @@ and `borders` (for `min` and `max` calls).
 Each operation section consists of different collectors
 for success calls and error (both error throw and `nil, err`)
 returns. `count` is the total requests count since instance start
-or stats restart. `latency` is the 0.99 quantile of request execution
-time if `metrics` driver used and quantiles enabled,
-otherwise `latency` is the total average.
-`time` is the total time of requests execution.
+or stats restart.  `time` is the total time of requests execution.
+`latency_average` is `time` / `count`.
+`latency_quantile_recent` is the 0.99 quantile of request execution
+time for a recent period (see 
+[`metrics` summary API](https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary)).
+It is computed only if `metrics` driver is used and quantiles are
+enabled. `latency_quantile_recent` value may be `-nan` if there
+wasn't any observations for several ages, see
+[tarantool/metrics#303](https://github.com/tarantool/metrics/issues/303).
+`latency` is a `latency_quantile_recent` if `metrics` driver is used
+and quantiles are enabled, otherwise it's `latency_average`.
 
 In [`metrics`](https://www.tarantool.io/en/doc/latest/book/monitoring/)
 registry statistics are stored as `tnt_crud_stats` metrics

--- a/README.md
+++ b/README.md
@@ -797,7 +797,17 @@ crud.cfg{stats_quantile_tolerated_error = 1e-4}
 ```
 See [tarantool/metrics#189](https://github.com/tarantool/metrics/issues/189) for
 details about the issue.
-
+You can also configure quantile `age_bucket_count` (default: 2) and
+`max_age_time` (in seconds, default: 60):
+```lua
+crud.cfg{
+    stats_quantile_age_bucket_count = 3,
+    stats_quantile_max_age_time = 30,
+}
+```
+See [`metrics` summary API](https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary)
+for details. These parameters can be used to smooth time window move
+or reduce the amount on `-nan` gaps for low request frequency applications.
 
 `select` section additionally contains `details` collectors.
 ```lua

--- a/crud/cfg.lua
+++ b/crud/cfg.lua
@@ -103,7 +103,7 @@ end
 -- @number[opt=1e-3] opts.stats_quantile_tolerated_error
 --  See tarantool/metrics summary API for details:
 --  https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary
---  If quantile value is -Inf, try to decrease quantile tolerance.
+--  If quantile value is -Inf, try to decrease quantile tolerated error.
 --  See https://github.com/tarantool/metrics/issues/189 for issue details.
 --  Decreasing the value increases computational load.
 --

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -87,7 +87,7 @@ end
 -- @number[opt=1e-3] opts.quantile_tolerated_error
 --  See tarantool/metrics summary API for details:
 --  https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary
---  If quantile value is -Inf, try to decrease quantile tolerance.
+--  If quantile value is -Inf, try to decrease quantile tolerated error.
 --  See https://github.com/tarantool/metrics/issues/189 for issue details.
 --
 -- @treturn boolean Returns `true`.

--- a/crud/stats/local_registry.lua
+++ b/crud/stats/local_registry.lua
@@ -28,12 +28,20 @@ local StatsLocalError = errors.new_class('StatsLocalError', {capture_stack = fal
 -- @number opts.quantile_tolerated_error
 --  Quantiles is not supported for local, so the value is ignored.
 --
+-- @number opts.quantile_age_buckets_count
+--  Quantiles is not supported for local, so the value is ignored.
+--
+-- @number opts.quantile_max_age_time
+--  Quantiles is not supported for local, so the value is ignored.
+--
 -- @treturn boolean Returns `true`.
 --
 function registry.init(opts)
     dev_checks({
         quantiles = 'boolean',
         quantile_tolerated_error = 'number',
+        quantile_age_buckets_count = 'number',
+        quantile_max_age_time = 'number',
     })
 
     StatsLocalError:assert(opts.quantiles == false,

--- a/crud/stats/local_registry.lua
+++ b/crud/stats/local_registry.lua
@@ -121,7 +121,8 @@ function registry.observe(latency, space_name, op, status)
 
     collectors.count = collectors.count + 1
     collectors.time = collectors.time + latency
-    collectors.latency = collectors.time / collectors.count
+    collectors.latency_average = collectors.time / collectors.count
+    collectors.latency = collectors.latency_average
 
     return true
 end

--- a/crud/stats/metrics_registry.lua
+++ b/crud/stats/metrics_registry.lua
@@ -84,7 +84,7 @@ end
 -- @number[opt=1e-3] opts.quantile_tolerated_error
 --  See metrics summary API for details:
 --  https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary
---  If quantile value is -Inf, try to decrease quantile tolerance.
+--  If quantile value is -Inf, try to decrease quantile tolerated error.
 --  See https://github.com/tarantool/metrics/issues/189 for issue details.
 --
 -- @treturn boolean Returns `true`.

--- a/crud/stats/registry_utils.lua
+++ b/crud/stats/registry_utils.lua
@@ -16,7 +16,8 @@ local registry_utils = {}
 --  Use `require('crud.stats').op` to pick one.
 --
 -- @treturn table Returns collectors for success and error requests.
---  Collectors store 'count', 'latency' and 'time' values. Also
+--  Collectors store 'count', 'latency', 'latency_average',
+--  'latency_quantile_recent' and 'time' values. Also
 --  returns additional collectors for select operation.
 --
 function registry_utils.build_collectors(op)
@@ -26,11 +27,19 @@ function registry_utils.build_collectors(op)
         ok = {
             count = 0,
             latency = 0,
+            latency_average = 0,
+            -- latency_quantile_recent presents only if driver
+            -- is 'metrics' and quantiles enabled.
+            latency_quantile_recent = nil,
             time = 0,
         },
         error = {
             count = 0,
             latency = 0,
+            latency_average = 0,
+            -- latency_quantile_recent presents only if driver
+            -- is 'metrics' and quantiles enabled.
+            latency_quantile_recent = nil,
             time = 0,
         },
     }

--- a/test/integration/cfg_test.lua
+++ b/test/integration/cfg_test.lua
@@ -27,6 +27,8 @@ group.test_defaults = function(g)
         stats_driver = stats.get_default_driver(),
         stats_quantiles = false,
         stats_quantile_tolerated_error = 1e-3,
+        stats_quantile_age_buckets_count = 2,
+        stats_quantile_max_age_time = 60,
     })
 end
 
@@ -99,4 +101,48 @@ group.test_gh_284_preset_stats_quantile_tolerated_error_is_preserved = function(
     t.assert_equals(cfg.stats, true)
     t.assert_equals(cfg.stats_quantile_tolerated_error, 1e-4,
         'Preset stats_quantile_tolerated_error presents')
+end
+
+group.test_gh_284_preset_stats_quantile_age_buckets_count_is_preserved = function(g)
+    -- Arrange some cfg values so test case will not depend on defaults.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats = false }})
+    t.assert_equals(cfg.stats, false)
+
+    -- Set stats_age_buckets_count.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats_quantile_age_buckets_count = 3 }})
+    t.assert_equals(cfg.stats_quantile_age_buckets_count, 3)
+
+    -- Set another cfg parameter, assert preset stats_quantile_age_buckets_count presents.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats = true }})
+    t.assert_equals(cfg.stats, true)
+    t.assert_equals(cfg.stats_quantile_age_buckets_count, 3,
+        'Preset stats_quantile_age_buckets_count presents')
+end
+
+group.test_gh_284_preset_stats_quantile_max_age_time_is_preserved = function(g)
+    -- Arrange some cfg values so test case will not depend on defaults.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats = false }})
+    t.assert_equals(cfg.stats, false)
+
+    -- Set stats_age_buckets_count.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats_quantile_max_age_time = 30 }})
+    t.assert_equals(cfg.stats_quantile_max_age_time, 30)
+
+    -- Set another cfg parameter, assert preset stats_quantile_max_age_time presents.
+    local cfg = g.cluster:server('router'):eval(
+        "return require('crud').cfg(...)",
+        {{ stats = true }})
+    t.assert_equals(cfg.stats, true)
+    t.assert_equals(cfg.stats_quantile_max_age_time, 30,
+        'Preset stats_quantile_max_age_time presents')
 end

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -529,6 +529,24 @@ for name, case in pairs(simple_operation_cases) do
         t.assert_le(changed_after.latency, ok_latency_max,
             'Changed latency has appropriate value')
 
+        local ok_average_max = math.max(changed_before.latency_average, after_finish - before_start)
+
+        t.assert_gt(changed_after.latency_average, 0,
+            'Changed average has appropriate value')
+        t.assert_le(changed_after.latency_average, ok_average_max,
+            'Changed average has appropriate value')
+
+        if g.params.quantiles == true then
+            local ok_quantile_max = math.max(
+                changed_before.latency_quantile_recent or 0,
+                after_finish - before_start)
+
+            t.assert_gt(changed_after.latency_quantile_recent, 0,
+                'Changed quantile has appropriate value')
+            t.assert_le(changed_after.latency_quantile_recent, ok_quantile_max,
+                'Changed quantile has appropriate value')
+        end
+
         local time_diff = changed_after.time - changed_before.time
 
         t.assert_gt(time_diff, 0, 'Total time increase has appropriate value')

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -55,7 +55,10 @@ local function enable_stats(g, params)
         require('crud').cfg{
             stats = true,
             stats_driver = params.driver,
-            stats_quantiles = params.quantiles
+            stats_quantiles = params.quantiles,
+            stats_quantile_tolerated_error = 1e-3,
+            stats_quantile_age_buckets_count = 3,
+            stats_quantile_max_age_time = 60,
         }
     ]], { params })
 end

--- a/test/unit/stats_test.lua
+++ b/test/unit/stats_test.lua
@@ -170,8 +170,24 @@ for name, case in pairs(observe_cases) do
             t.assert_equals(changed.count, run_count, 'Count incremented by count of runs')
 
             local sleep_time = helpers.simple_functions_params().sleep_time
+
             t.assert_ge(changed.latency, sleep_time, 'Latency has appropriate value')
             t.assert_le(changed.latency, time_diffs[#time_diffs], 'Latency has appropriate value')
+
+            t.assert_ge(changed.latency_average, sleep_time, 'Average has appropriate value')
+            t.assert_le(changed.latency_average, time_diffs[#time_diffs], 'Average has appropriate value')
+
+            if g.params.quantiles == true then
+                t.assert_ge(
+                    changed.latency_quantile_recent,
+                    sleep_time,
+                    'Quantile has appropriate value')
+
+                t.assert_le(
+                    changed.latency_quantile_recent,
+                    time_diffs[#time_diffs],
+                    'Quantile has appropriate value')
+            end
 
             t.assert_ge(changed.time, sleep_time * run_count,
                 'Total time increase has appropriate value')
@@ -187,6 +203,7 @@ for name, case in pairs(observe_cases) do
                 {
                     count = 0,
                     latency = 0,
+                    latency_average = 0,
                     time = 0
                 },
                 'Other status collectors initialized after observations'
@@ -387,15 +404,31 @@ for name, case in pairs(pairs_cases) do
 
         t.assert_equals(changed.count, 1, 'Count incremented by 1')
 
-        t.assert_ge(changed.latency,
+        t.assert_ge(
+            changed.latency,
             params.sleep_time * (case.build_sleep_multiplier + case.iterations_expected),
             'Latency has appropriate value')
         t.assert_le(changed.latency, time_diff, 'Latency has appropriate value')
 
+        t.assert_ge(
+            changed.latency_average,
+            params.sleep_time * (case.build_sleep_multiplier + case.iterations_expected),
+            'Average has appropriate value')
+        t.assert_le(changed.latency_average, time_diff, 'Average has appropriate value')
+
+        if g.params.quantiles == true then
+            t.assert_ge(
+                changed.latency_quantile_recent,
+                params.sleep_time * (case.build_sleep_multiplier + case.iterations_expected),
+                'Quantile has appropriate value')
+
+            t.assert_le(changed.latency_quantile_recent, time_diff, 'Quantile has appropriate value')
+        end
+
         t.assert_ge(changed.time,
             params.sleep_time * (case.build_sleep_multiplier + case.iterations_expected),
             'Total time has appropriate value')
-        t.assert_le(changed.time, time_diff, 'Total time  has appropriate value')
+        t.assert_le(changed.time, time_diff, 'Total time has appropriate value')
 
         -- Other collectors (unchanged_coll: 'error' or 'ok')
         -- have been initialized and have default values.
@@ -407,6 +440,7 @@ for name, case in pairs(pairs_cases) do
             {
                 count = 0,
                 latency = 0,
+                latency_average = 0,
                 time = 0
             },
             'Other status collectors initialized after observations'


### PR DESCRIPTION
### doc: fix quantile tolerated error description

### stats: make quantile age params configurable

The main motivation of making these parameters configurable is to be
able to write time-adequate test cases for #286 issue, but they may be
useful in getting rid of #286 effect at all or in quantile time window
calibration.

After this patch, statistics summary quantile aging params
`age_bucket_count` and `max_age_time` [1] could be configured:
```lua
crud.cfg{
    stats_quantile_age_bucket_count = 3,
    stats_quantile_max_age_time = 30,
}
```

Only type validation is conducted in crud.cfg, every other validation is
performed by metrics itself.

1. https://www.tarantool.io/ru/doc/latest/book/monitoring/api_reference/#summary

### stats: separate quantile and average fields

Add separate quantile (`latency_quantile_recent`) and average (
`latency_average`) fields to `crud.stats()` output. `latency` field and
tarantool/metrics output remains unchanged.

Before this patch, `latency` displayed `latency_quantile_recent` or
`latency_average` and there wasn't any was to see pre-computed average
if quantiles are enabled. But it may be useful if quantile is `nan`.

Quantiles may display `-nan` if there were no observations for a several
ages. Such behavior is expected [1] and valid: for example, Grafana
should ignore such values and they will be displayed as `No data` for
a window when there wasn't any requests.

1. https://github.com/tarantool/metrics/issues/303

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #286
