### PR TITLE
Add module version constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ luacov.report.out
 luacov.stats.out
 build/*.cmake
 build/Makefile
+.history
+crud/VERSION.lua
+Makefile
+CTestTestfile.cmake
+cmake_install.cmake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* crud.VERSION constant to make it possible to determine crud module
+  version application runs on in runtime
+
 ### Changed
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,26 @@ file(GLOB_RECURSE LUA_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/cartridge/roles/*.lua"
 )
 
+## VERSION ####################################################################
+###############################################################################
+
+execute_process(
+  COMMAND git describe --tags --always
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE GIT_DESCRIBE
+  ERROR_QUIET
+)
+
+if (NOT GIT_DESCRIBE)
+  set(GIT_DESCRIBE "unknown")
+endif()
+
+configure_file (
+  "${PROJECT_SOURCE_DIR}/crud/VERSION.lua.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/crud/VERSION.lua"
+)
+
 ## Testing ####################################################################
 ###############################################################################
 
@@ -78,6 +98,7 @@ endif()
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}
+  PATTERN "*.in" EXCLUDE
 )
 
 install(

--- a/README.md
+++ b/README.md
@@ -835,6 +835,12 @@ support preserving stats between role reload
 (see [tarantool/metrics#334](https://github.com/tarantool/metrics/issues/334)),
 thus this feature will be unsupported for `metrics` driver.
 
+### VERSION
+
+`VERSION` - is a crud module version constant.
+
+Use `crud.VERSION` on "routers" to get module version, or `_crud.VERSION` - on storages.
+
 ## Cartridge roles
 
 `cartridge.roles.crud-storage` is a Tarantool Cartridge role that depends on the

--- a/crud.lua
+++ b/crud.lua
@@ -20,6 +20,13 @@ local stats = require('crud.stats')
 
 local crud = {}
 
+local ok, VERSION = pcall(require, 'crud.VERSION')
+if not ok then
+    VERSION = 'unknown'
+end
+
+crud.VERSION = VERSION
+
 --- CRUD operations.
 -- @section crud
 
@@ -123,6 +130,7 @@ function crud.init_storage()
         rawset(_G, '_crud', {})
     end
 
+    _G._crud.VERSION = VERSION
     insert.init()
     get.init()
     replace.init()

--- a/crud/VERSION.lua.in
+++ b/crud/VERSION.lua.in
@@ -1,0 +1,3 @@
+#!/usr/bin/env tarantool
+
+return "@GIT_DESCRIBE@"

--- a/test/unit/version_test.lua
+++ b/test/unit/version_test.lua
@@ -1,0 +1,57 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g = t.group('version')
+
+local helpers = require('test.helper')
+
+g.before_all = function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_say_hi'),
+        use_vshard = true,
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                alias = 'router',
+                roles = { 'crud-router' },
+                servers = {
+                    { instance_uuid = helpers.uuid('a', 1), alias = 'router' },
+                },
+            },
+            {
+                uuid = helpers.uuid('b'),
+                alias = 's-1',
+                roles = { 'crud-storage' },
+                servers = {
+                    { instance_uuid = helpers.uuid('b', 1), alias = 's1-master' },
+                    { instance_uuid = helpers.uuid('b', 2), alias = 's1-replica' },
+                },
+            },
+            {
+                uuid = helpers.uuid('c'),
+                alias = 's-2',
+                roles = { 'crud-storage' },
+                servers = {
+                    { instance_uuid = helpers.uuid('c', 1), alias = 's2-master' },
+                    { instance_uuid = helpers.uuid('c', 2), alias = 's2-replica' },
+                },
+            }
+        },
+    })
+    g.cluster:start()
+end
+
+g.after_all = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+g.test_version = function()
+    local handle = io.popen('git describe --tags --always')
+    local version = handle:read("*a"):gsub('\n*', '')
+    handle:close()
+    t.assert_equals(g.cluster.main_server.net_box:eval('return crud.VERSION'), version)
+    t.assert_equals(g.cluster.servers[2].net_box:eval('return _crud.VERSION'), version)
+    t.assert_equals(g.cluster.servers[3].net_box:eval('return _crud.VERSION'), version)
+end


### PR DESCRIPTION
add crud.VERSION (_crud.VERSION) constant to make possible to determine module version in runtime.

I didn't forget about

- [X] Tests
- [X] Changelog
- [X] Documentation

Closes #240
