### PR TITLE
test: fix timeout error message for 2.10.0-rc1

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -488,4 +488,25 @@ function helpers.count_on_replace_triggers(server, space_name)
     ]], {space_name})
 end
 
+-- 'Timeout exceeded' or 'timed out'.
+--
+-- See https://github.com/tarantool/tarantool/pull/6538.
+function helpers.assert_timeout_error(value, message)
+    t.assert_type(value, 'string', nil, 2)
+
+    local err_1 = 'Timeout exceeded'
+    local err_2 = 'timed out'
+
+    if string.find(value, err_1) or string.find(value, err_2) then
+        return
+    end
+
+    local err = string.format('Could not find %q or %q in string %q', err_1,
+        err_2, value)
+    if message ~= nil then
+        err = message .. '\n' .. err
+    end
+    error(err, 2)
+end
+
 return helpers

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -141,7 +141,7 @@ g.test_timeout = function()
 
     t.assert_equals(results, nil)
     t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-000000000000", true)
-    t.assert_str_contains(err.err, "Timeout exceeded")
+    helpers.assert_timeout_error(err.err)
 end
 
 local function check_single_vshard_call(g, exp_vshard_call, opts)
@@ -272,5 +272,5 @@ g.test_any_vshard_call_timeout = function()
 
     t.assert_equals(results, nil)
     t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-000000000000", true)
-    t.assert_str_contains(err.err, "Timeout exceeded")
+    helpers.assert_timeout_error(err.err)
 end


### PR DESCRIPTION
Otherwise the test cases fail on tarantool 2.10.0-beta2-165-gc463e56b9
and newer.

See https://github.com/tarantool/tarantool/pull/6538.