### PR TITLE
Tiny documentation enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ luacov.report.out
 luacov.stats.out
 build/*.cmake
 build/Makefile
+
+# Vim Swap files.
+.*.s[a-w][a-z]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/tarantool/crud/badge.svg?branch=master)](https://coveralls.io/github/tarantool/crud?branch=master)
 
 The `CRUD` module allows to perform CRUD operations on the cluster.
-It also provides the `crud-storage` role for
+It also provides the `crud-storage` and `crud-router` roles for
 [Tarantool Cartridge](https://github.com/tarantool/cartridge).
 
 ## API

--- a/README.md
+++ b/README.md
@@ -8,6 +8,35 @@ The `CRUD` module allows to perform CRUD operations on the cluster.
 It also provides the `crud-storage` and `crud-router` roles for
 [Tarantool Cartridge](https://github.com/tarantool/cartridge).
 
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [API](#api)
+  - [Insert](#insert)
+  - [Get](#get)
+  - [Update](#update)
+  - [Delete](#delete)
+  - [Replace](#replace)
+  - [Upsert](#upsert)
+  - [Select](#select)
+    - [Select conditions](#select-conditions)
+  - [Pairs](#pairs)
+  - [Min and max](#min-and-max)
+  - [Cut extra rows](#cut-extra-rows)
+  - [Cut extra objects](#cut-extra-objects)
+  - [Truncate](#truncate)
+  - [Len](#len)
+  - [Count](#count)
+  - [Call options for crud methods](#call-options-for-crud-methods)
+  - [Statistics](#statistics)
+- [Cartridge roles](#cartridge-roles)
+  - [Usage](#usage)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## API
 
 The CRUD operations should be called from router.

--- a/doc/pairs.md
+++ b/doc/pairs.md
@@ -5,6 +5,20 @@ The arguments are the same as [``crud.select``](https://github.com/tarantool/cru
 Below are examples that may help you.
 Examples schema is similar to the [select documentation](select.md/#examples-space-format)
 
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Getting space](#getting-space)
+- [``use_tomap`` parameter](#use_tomap-parameter)
+- [Pagination](#pagination)
+- [Lua Fun](#lua-fun)
+- [`fields` parameter](#fields-parameter)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 ## Getting space
 
 Let's check ``developers`` space contents to make other examples more clear. Just select first 4 values without conditions.

--- a/doc/select.md
+++ b/doc/select.md
@@ -1,5 +1,27 @@
 # Select examples
 
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Filtering](#filtering)
+  - [Examples schema](#examples-schema)
+  - [Getting space](#getting-space)
+  - [Select using index](#select-using-index)
+  - [Select using composite index](#select-using-composite-index)
+  - [Select using partial key](#select-using-partial-key)
+  - [Select using non-indexed field](#select-using-non-indexed-field)
+  - [Avoiding full scan](#avoiding-full-scan)
+- [Pagination](#pagination)
+  - [``first`` parameter](#first-parameter)
+  - [``after`` parameter](#after-parameter)
+  - [Combine ``first`` and ``after``](#combine-first-and-after)
+  - [Reverse pagination](#reverse-pagination)
+- [`fields` parameter](#fields-parameter)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Filtering
 
 ``CRUD`` allows to filter tuples by conditions. Each condition can use field name (or number) or index name. The first condition that uses index name is used to iterate over space. If there is no conditions that match index names, full scan is performed. Other conditions are used as additional filters. Search condition for the indexed field must be placed first to avoid a full scan.


### PR DESCRIPTION
- Added forgotten `crud-router` mention.
- Added tables of contents (using [doctoc](https://github.com/thlorenz/doctoc)).
- Added Vim Swap files into .gitignore.