### PR TITLE
Release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.11.2] - 23-05-22
+
+### Added
 * Make metrics quantile collector age params configurable (#286).
 * Add separate `latency_average` and `latency_quantile_recent`
   fields to `crud.stats()` output (#286).
-
-### Changed
 
 ### Fixed
 * Preset `stats_quantile_tolerated_error` `crud.cfg` parameter is no


### PR DESCRIPTION
### Overview

This is a bugfix release. Several things related to crud
statistics (0.11.0 and 0.11.1 release features) was improved or
fixed.

### Breaking changes

There are no breaking changes in the release.

### New features

- Make metrics quantile collector age params configurable (#286).

- Add separate `latency_average` and `latency_quantile_recent`
  fields to `crud.stats()` output (#286).

### Bugfixes

- Preset `stats_quantile_tolerated_error` `crud.cfg` parameter is no
  more lost on configuration update (#284).

I didn't forget about

- Tests
- [x] Changelog
- Documentation
