### PR TITLE
Fix crud.select() + after behavior problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - [6, 1064, 'Alexey', 'Sidorov', 31]
   ...
 
+* `crud.select()` results order with negative `first`.
+
 ## [0.11.2] - 23-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+* Optimize `crud.select()` without conditions and with `after`.
 
 ### Fixed
 * `crud.select()` if a condition is '<=' and it's value < `after`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - [1, 477, 'Alexey', 'Adams', 20]
   ...
 
+* `crud.select()` filtration by a first condition if the condition is '>'
+  or '>=' and it's value > `after`.
+
+  Before this patch:
+
+  tarantool> crud.select('developers', {{'>=', 'id', 5}}, {first = 10, after = rows[2]}).rows
+  ---
+  - - [3, 2804, 'Pavel', 'Adams', 27]
+    - [4, 1161, 'Mikhail', 'Liston', 51]
+    - [5, 1172, 'Dmitry', 'Jacobi', 16]
+    - [6, 1064, 'Alexey', 'Sidorov', 31]
+  ...
+
+  After this patch:
+
+  tarantool> crud.select('developers', {{'>=', 'id', 5}}, {first = 10, after = rows[2]}).rows
+  ---
+    - [5, 1172, 'Dmitry', 'Jacobi', 16]
+    - [6, 1064, 'Alexey', 'Sidorov', 31]
+  ...
+
 ## [0.11.2] - 23-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,40 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ...
 
 * `crud.select()` results order with negative `first`.
+* `crud.select()` if a condition is '=' or '==' with negative `first`.
+
+  Suppose we have a non-unique secondary index by the field `age` field and a
+  space:
+
+  tarantool> crud.select('developers', nil, {first = 10})
+  ---
+  - metadata: [{'name': 'id', 'type': 'unsigned'}, {'name': 'bucket_id', 'type': 'unsigned'},
+      {'name': 'name', 'type': 'string'}, {'name': 'surname', 'type': 'string'}, {'name': 'age',
+        'type': 'number'}]
+    rows:
+    - [1, 477, 'Alexey', 'Adams', 20]
+    - [2, 401, 'Sergey', 'Allred', 27]
+    - [3, 2804, 'Pavel', 'Adams', 27]
+    - [4, 1161, 'Mikhail', 'Liston', 27]
+    - [5, 1172, 'Dmitry', 'Jacobi', 27]
+    - [6, 1064, 'Alexey', 'Sidorov', 31]
+  - null
+  ...
+
+  Before this patch:
+
+  tarantool> crud.select('developers', {{'=', 'age', 27}}, {first = -10, after = rows[4]}).rows
+  ---
+  - []
+  ...
+
+  After this patch:
+
+  tarantool> crud.select('developers', {{'=', 'age', 27}}, {first = -10, after = rows[4]}).rows
+  ---
+  - - [2, 401, 'Sergey', 'Allred', 27]
+    - [3, 2804, 'Pavel', 'Adams', 27]
+  ...
 
 ## [0.11.2] - 23-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+* `crud.select()` if a condition is '<=' and it's value < `after`.
+
+  Before this patch:
+
+  tarantool> crud.select('developers', {{'<=', 'id', 3}}, {first = 10, after = rows[5]}).rows
+  ---
+  - - [2, 401, 'Sergey', 'Allred', 21]
+    - [1, 477, 'Alexey', 'Adams', 20]
+  ...
+
+  After this patch:
+
+  tarantool> crud.select('developers', {{'<=', 'id', 3}}, {first = 10, after = rows[5]}).rows
+  ---
+  - - [3, 2804, 'Pavel', 'Adams', 27]
+    - [2, 401, 'Sergey', 'Allred', 21]
+    - [1, 477, 'Alexey', 'Adams', 20]
+  ...
 
 ## [0.11.2] - 23-05-22
 

--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ where:
 * `conditions` (`?table`) - array of [select conditions](#select-conditions)
 * `opts`:
   * `first` (`?number`) - the maximum count of the objects to return.
-     If negative value is specified, the last objects are returned
-     (`after` option is required in this case).
+     If negative value is specified, the objects behind `after` are returned
+     (`after` option is required in this case). [See pagination examples](doc/select.md#pagination).
   * `after` (`?table`) - tuple after which objects should be selected
   * `batch_size` (`?number`) - number of tuples to process per one request to storage
   * `bucket_id` (`?number|cdata`) - bucket ID

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -455,7 +455,7 @@ function utils.invert_tarantool_iter(iter)
 end
 
 function utils.reverse_inplace(t)
-    for i = 1,#t - 1 do
+    for i = 1,math.floor(#t / 2) do
         t[i], t[#t - i + 1] = t[#t - i + 1], t[i]
     end
     return t

--- a/crud/compare/plan.lua
+++ b/crud/compare/plan.lua
@@ -269,7 +269,7 @@ function plan.new(space, conditions, opts)
         if scan_iter == box.index.EQ then
             scan_iter = box.index.GE
         elseif scan_iter == box.index.REQ then
-            scan_iter = box.index.LT
+            scan_iter = box.index.LE
         end
     end
 

--- a/crud/compare/plan.lua
+++ b/crud/compare/plan.lua
@@ -266,9 +266,7 @@ function plan.new(space, conditions, opts)
     -- Moreover, for correct pagination we change iterator
     -- to continue iterating in direct and reverse order.
     if scan_after_tuple ~= nil then
-        if scan_iter == box.index.LE then
-            scan_iter = box.index.LT
-        elseif scan_iter == box.index.EQ then
+        if scan_iter == box.index.EQ then
             scan_iter = box.index.GE
         elseif scan_iter == box.index.REQ then
             scan_iter = box.index.LT

--- a/crud/select/executor.lua
+++ b/crud/select/executor.lua
@@ -42,9 +42,11 @@ end
 local generate_value
 
 if has_keydef then
-    generate_value = function(after_tuple, scan_value, index_parts)
+    generate_value = function(after_tuple, scan_value, index_parts, tarantool_iter)
+        local cmp_operator = select_comparators.get_cmp_operator(tarantool_iter)
         local key_def = keydef_lib.new(index_parts)
-        if key_def:compare_with_key(after_tuple, scan_value) < 0 then
+        local cmp = key_def:compare_with_key(after_tuple, scan_value)
+        if (cmp_operator == '<' and cmp < 0) or (cmp_operator == '>' and cmp > 0) then
             return key_def:extract_key(after_tuple)
         end
     end

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -579,7 +579,10 @@ pgroup.test_eq_condition_with_index = function(g)
         },{
             id = 7, name = "Jack", last_name = "Sparrow",
             age = 33, city = "Chicago",
-        },
+        }, {
+            id = 8, name = "Nick", last_name = "Smith",
+            age = 20, city = "London",
+        }
     })
 
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
@@ -602,6 +605,51 @@ pgroup.test_eq_condition_with_index = function(g)
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {5, 7})) -- in id order
+
+    -- after obj 5 with negative first
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', conditions, {after=after, first=-10}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1, 3})) -- in id order
+
+    -- after obj 8
+    local after = crud_utils.flatten(customers[8], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', conditions, {after=after, first=10}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1, 3, 5, 7})) -- in id order
+
+    -- after obj 8 with negative first
+    local after = crud_utils.flatten(customers[8], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', conditions, {after=after, first=-10}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {}))
+
+    -- after obj 2
+    local after = crud_utils.flatten(customers[2], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', conditions, {after=after, first=10}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {}))
+
+    -- after obj 2 with negative first
+    local after = crud_utils.flatten(customers[2], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+        'crud.select', {'customers', conditions, {after=after, first=-10}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1, 3, 5, 7})) -- in id order
 end
 
 pgroup.test_ge_condition_with_index = function(g)

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -206,15 +206,15 @@ pgroup.test_negative_first = function(g)
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
     -- no conditions
-    -- first -3 after 5
-    local first = -3
-    local after = crud_utils.flatten(customers[5], g.space_format)
+    -- first -4 after 6
+    local first = -4
+    local after = crud_utils.flatten(customers[6], g.space_format)
     local result, err = g.cluster.main_server.net_box:call(
        'crud.select', {'customers', nil, {first=first, after=after}})
 
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
-    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2, 3, 4}))
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2, 3, 4, 5}))
 
     -- id >= 2
     -- first -2 after 5

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -273,6 +273,94 @@ pgroup.test_negative_first = function(g)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {6}))
 end
 
+pgroup.test_positive_first = function(g)
+    local customers = helpers.insert_objects(g, 'customers', {
+        {
+            id = 1, name = "Elizabeth", last_name = "Jackson",
+            age = 11, city = "New York",
+        }, {
+            id = 2, name = "Mary", last_name = "Brown",
+            age = 22, city = "Los Angeles",
+        }, {
+            id = 3, name = "David", last_name = "Smith",
+            age = 33, city = "Los Angeles",
+        }, {
+            id = 4, name = "William", last_name = "White",
+            age = 44, city = "Chicago",
+        }, {
+            id = 5, name = "Jack", last_name = "Sparrow",
+            age = 55, city = "London",
+        }, {
+            id = 6, name = "William", last_name = "Terner",
+            age = 66, city = "Oxford",
+        }, {
+            id = 7, name = "Elizabeth", last_name = "Swan",
+            age = 77, city = "Cambridge",
+        }, {
+            id = 8, name = "Hector", last_name = "Barbossa",
+            age = 88, city = "London",
+        },
+    })
+
+    table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
+
+    -- id >= 3
+    -- first 10 after 5
+    local conditions = {
+        {'>=', 'id', 3},
+    }
+    local first = 10
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {6, 7, 8}))
+
+    -- id <= 3
+    -- first 10 after 5
+    local conditions = {
+        {'<=', 'id', 3},
+    }
+    local first = 10
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {3, 2, 1}))
+
+    -- id <= 6
+    -- first 10 after 5
+    local conditions = {
+        {'<=', 'id', 6},
+    }
+    local first = 10
+    local after = crud_utils.flatten(customers[5], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4, 3, 2, 1}))
+
+    -- id >= 6
+    -- first 10 after 2
+    local conditions = {
+        {'>=', 'id', 6},
+    }
+    local first = 10
+    local after = crud_utils.flatten(customers[2], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call(
+       'crud.select', {'customers', conditions, {first=first, after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {6, 7, 8}))
+end
+
 pgroup.test_negative_first_with_batch_size = function(g)
     local customers = helpers.insert_objects(g, 'customers', {
         {

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -592,6 +592,14 @@ pgroup.test_le_condition_with_index = function(g)
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1})) -- in age order
+
+    -- after obj 2
+    local after = crud_utils.flatten(customers[2], g.space_format)
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions, {after=after}})
+
+    t.assert_equals(err, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {3, 1})) -- in age order
 end
 
 pgroup.test_lt_condition_with_index = function(g)

--- a/test/unit/reverse_inplace_test.lua
+++ b/test/unit/reverse_inplace_test.lua
@@ -1,0 +1,24 @@
+local t = require('luatest')
+local g = t.group('utils')
+
+local utils = require('crud.common.utils')
+
+local reverse_inplace_cases = {
+    single_value = {1},
+    two_values = {1, 2},
+    three_values = {1, 2, 3},
+    four_values = {1, 2, 3, 4},
+    uneven_values = {1, 2, 3, 4, 5, 6, 7, 8, 9},
+    even_values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+}
+
+for case_name, case in pairs(reverse_inplace_cases) do
+    g["test_reverse_inplace_" .. case_name] = function()
+        local case_reversed = {}
+        for i=#case,1,-1 do
+            table.insert(case_reversed, case[i])
+        end
+        case = utils.reverse_inplace(case)
+        t.assert_equals(case, case_reversed)
+    end
+end

--- a/test/unit/select_plan_test.lua
+++ b/test/unit/select_plan_test.lua
@@ -276,7 +276,7 @@ g.test_first = function()
     t.assert_equals(plan.scan_value, {90}) -- after_tuple id
     t.assert_equals(plan.after_tuple, after_tuple)
     t.assert_equals(plan.scan_condition_num, 1)
-    t.assert_equals(plan.tarantool_iter, box.index.GE) -- inverted iterator
+    t.assert_equals(plan.tarantool_iter, box.index.EQ)
     t.assert_equals(plan.total_tuples_count, 10)
     t.assert_equals(plan.sharding_key, nil)
     t.assert_equals(plan.field_names, nil)

--- a/test/unit/select_plan_test.lua
+++ b/test/unit/select_plan_test.lua
@@ -254,7 +254,7 @@ g.test_first = function()
     t.assert_equals(plan.scan_value, {777}) -- after_tuple id
     t.assert_equals(plan.after_tuple, after_tuple)
     t.assert_equals(plan.scan_condition_num, nil)
-    t.assert_equals(plan.tarantool_iter, box.index.LT) -- inverted iterator
+    t.assert_equals(plan.tarantool_iter, box.index.LE) -- inverted iterator
     t.assert_equals(plan.total_tuples_count, 10)
     t.assert_equals(plan.sharding_key, nil)
     t.assert_equals(plan.field_names, nil)


### PR DESCRIPTION
It seems to me that now there are logical errors with `select` + `after`:

1. Always a smaller key is choosed to start the `select` when has_keydef.
2. Unsymmetric behavior on ascending and descending order with ER/REQ. 
3. `select(nil)` + `after` always traverse to the `after` from beginning.

The patch fixes the problems.
