### PR TITLE
Fix crud delete error message

### DIFF
--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -120,7 +120,7 @@ local function call_delete_on_router(space_name, key, opts)
     )
 
     if err ~= nil then
-        local err_wrapped = DeleteError:new("Failed to call delete on storage-side: %s")
+        local err_wrapped = DeleteError:new("Failed to call delete on storage-side: %s", err)
 
         if sharding.result_needs_sharding_reload(err) then
             return nil, err_wrapped, const.NEED_SHARDING_RELOAD


### PR DESCRIPTION
Fix minor issue in CRUD delete message format:
```
- null
- line: 123
  class_name: DeleteError
  err: 'Failed to call delete on storage-side: %s'
  file: '...rtridge_app/myapp/.rocks/share/tarantool/crud/delete.lua'
  str: 'DeleteError: Failed to call delete on storage-side: %s'
```

After the fix:
```
- null
- line: 123
  class_name: DeleteError
  err: "Failed to call delete on storage-side: CallError: Failed for 50b73728-f3e5-4363-bfaa-011beef0d20c:
    Function returned an error: NotInitialized: crud isn't initialized on replicaset:
. . . 
```