### PR TITLE
Make CRUD select error message more clearer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   an user can explicitly request a full scan through by passing `fullscan=true`
   to `select` or `count` options table argument in which a case a log entry will
   not be created (#276).
+* Make select error description more informative when merger
+  built-in module or tuple-merger external module is used
+  in case of disabled/uninit storage (#229).
 
 ### Fixed
 * `crud.select()` if a condition is '<=' and it's value < `after`.

--- a/crud/select/merger.lua
+++ b/crud/select/merger.lua
@@ -11,6 +11,7 @@ local merger_lib = compat.require('tuple.merger', 'merger')
 
 local Keydef = require('crud.compare.keydef')
 local stats = require('crud.stats')
+local utils = require("crud.common.utils")
 
 local function bswap_u16(num)
     return bit.rshift(bit.bswap(tonumber(num)), 16)
@@ -113,7 +114,8 @@ local function fetch_chunk(context, state)
     -- Wait for requested data.
     local res, err = future:wait_result(timeout)
     if res == nil then
-        error(err)
+        local wrapped_err = errors.wrap(utils.update_storage_call_error_description(err, func_name, replicaset.uuid))
+        error(wrapped_err)
     end
 
     -- Decode metainfo, leave data to be processed by the merger.


### PR DESCRIPTION
There is a difference between error description for select and other CRUD calls in case of CRUD storage unavailability.
```
crud.get('profile', 1)
---
- null
- line: 128
  class_name: GetError
  err: "Failed to call get on storage-side: CallError: Failed for 50b73728-f3e5-4363-bfaa-011beef0d20c:
    Function returned an error: NotInitialized: crud isn't initialized on replicaset:
    \"nil\"\nstack traceback:\n\t...ge_app/myapp/.rocks/share/tarantool/crud/common/call.lua:52:
```
```
crud.select('profile')
---
- null
- line: 173
  class_name: SelectError
  err: Procedure '_crud.select_on_storage' is not defined
  file: '...app/.rocks/share/tarantool/crud/common/sharding/init.lua'
  stack: "stack traceback:\n\t...app/.rocks/share/tarantool/crud/common/sharding/init.lua:173:
```

The select error description does not give any clues what might be the cause of this error.
Here is the updated error text:
```
crud.get('profile', 1)
---
- null
- line: 128
  class_name: GetError
  err: "Failed to call get on storage-side: CallError: Failed for 50b73728-f3e5-4363-bfaa-011beef0d20c:
    Function returned an error: NotInitialized: crud isn't initialized on replicaset:
    \"50b73728-f3e5-4363-bfaa-011beef0d20c\"\nstack traceback:\n\t...e_app/myapp/.rocks/share/tarantool/crud/common/utils.lua:701:
```
```
crud.select('profile')
---
- null
- line: 173
  class_name: SelectError
  err: "NotInitialized: crud isn't initialized on replicaset: \"50b73728-f3e5-4363-bfaa-011beef0d20c\"\nstack
    traceback:\n\t...e_app/myapp/.rocks/share/tarantool/crud/common/utils.lua:701:
```
The new error description for select also contains information about replicaset id.
Additionally, nil replicaset id is fixed in error messages for single calls: get, delete, etc.

See also #229 