### PR TITLE
Release 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+
+### Fixed
+
+## [0.11.3] - 15-06-22
+
+### Changed
 * Optimize `crud.select()` without conditions and with `after`.
 * Behaviour of potentially long `select` and `count` calls: a critical log entry
   containing the current stack traceback is created upon such function calls —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Behaviour of potentially long `select` and `count` calls: a critical log entry
   containing the current stack traceback is created upon such function calls —
   an user can explicitly request a full scan through by passing `fullscan=true`
-  to `select` or `count` options table argument in which a case a log entry will
+  to `select` or `count` options table argument in which case a log entry will
   not be created (#276).
 * Make select error description more informative when merger
   built-in module or tuple-merger external module is used


### PR DESCRIPTION
### Overview

This is a bugfix release. Several cases of pagination using select
with after was fixed or improved. Warning has been added to
potentially long select and count calls. Storage select errors
were reworked to be consistent with other calls errors.

### Breaking changes

There are no breaking changes in the release.

### New features

* Optimize `crud.select()` without conditions and with
  `after` (PR #295).

* A critical log entry containing the current stack traceback is
  created upon potentially long `select` and `count` calls —
  an user can explicitly request a full scan through by passing
  `fullscan=true` to `select` or `count` options table argument
  in which case a log entry will not be created (#276).

### Bugfixes

* Make select error description more informative when merger
  built-in module or tuple-merger external module is used
  in case of disabled/uninit storage (#229).

* `crud.select()` if a condition is '<=' and it's
  value < `after` (PR #295).

  Previous releases:
  
  ```
  tarantool> crud.select('developers',
           > {{'<=', 'id', 3}}, {first = 10, after = rows[5]}).rows
  ---
  - - [2, 401, 'Sergey', 'Allred', 21]
    - [1, 477, 'Alexey', 'Adams', 20]
  ...
  ```
  
  After this release:
  
  ```
  tarantool> crud.select('developers',
           > {{'<=', 'id', 3}}, {first = 10, after = rows[5]}).rows
  ---
  - - [3, 2804, 'Pavel', 'Adams', 27]
    - [2, 401, 'Sergey', 'Allred', 21]
    - [1, 477, 'Alexey', 'Adams', 20]
  ...
  ```

* `crud.select()` filtration by a first condition if the condition
  is '>' or '>=' and it's value > `after` (PR #295).
  
  Previous releases:
  
  ```
  tarantool> crud.select('developers',
           > {{'>=', 'id', 5}}, {first = 10, after = rows[2]}).rows
  ---
  - - [3, 2804, 'Pavel', 'Adams', 27]
    - [4, 1161, 'Mikhail', 'Liston', 51]
    - [5, 1172, 'Dmitry', 'Jacobi', 16]
    - [6, 1064, 'Alexey', 'Sidorov', 31]
  ...
  ```
  
  After this release:
  
  ```
  tarantool> crud.select('developers',
           > {{'>=', 'id', 5}}, {first = 10, after = rows[2]}).rows
  ---
    - [5, 1172, 'Dmitry', 'Jacobi', 16]
    - [6, 1064, 'Alexey', 'Sidorov', 31]
  ...
  ```

* `crud.select()` results order with negative `first` (PR #295).
* `crud.select()` if a condition is '=' or '==' with
  negative `first` (PR #295).
  
  Suppose we have a non-unique secondary index by the field `age`
  field and a space:
  
  ```
  tarantool> crud.select('developers', nil, {first = 10})
  ---
  - metadata: [{'name': 'id', 'type': 'unsigned'},
      {'name': 'bucket_id', 'type': 'unsigned'},
      {'name': 'name', 'type': 'string'},
      {'name': 'surname', 'type': 'string'},
      {'name': 'age', 'type': 'number'}]
    rows:
    - [1, 477, 'Alexey', 'Adams', 20]
    - [2, 401, 'Sergey', 'Allred', 27]
    - [3, 2804, 'Pavel', 'Adams', 27]
    - [4, 1161, 'Mikhail', 'Liston', 27]
    - [5, 1172, 'Dmitry', 'Jacobi', 27]
    - [6, 1064, 'Alexey', 'Sidorov', 31]
  - null
  ...
  ```
  
  Previous releases:
  
  ```
  tarantool> crud.select('developers',
           > {{'=', 'age', 27}}, {first = -10, after = rows[4]}).rows
  ---
  - []
  ...
  ```
  
  After this release:
  
  ```
  tarantool> crud.select('developers',
           > {{'=', 'age', 27}}, {first = -10, after = rows[4]}).rows
  ---
  - - [2, 401, 'Sergey', 'Allred', 27]
    - [3, 2804, 'Pavel', 'Adams', 27]
  ...
  ```