### PR TITLE
ci: add testing against tarantool-2.10

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # We need 1.10.6 here to check that module works with
         # old Tarantool versions that don't have "tuple-keydef"/"tuple-merger" support.
-        tarantool-version: ["1.10.6", "1.10", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+        tarantool-version: ["1.10.6", "1.10", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.10"]
         metrics-version: [""]
         remove-merger: [false]
         include:


### PR DESCRIPTION
Tarantool 2.10.0 was released in May 2022 (see https://github.com/tarantool/tarantool/releases/tag/2.10.0). The setup-tarantool action supports tarantool-2.10+ since June 2022 (see https://github.com/tarantool/setup-tarantool/releases/tag/v1.3.0). July 2022 is now and it is good time to add testing on tarantool 2.10 for the module.


