### PR TITLE
ddl: fix record delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * Fetching invalid ddl confuguration (sharding key for non-existing space)
   is no longer breaks CRUD requests (#308, PR #309).
+* ddl space record delete no more throws error if crud is used (#310, PR #311).
+* crud sharding metainfo is now updated on ddl record delete (#310, PR #311).
 
 ## [0.12.0] - 28-06-22
 


### PR DESCRIPTION
Before this patch and after introducing sharding info hash cache [1] calling delete on "_ddl_sharding_info" and "_ddl_sharding_func" spaces resulted in "attempt to index local 'tuple' (a nil value)" trigger error. This patch fixes the trigger. If sharding info record is deleted, corresponding cache section will be deleted as well.

1. https://github.com/tarantool/crud/commit/428744d6f47a625142fa61e15e80e475b8b1d018

I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation

Closes #310
