### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
-* Fetching invalid ddl confuguration (sharding key for non-existing space)
+* Fetching invalid ddl configuration (sharding key for non-existing space)
   is no longer breaks CRUD requests (#308, PR #309).
 * ddl space record delete no more throws error if crud is used (#310, PR #311).
 * crud sharding metainfo is now updated on ddl record delete (#310, PR #311).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+
+## [0.12.1] - 21-07-22
+
+### Fixed
 * Fetching invalid ddl configuration (sharding key for non-existing space)
   is no longer breaks CRUD requests (#308, PR #309).
 * ddl space record delete no more throws error if crud is used (#310, PR #311).


### PR DESCRIPTION
# 0.12.1

## Overview

This is a bugfix release. It introduces several fixes related to crud and
ddl module integration.

## Breaking changes

There are no breaking changes in the release.

## Bugfixes

* Fetching invalid ddl configuration (sharding key for non-existing space) is no longer breaks CRUD requests (#308, PR #309).
* ddl space record delete no more throws error if crud is used (#310, PR #311).
* crud sharding metainfo is now updated on ddl record delete (#310, PR #311).


I didn't forget about

- Tests
- [x] Changelog
-  Documentation
