### PR TITLE
sharding func: fix specifying `vshard` sharding funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix specifying `vshard` sharding funcs (#314).
+
 ## [0.12.1] - 21-07-22
 
 ### Fixed

--- a/deps.sh
+++ b/deps.sh
@@ -27,7 +27,7 @@ rm "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
 rmdir "${TMPDIR}"
 
 tarantoolctl rocks install cartridge 2.7.4
-tarantoolctl rocks install ddl 1.6.0
+tarantoolctl rocks install ddl 1.6.2
 tarantoolctl rocks install migrations 0.4.2
 
 tarantoolctl rocks make

--- a/test/entrypoint/srv_ddl.lua
+++ b/test/entrypoint/srv_ddl.lua
@@ -161,6 +161,14 @@ package.preload['customers-storage'] = function()
             local customers_G_func_schema = table.deepcopy(customers_id_key_schema)
             customers_G_func_schema.sharding_func = 'some_module.sharding_func'
 
+            local customers_empty_sharding_func_schema = table.deepcopy(customers_id_key_schema)
+
+            local customers_vshard_mpcrc32_schema = table.deepcopy(customers_id_key_schema)
+            customers_vshard_mpcrc32_schema.sharding_func = 'vshard.router.bucket_id_mpcrc32'
+
+            local customers_vshard_strcrc32_schema = table.deepcopy(customers_id_key_schema)
+            customers_vshard_strcrc32_schema.sharding_func = 'vshard.router.bucket_id_strcrc32'
+
             local schema = {
                 spaces = {
                     customers = customers_id_schema,
@@ -173,6 +181,9 @@ package.preload['customers-storage'] = function()
                     customers_name_age_key_three_fields_index = customers_name_age_key_three_fields_index_schema,
                     customers_G_func = customers_G_func_schema,
                     customers_body_func = customers_body_func_schema,
+                    customers_empty_sharding_func = customers_empty_sharding_func_schema,
+                    customers_vshard_mpcrc32 = customers_vshard_mpcrc32_schema,
+                    customers_vshard_strcrc32 = customers_vshard_strcrc32_schema,
                 }
             }
 
@@ -188,7 +199,9 @@ package.preload['customers-storage'] = function()
                 box.space['_ddl_sharding_key']:update(space_name, {{'=', fieldno_sharding_key, sharding_key_def}})
             end)
             rawset(_G, 'set_sharding_func', function(space_name, fieldno_sharding_func, sharding_func_def)
-                box.space['_ddl_sharding_func']:update(space_name, {{'=', fieldno_sharding_func, sharding_func_def}})
+                local record = {space_name, box.NULL, box.NULL}
+                record[fieldno_sharding_func] = sharding_func_def
+                box.space['_ddl_sharding_func']:replace(record)
             end)
         end,
     }

--- a/test/integration/ddl_sharding_key_test.lua
+++ b/test/integration/ddl_sharding_key_test.lua
@@ -898,6 +898,7 @@ pgroup.test_update_cache_with_incorrect_key = function(g)
         customers = {parts = {{fieldno = 1}}},
         customers_G_func = {parts = {{fieldno = 1}}},
         customers_body_func = {parts = {{fieldno = 1}}},
+        customers_empty_sharding_func = {parts = {{fieldno = 1}}},
         customers_age_key = {parts = {{fieldno = 4}}},
         customers_name_age_key_different_indexes = {parts = {{fieldno = 3}, {fieldno = 4}}},
         customers_name_age_key_three_fields_index = {parts = {{fieldno = 3}, {fieldno = 4}}},
@@ -905,6 +906,8 @@ pgroup.test_update_cache_with_incorrect_key = function(g)
         customers_name_key_non_uniq_index = {parts = {{fieldno = 3}}},
         customers_name_key_uniq_index = {parts = {{fieldno = 3}}},
         customers_secondary_idx_name_key = {parts = {{fieldno = 3}}},
+        customers_vshard_mpcrc32 = {parts = {{fieldno = 1}}},
+        customers_vshard_strcrc32 = {parts = {{fieldno = 1}}}
     })
 
     -- no error just warning
@@ -925,12 +928,15 @@ pgroup.test_update_cache_with_incorrect_key = function(g)
         customers = {parts = {{fieldno = 1}}},
         customers_G_func = {parts = {{fieldno = 1}}},
         customers_body_func = {parts = {{fieldno = 1}}},
+        customers_empty_sharding_func = {parts = {{fieldno = 1}}},
         customers_age_key = {parts = {{fieldno = 4}}},
         customers_name_age_key_different_indexes = {parts = {{fieldno = 3}, {fieldno = 4}}},
         customers_name_age_key_three_fields_index = {parts = {{fieldno = 3}, {fieldno = 4}}},
         customers_name_key_non_uniq_index = {parts = {{fieldno = 3}}},
         customers_name_key_uniq_index = {parts = {{fieldno = 3}}},
         customers_secondary_idx_name_key = {parts = {{fieldno = 3}}},
+        customers_vshard_mpcrc32 = {parts = {{fieldno = 1}}},
+        customers_vshard_strcrc32 = {parts = {{fieldno = 1}}}
     })
 
     -- get data from cache for space with incorrect sharding key
@@ -951,12 +957,15 @@ pgroup.test_update_cache_with_incorrect_key = function(g)
         customers = {parts = {{fieldno = 1}}},
         customers_G_func = {parts = {{fieldno = 1}}},
         customers_body_func = {parts = {{fieldno = 1}}},
+        customers_empty_sharding_func = {parts = {{fieldno = 1}}},
         customers_age_key = {parts = {{fieldno = 4}}},
         customers_name_age_key_different_indexes = {parts = {{fieldno = 3}, {fieldno = 4}}},
         customers_name_age_key_three_fields_index = {parts = {{fieldno = 3}, {fieldno = 4}}},
         customers_name_key_non_uniq_index = {parts = {{fieldno = 3}}},
         customers_name_key_uniq_index = {parts = {{fieldno = 3}}},
         customers_secondary_idx_name_key = {parts = {{fieldno = 3}}},
+        customers_vshard_mpcrc32 = {parts = {{fieldno = 1}}},
+        customers_vshard_strcrc32 = {parts = {{fieldno = 1}}}
     })
 end
 


### PR DESCRIPTION
Starting from 0.11.0 user can specify sharding func to
calculate bucket_id with sharding func definition as a part of
DDL schema or insert manually to the space `_ddl_sharding_func`.

Right now ddl fails with setting schema with vshard sharding function
(https://github.com/tarantool/ddl/issues/91).
But even if this bug is fixed, there is also a bug on CRUD side.
Inserting manually to the space `_ddl_sharding_func` showed
that CRUD search vshard sharding func in `_G` but this
approach doesn't work with vshard case.

This patch allows to specify `vshard` sharding func
inserting manually to the space `_ddl_sharding_func`.

I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation

Closes #314 
