### PR TITLE
tests: fix call options

### DIFF
--- a/test/integration/count_test.lua
+++ b/test/integration/count_test.lua
@@ -766,7 +766,7 @@ pgroup.test_composite_index = function(g)
     }
 
     -- no after
-    local result, err = g.cluster.main_server.net_box:call('crud.count', {'customers', conditions}, {fullscan = true})
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {'customers', conditions, {fullscan = true}})
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 4)

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -789,7 +789,7 @@ pgroup.test_ge_condition_with_index = function(g)
     }
 
     -- no after
-    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions}, {fullscan = true})
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions, {fullscan = true}})
 
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
@@ -829,7 +829,7 @@ pgroup.test_le_condition_with_index = function(g)
     }
 
     -- no after
-    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions}, {fullscan = true})
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions, {fullscan = true}})
 
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
@@ -962,7 +962,7 @@ pgroup.test_composite_index = function(g)
     }
 
     -- no after
-    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions}, {fullscan = true})
+    local result, err = g.cluster.main_server.net_box:call('crud.select', {'customers', conditions, {fullscan = true}})
 
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)


### PR DESCRIPTION
`{fullscan = true}` option was supposed to be passed to request options
instead of net.box ones. Starting from Tarantool 2.10.1, net.box checks
its options and throws error if illegal parameter is passed [1].

1. https://github.com/tarantool/tarantool/commit/d7da59b4a33c9547da68431a22ee256e50a3df62

I didn't forget about

- [x] Tests
- Changelog (not needed, test update)
- Documentation (not needed, test update)
