### PR TITLE
api: support vshard groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.13.0] - 29-08-22
 
 ### Added
-* `crud.storage_info` function to get storages status (#229, PR #299).
+* `crud.storage_info` function to get storages status (#229).
 
 ### Fixed
 * Fix specifying `vshard` sharding funcs (#314).
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * Fetching invalid ddl configuration (sharding key for non-existing space)
-  is no longer breaks CRUD requests (#308, PR #309).
-* ddl space record delete no more throws error if crud is used (#310, PR #311).
-* crud sharding metainfo is now updated on ddl record delete (#310, PR #311).
+  is no longer breaks CRUD requests (#308).
+* ddl space record delete no more throws error if crud is used (#310).
+* crud sharding metainfo is now updated on ddl record delete (#310).
 
 ## [0.12.0] - 28-06-22
 
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `crud.insert_many()`/`crud.insert_object_many()`/
   `crud.upsert_many()`/`crud.upsert_object_many()`
   `crud.replace_many()`/`crud.replace_object_many()`
-  with partial consistency (#193, PR #232).
+  with partial consistency (#193).
 
 ## [0.11.3] - 15-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* Deprecate using space id in `crud.len` (#255).
+
 ## [0.13.0] - 29-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+* Support `vshard_router` option in operations for Cartridge vshard groups
+  or non-default vshard routers (#44).
+
 ### Changed
 * Deprecate using space id in `crud.len` (#255).
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ where:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `bucket_id` (`?number|cdata`) - bucket ID
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array contains one inserted row, error.
 
@@ -259,6 +262,9 @@ where:
   * `rollback_on_error` (`?boolean`) - any failed operation will lead to
     rollback on a storage, where the operation is failed, report error
     about what tuples were rollback, default is `false`
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array with inserted rows, array of errors.
 Each error object can contain field `operation_data`.
@@ -393,6 +399,9 @@ where:
   * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
     the replicas
   * `balance` (`?boolean`) - use replica according to vshard load balancing policy
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array contains one row, error.
 
@@ -426,6 +435,9 @@ where:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `bucket_id` (`?number|cdata`) - bucket ID
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array contains one updated row, error.
 
@@ -458,6 +470,9 @@ where:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `bucket_id` (`?number|cdata`) - bucket ID
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array contains one deleted row (empty for vinyl), error.
 
@@ -492,6 +507,9 @@ where:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `bucket_id` (`?number|cdata`) - bucket ID
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns inserted or replaced rows and metadata or nil with error.
 
@@ -544,6 +562,9 @@ where:
   * `rollback_on_error` (`?boolean`) - any failed operation will lead to
     rollback on a storage, where the operation is failed, report error
     about what tuples were rollback, default is `false`
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array with inserted/replaced rows, array of errors.
 Each error object can contain field `operation_data`.
@@ -676,6 +697,9 @@ where:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
   * `bucket_id` (`?number|cdata`) - bucket ID
   * `fields` (`?table`) - field names for getting only a subset of fields
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and empty array of rows or nil, error.
 
@@ -733,6 +757,9 @@ where:
   * `rollback_on_error` (`?boolean`) - any failed operation will lead to
     rollback on a storage, where the operation is failed, report error
     about what tuples were rollback, default is `false`
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns metadata and array of errors.
 Each error object can contain field `operation_data`.
@@ -869,6 +896,9 @@ where:
   * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
     the replicas
   * `balance` (`?boolean`) - use replica according to vshard load balancing policy
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 
 Returns metadata and array of rows, error.
@@ -1007,6 +1037,9 @@ where:
 * `space_name` (`string`) - name of the space
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns true or nil with error.
 
@@ -1040,6 +1073,9 @@ where:
 * `space_name` (`string`) - name of the space
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 Returns number or nil with error.
 
@@ -1089,6 +1125,7 @@ where:
 * `opts`:
   * `timeout` (`?number`) -  maximum time (in seconds, default: 2) to wait for response from
   cluster instances.
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or vshard router instance.
 
 Returns storages status table by instance UUID or nil with error. Status table fields:
 * `status` contains a string representing the status:
@@ -1158,6 +1195,9 @@ where:
   * `balance` (`?boolean`) - use replica according to
     [vshard load balancing policy](https://www.tarantool.io/en/doc/latest/reference/reference_rock/vshard/vshard_api/#router-api-call),
     default value is `false`
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
 
 ```lua
 crud.count('customers', {{'==', 'age', 35}})

--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,9 @@ Returns number or nil with error.
 Using space id instead of space name is also possible, but
 deprecated and will be removed in future releases.
 
+Using space id in crud.len and custom vshard_router is not
+supported by statistics: space labels may be inconsistent.
+
 **Example:**
 
 Using `memtx`:

--- a/README.md
+++ b/README.md
@@ -971,7 +971,7 @@ local res, err = crud.cut_rows(rows, metadata, fields)
 where:
 
 * `rows` (`table`) - array of tuples for cutting
-* `matadata` (`?metadata`) - metadata about `rows` fields
+* `metadata` (`?table`) - metadata about `rows` fields
 * `fields` (`table`) - field names of fields that should be contained in the result
 
 Returns metadata and array of rows, error.

--- a/README.md
+++ b/README.md
@@ -1037,12 +1037,14 @@ local result, err = crud.len(space_name, opts)
 
 where:
 
-* `space_name` (`string|number`) - name of the space as well
-  as numerical id of the space
+* `space_name` (`string`) - name of the space
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
 
 Returns number or nil with error.
+
+Using space id instead of space name is also possible, but
+deprecated and will be removed in future releases.
 
 **Example:**
 

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -75,7 +75,9 @@ local function call_get_border_on_router(border_name, space_name, index_name, op
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local replicasets = vshard_router:routeall()
+    local space = utils.get_space(space_name, replicasets)
     if space == nil then
         return nil, BorderError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end
@@ -98,7 +100,6 @@ local function call_get_border_on_router(border_name, space_name, index_name, op
     local cmp_key_parts = utils.merge_primary_key_parts(index.parts, primary_index.parts)
     local field_names = utils.enrich_field_names_with_cmp_key(opts.fields, cmp_key_parts, space:format())
 
-    local replicasets = vshard.router.routeall()
     local call_opts = {
         mode = 'read',
         replicasets = replicasets,

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local const = require('crud.common.const')
 local dev_checks = require('crud.common.dev_checks')
@@ -71,9 +70,8 @@ local function call_get_border_on_router(vshard_router, border_name, space_name,
     checks('table', 'string', 'string', '?string|number', {
         timeout = '?number',
         fields = '?table',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local replicasets = vshard_router:routeall()
     local space = utils.get_space(space_name, replicasets)
@@ -160,7 +158,11 @@ local function call_get_border_on_router(vshard_router, border_name, space_name,
 end
 
 local function get_border(border_name, space_name, index_name, opts)
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, BorderError:new(err)
+    end
 
     return schema.wrap_func_reload(vshard_router, call_get_border_on_router,
         border_name, space_name, index_name, opts
@@ -182,6 +184,11 @@ end
 --
 -- @tparam ?table opts.fields
 --  Field names for getting only a subset of fields
+--
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
 --
 -- @return[1] result
 -- @treturn[2] nil
@@ -205,6 +212,11 @@ end
 --
 -- @tparam ?table opts.fields
 --  Field names for getting only a subset of fields
+--
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
 --
 -- @return[1] result
 -- @treturn[2] nil

--- a/crud/common/call.lua
+++ b/crud/common/call.lua
@@ -48,7 +48,8 @@ local function wrap_vshard_err(err, func_name, replicaset_uuid, bucket_id)
     end
 
     if replicaset_uuid == nil then
-        local replicaset, _ = vshard.router.route(bucket_id)
+        local vshard_router = vshard.router.static
+        local replicaset, _ = vshard_router:route(bucket_id)
         if replicaset == nil then
             return CallError:new(
                 "Function returned an error, but we couldn't figure out the replicaset: %s", err
@@ -150,7 +151,8 @@ function call.single(bucket_id, func_name, func_args, opts)
 
     local timeout = opts.timeout or const.DEFAULT_VSHARD_CALL_TIMEOUT
 
-    local res, err = vshard.router[vshard_call_name](bucket_id, func_name, func_args, {
+    local vshard_router = vshard.router.static
+    local res, err = vshard_router[vshard_call_name](vshard_router, bucket_id, func_name, func_args, {
         timeout = timeout,
     })
 
@@ -172,7 +174,8 @@ function call.any(func_name, func_args, opts)
 
     local timeout = opts.timeout or const.DEFAULT_VSHARD_CALL_TIMEOUT
 
-    local replicasets, err = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets, err = vshard_router:routeall()
     if replicasets == nil then
         return nil, CallError:new("Failed to get all replicasets: %s", err.err)
     end

--- a/crud/common/map_call_cases/base_iter.lua
+++ b/crud/common/map_call_cases/base_iter.lua
@@ -1,5 +1,4 @@
 local errors = require('errors')
-local vshard = require('vshard')
 
 local dev_checks = require('crud.common.dev_checks')
 local GetReplicasetsError = errors.new_class('GetReplicasetsError')
@@ -24,14 +23,14 @@ function BaseIterator:new(opts)
     dev_checks('table', {
         func_args = '?table',
         replicasets = '?table',
+        vshard_router = 'table',
     })
 
     local replicasets, err
     if opts.replicasets ~= nil then
         replicasets = opts.replicasets
     else
-        local vshard_router = vshard.router.static
-        replicasets, err = vshard_router:routeall()
+        replicasets, err = opts.vshard_router:routeall()
         if err ~= nil then
             return nil, GetReplicasetsError:new("Failed to get all replicasets: %s", err.err)
         end

--- a/crud/common/map_call_cases/base_iter.lua
+++ b/crud/common/map_call_cases/base_iter.lua
@@ -30,8 +30,9 @@ function BaseIterator:new(opts)
     if opts.replicasets ~= nil then
         replicasets = opts.replicasets
     else
-        replicasets, err = vshard.router.routeall()
-        if replicasets == nil then
+        local vshard_router = vshard.router.static
+        replicasets, err = vshard_router:routeall()
+        if err ~= nil then
             return nil, GetReplicasetsError:new("Failed to get all replicasets: %s", err.err)
         end
     end

--- a/crud/common/map_call_cases/base_postprocessor.lua
+++ b/crud/common/map_call_cases/base_postprocessor.lua
@@ -7,11 +7,12 @@ local BasePostprocessor = {}
 -- @function new
 --
 -- @return[1] table postprocessor
-function BasePostprocessor:new()
+function BasePostprocessor:new(vshard_router)
     local postprocessor = {
         results = {},
         early_exit = false,
-        errs = nil
+        errs = nil,
+        vshard_router = vshard_router,
     }
 
     setmetatable(postprocessor, self)
@@ -58,7 +59,7 @@ function BasePostprocessor:collect(result_info, err_info)
 
     if err ~= nil then
         self.results = nil
-        self.errs = err_info.err_wrapper(err, unpack(err_info.wrapper_args))
+        self.errs = err_info.err_wrapper(self.vshard_router, err, unpack(err_info.wrapper_args))
         self.early_exit = true
 
         return self.early_exit

--- a/crud/common/map_call_cases/batch_insert_iter.lua
+++ b/crud/common/map_call_cases/batch_insert_iter.lua
@@ -32,9 +32,10 @@ function BatchInsertIterator:new(opts)
         tuples = 'table',
         space = 'table',
         execute_on_storage_opts = 'table',
+        vshard_router = 'table',
     })
 
-    local sharding_data, err = sharding.split_tuples_by_replicaset(opts.tuples, opts.space)
+    local sharding_data, err = sharding.split_tuples_by_replicaset(opts.vshard_router, opts.tuples, opts.space)
     if err ~= nil then
         return nil, SplitTuplesError:new("Failed to split tuples by replicaset: %s", err.err)
     end

--- a/crud/common/map_call_cases/batch_postprocessor.lua
+++ b/crud/common/map_call_cases/batch_postprocessor.lua
@@ -51,7 +51,7 @@ function BatchPostprocessor:collect(result_info, err_info)
                 err_to_wrap = err.err
             end
 
-            local err_obj = err_info.err_wrapper(err_to_wrap, unpack(err_info.wrapper_args))
+            local err_obj = err_info.err_wrapper(self.vshard_router, err_to_wrap, unpack(err_info.wrapper_args))
             err_obj.operation_data = err.operation_data
             err_obj.space_schema_hash = err.space_schema_hash
 

--- a/crud/common/map_call_cases/batch_upsert_iter.lua
+++ b/crud/common/map_call_cases/batch_upsert_iter.lua
@@ -35,11 +35,15 @@ function BatchUpsertIterator:new(opts)
         space = 'table',
         operations = 'table',
         execute_on_storage_opts = 'table',
+        vshard_router = 'table',
     })
 
-    local sharding_data, err = sharding.split_tuples_by_replicaset(opts.tuples, opts.space, {
-        operations = opts.operations,
-    })
+    local sharding_data, err = sharding.split_tuples_by_replicaset(
+        opts.vshard_router,
+        opts.tuples,
+        opts.space,
+        {operations = opts.operations})
+
     if err ~= nil then
         return nil, SplitTuplesError:new("Failed to split tuples by replicaset: %s", err.err)
     end

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -1,7 +1,6 @@
 local fiber = require('fiber')
 local msgpack = require('msgpack')
 local digest = require('digest')
-local vshard = require('vshard')
 local errors = require('errors')
 local log = require('log')
 
@@ -86,18 +85,17 @@ end
 -- This wrapper is used for functions that can fail if router uses outdated
 -- space schema. In case of such errors these functions returns `need_reload`
 -- for schema-dependent errors.
-function schema.wrap_func_reload(func, ...)
+function schema.wrap_func_reload(vshard_router, func, ...)
     local i = 0
 
     local res, err, need_reload
     while true do
-        res, err, need_reload = func(...)
+        res, err, need_reload = func(vshard_router, ...)
 
         if err == nil or need_reload ~= const.NEED_SCHEMA_RELOAD then
             break
         end
 
-        local vshard_router = vshard.router.static
         local ok, reload_schema_err = reload_schema(vshard_router)
         if not ok then
             log.warn("Failed to reload schema: %s", reload_schema_err)

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -91,7 +91,8 @@ function schema.wrap_func_reload(func, ...)
             break
         end
 
-        local ok, reload_schema_err = reload_schema(vshard.router.routeall())
+        local vshard_router = vshard.router.static
+        local ok, reload_schema_err = reload_schema(vshard_router:routeall())
         if not ok then
             log.warn("Failed to reload schema: %s", reload_schema_err)
             break

--- a/crud/common/sharding/init.lua
+++ b/crud/common/sharding/init.lua
@@ -14,7 +14,8 @@ local sharding_utils = require('crud.common.sharding.utils')
 local sharding = {}
 
 function sharding.get_replicasets_by_bucket_id(bucket_id)
-    local replicaset, err = vshard.router.route(bucket_id)
+    local vshard_router = vshard.router.static
+    local replicaset, err = vshard_router:route(bucket_id)
     if replicaset == nil then
         return nil, GetReplicasetsError:new("Failed to get replicaset for bucket_id %s: %s", bucket_id, err.err)
     end
@@ -43,7 +44,7 @@ function sharding.key_get_bucket_id(space_name, key, specified_bucket_id)
         }
     end
 
-    return { bucket_id = vshard.router.bucket_id_strcrc32(key) }
+    return { bucket_id = vshard_router:bucket_id_strcrc32(key) }
 end
 
 function sharding.tuple_get_bucket_id(tuple, space, specified_bucket_id)
@@ -241,7 +242,8 @@ function sharding.split_tuples_by_replicaset(tuples, space, opts)
             skip_sharding_hash_check = false
         end
 
-        local replicaset, err = vshard.router.route(sharding_data.bucket_id)
+        local vshard_router = vshard.router.static
+        local replicaset, err = vshard_router:route(sharding_data.bucket_id)
         if replicaset == nil then
             return nil, GetReplicasetsError:new(
                     "Failed to get replicaset for bucket_id %s: %s",

--- a/crud/common/sharding/init.lua
+++ b/crud/common/sharding/init.lua
@@ -32,7 +32,8 @@ function sharding.key_get_bucket_id(space_name, key, specified_bucket_id)
         return { bucket_id = specified_bucket_id }
     end
 
-    local sharding_func_data, err = sharding_metadata_module.fetch_sharding_func_on_router(space_name)
+    local vshard_router = vshard.router.static
+    local sharding_func_data, err = sharding_metadata_module.fetch_sharding_func_on_router(vshard_router, space_name)
     if err ~= nil then
         return nil, err
     end
@@ -53,7 +54,8 @@ function sharding.tuple_get_bucket_id(tuple, space, specified_bucket_id)
     end
 
     local sharding_index_parts = space.index[0].parts
-    local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space.name)
+    local vshard_router = vshard.router.static
+    local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space.name)
     if err ~= nil then
         return nil, err
     end

--- a/crud/common/sharding/sharding_func.lua
+++ b/crud/common/sharding/sharding_func.lua
@@ -1,6 +1,5 @@
 local errors = require('errors')
 local log = require('log')
-local vshard = require('vshard')
 
 local dev_checks = require('crud.common.dev_checks')
 local router_cache = require('crud.common.sharding.router_metadata_cache')
@@ -102,12 +101,11 @@ local function as_callable_object(sharding_func_def, space_name)
     )
 end
 
-function sharding_func_module.construct_as_callable_obj_cache(metadata_map, specified_space_name)
-    dev_checks('table', 'string')
+function sharding_func_module.construct_as_callable_obj_cache(vshard_router, metadata_map, specified_space_name)
+    dev_checks('table', 'table', 'string')
 
     local result_err
 
-    local vshard_router = vshard.router.static
     local cache = router_cache.get_instance(vshard_router)
     cache[router_cache.SHARDING_FUNC_MAP_NAME] = {}
     local func_cache = cache[router_cache.SHARDING_FUNC_MAP_NAME]

--- a/crud/common/sharding/sharding_func.lua
+++ b/crud/common/sharding/sharding_func.lua
@@ -1,8 +1,9 @@
 local errors = require('errors')
 local log = require('log')
+local vshard = require('vshard')
 
 local dev_checks = require('crud.common.dev_checks')
-local cache = require('crud.common.sharding.router_metadata_cache')
+local router_cache = require('crud.common.sharding.router_metadata_cache')
 local utils = require('crud.common.utils')
 
 local ShardingFuncError = errors.new_class('ShardingFuncError',  {capture_stack = false})
@@ -106,11 +107,13 @@ function sharding_func_module.construct_as_callable_obj_cache(metadata_map, spec
 
     local result_err
 
-    cache[cache.SHARDING_FUNC_MAP_NAME] = {}
-    local func_cache = cache[cache.SHARDING_FUNC_MAP_NAME]
+    local vshard_router = vshard.router.static
+    local cache = router_cache.get_instance(vshard_router)
+    cache[router_cache.SHARDING_FUNC_MAP_NAME] = {}
+    local func_cache = cache[router_cache.SHARDING_FUNC_MAP_NAME]
 
-    cache[cache.META_HASH_MAP_NAME][cache.SHARDING_FUNC_MAP_NAME] = {}
-    local func_hash_cache = cache[cache.META_HASH_MAP_NAME][cache.SHARDING_FUNC_MAP_NAME]
+    cache[router_cache.META_HASH_MAP_NAME][router_cache.SHARDING_FUNC_MAP_NAME] = {}
+    local func_hash_cache = cache[router_cache.META_HASH_MAP_NAME][router_cache.SHARDING_FUNC_MAP_NAME]
 
     for space_name, metadata in pairs(metadata_map) do
         if metadata.sharding_func_def ~= nil then

--- a/crud/common/sharding/sharding_key.lua
+++ b/crud/common/sharding/sharding_key.lua
@@ -1,6 +1,5 @@
 local errors = require('errors')
 local log = require('log')
-local vshard = require('vshard')
 
 local dev_checks = require('crud.common.dev_checks')
 local router_cache = require('crud.common.sharding.router_metadata_cache')
@@ -77,14 +76,14 @@ end
 
 -- Extract sharding key from pk.
 -- Returns a table with sharding key or pair of nil and error.
-function sharding_key_module.extract_from_pk(space_name, sharding_key_as_index_obj, primary_index_parts, primary_key)
-    dev_checks('string', '?table', 'table', '?')
+function sharding_key_module.extract_from_pk(vshard_router, space_name, sharding_key_as_index_obj,
+                                             primary_index_parts, primary_key)
+    dev_checks('table', 'string', '?table', 'table', '?')
 
     if sharding_key_as_index_obj == nil then
         return primary_key
     end
 
-    local vshard_router = vshard.router.static
     local cache = router_cache.get_instance(vshard_router)
     local res = is_part_of_pk(cache, space_name, primary_index_parts, sharding_key_as_index_obj)
     if res == false then
@@ -100,12 +99,11 @@ function sharding_key_module.extract_from_pk(space_name, sharding_key_as_index_o
     return extract_from_index(primary_key, primary_index_parts, sharding_key_as_index_obj)
 end
 
-function sharding_key_module.construct_as_index_obj_cache(metadata_map, specified_space_name)
-    dev_checks('table', 'string')
+function sharding_key_module.construct_as_index_obj_cache(vshard_router, metadata_map, specified_space_name)
+    dev_checks('table', 'table', 'string')
 
     local result_err
 
-    local vshard_router = vshard.router.static
     local cache = router_cache.get_instance(vshard_router)
     cache[router_cache.SHARDING_KEY_MAP_NAME] = {}
     local key_cache = cache[router_cache.SHARDING_KEY_MAP_NAME]

--- a/crud/common/sharding_func.lua
+++ b/crud/common/sharding_func.lua
@@ -1,7 +1,7 @@
 local log = require('log')
-local vshard = require('vshard')
 
 local sharding_metadata_module = require('crud.common.sharding.sharding_metadata')
+local utils = require('crud.common.utils')
 
 local sharding_func_cache = {}
 
@@ -15,8 +15,9 @@ function sharding_func_cache.update_cache(space_name, vshard_router)
     log.warn("require('crud.common.sharding_func').update_cache()" ..
              "is deprecated and will be removed in future releases")
 
-    if vshard_router == nil then
-        vshard_router = vshard.router.static
+    local vshard_router, err = utils.get_vshard_router_instance(vshard_router)
+    if err ~= nil then
+        return nil, err
     end
 
     return sharding_metadata_module.update_sharding_func_cache(vshard_router, space_name)

--- a/crud/common/sharding_func.lua
+++ b/crud/common/sharding_func.lua
@@ -1,4 +1,5 @@
 local log = require('log')
+local vshard = require('vshard')
 
 local sharding_metadata_module = require('crud.common.sharding.sharding_metadata')
 
@@ -10,10 +11,15 @@ local sharding_func_cache = {}
 -- projects like `require('crud.common.sharding_key').update_cache()`
 -- This method provides similar behavior for
 -- sharding function cache.
-function sharding_func_cache.update_cache(space_name)
+function sharding_func_cache.update_cache(space_name, vshard_router)
     log.warn("require('crud.common.sharding_func').update_cache()" ..
              "is deprecated and will be removed in future releases")
-    return sharding_metadata_module.update_sharding_func_cache(space_name)
+
+    if vshard_router == nil then
+        vshard_router = vshard.router.static
+    end
+
+    return sharding_metadata_module.update_sharding_func_cache(vshard_router, space_name)
 end
 
 return sharding_func_cache

--- a/crud/common/sharding_key.lua
+++ b/crud/common/sharding_key.lua
@@ -1,7 +1,7 @@
 local log = require('log')
-local vshard = require('vshard')
 
 local sharding_metadata_module = require('crud.common.sharding.sharding_metadata')
+local utils = require('crud.common.utils')
 
 local sharding_key_cache = {}
 
@@ -13,8 +13,9 @@ function sharding_key_cache.update_cache(space_name, vshard_router)
     log.warn("require('crud.common.sharding_key').update_cache()" ..
              "is deprecated and will be removed in future releases")
 
-    if vshard_router == nil then
-        vshard_router = vshard.router.static
+    local vshard_router, err = utils.get_vshard_router_instance(vshard_router)
+    if err ~= nil then
+        return nil, err
     end
 
     return sharding_metadata_module.update_sharding_key_cache(vshard_router, space_name)

--- a/crud/common/sharding_key.lua
+++ b/crud/common/sharding_key.lua
@@ -1,4 +1,5 @@
 local log = require('log')
+local vshard = require('vshard')
 
 local sharding_metadata_module = require('crud.common.sharding.sharding_metadata')
 
@@ -8,10 +9,15 @@ local sharding_key_cache = {}
 -- we already have customers using old API
 -- for updating sharding key cache in their
 -- projects like `require('crud.common.sharding_key').update_cache()`
-function sharding_key_cache.update_cache(space_name)
+function sharding_key_cache.update_cache(space_name, vshard_router)
     log.warn("require('crud.common.sharding_key').update_cache()" ..
              "is deprecated and will be removed in future releases")
-    return sharding_metadata_module.update_sharding_key_cache(space_name)
+
+    if vshard_router == nil then
+        vshard_router = vshard.router.static
+    end
+
+    return sharding_metadata_module.update_sharding_key_cache(vshard_router, space_name)
 end
 
 return sharding_key_cache

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -634,7 +634,8 @@ function utils.cut_rows(rows, metadata, field_names)
 end
 
 local function flatten_obj(space_name, obj)
-    local space_format, err = utils.get_space_format(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space_format, err = utils.get_space_format(space_name, vshard_router:routeall())
     if err ~= nil then
         return nil, FlattenError:new("Failed to get space format: %s", err), const.NEED_SCHEMA_RELOAD
     end
@@ -760,7 +761,8 @@ end
 --
 -- @return a table of storage states by replica uuid.
 function utils.storage_info(opts)
-    local replicasets, err = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets, err = vshard_router:routeall()
     if replicasets == nil then
         return nil, StorageInfoError:new("Failed to get all replicasets: %s", err.err)
     end

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -633,8 +633,7 @@ function utils.cut_rows(rows, metadata, field_names)
     }
 end
 
-local function flatten_obj(space_name, obj)
-    local vshard_router = vshard.router.static
+local function flatten_obj(vshard_router, space_name, obj)
     local space_format, err = utils.get_space_format(space_name, vshard_router:routeall())
     if err ~= nil then
         return nil, FlattenError:new("Failed to get space format: %s", err), const.NEED_SCHEMA_RELOAD
@@ -648,8 +647,8 @@ local function flatten_obj(space_name, obj)
     return tuple
 end
 
-function utils.flatten_obj_reload(space_name, obj)
-    return schema.wrap_func_reload(flatten_obj, space_name, obj)
+function utils.flatten_obj_reload(vshard_router, space_name, obj)
+    return schema.wrap_func_reload(vshard_router, flatten_obj, space_name, obj)
 end
 
 -- Merge two options map.

--- a/crud/count.lua
+++ b/crud/count.lua
@@ -151,7 +151,7 @@ local function call_count_on_router(space_name, user_conditions, opts)
 
     -- We don't need sharding info if bucket_id specified.
     if opts.bucket_id == nil then
-        sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
         if err ~= nil then
             return nil, err
         end

--- a/crud/count.lua
+++ b/crud/count.lua
@@ -134,7 +134,8 @@ local function call_count_on_router(space_name, user_conditions, opts)
         return nil, CountError:new("Failed to parse conditions: %s", err)
     end
 
-    local replicasets, err = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets, err = vshard_router:routeall()
     if err ~= nil then
         return nil, CountError:new("Failed to get all replicasets: %s", err)
     end

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -81,7 +81,7 @@ local function call_delete_on_router(space_name, key, opts)
     if opts.bucket_id == nil then
         local primary_index_parts = space.index[0].parts
 
-        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
         if err ~= nil then
             return nil, err
         end

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -55,8 +55,8 @@ end
 -- returns result, err, need_reload
 -- need_reload indicates if reloading schema could help
 -- see crud.common.schema.wrap_func_reload()
-local function call_delete_on_router(space_name, key, opts)
-    dev_checks('string', '?', {
+local function call_delete_on_router(vshard_router, space_name, key, opts)
+    dev_checks('table', 'string', '?', {
         timeout = '?number',
         bucket_id = '?number|cdata',
         fields = '?table',
@@ -64,7 +64,6 @@ local function call_delete_on_router(space_name, key, opts)
 
     opts = opts or {}
 
-    local vshard_router = vshard.router.static
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, DeleteError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
@@ -86,7 +85,8 @@ local function call_delete_on_router(space_name, key, opts)
             return nil, err
         end
 
-        sharding_key, err = sharding_key_module.extract_from_pk(space_name,
+        sharding_key, err = sharding_key_module.extract_from_pk(vshard_router,
+                                                                space_name,
                                                                 sharding_key_data.value,
                                                                 primary_index_parts, key)
         if err ~= nil then
@@ -98,7 +98,7 @@ local function call_delete_on_router(space_name, key, opts)
         skip_sharding_hash_check = true
     end
 
-    local bucket_id_data, err = sharding.key_get_bucket_id(space_name, sharding_key, opts.bucket_id)
+    local bucket_id_data, err = sharding.key_get_bucket_id(vshard_router, space_name, sharding_key, opts.bucket_id)
     if err ~= nil then
         return nil, err
     end
@@ -114,7 +114,7 @@ local function call_delete_on_router(space_name, key, opts)
         timeout = opts.timeout,
     }
 
-    local storage_result, err = call.single(
+    local storage_result, err = call.single(vshard_router,
         bucket_id_data.bucket_id, DELETE_FUNC_NAME,
         {space_name, key, opts.fields, delete_on_storage_opts},
         call_opts
@@ -167,8 +167,10 @@ function delete.call(space_name, key, opts)
         fields = '?table',
     })
 
-    return schema.wrap_func_reload(sharding.wrap_method,
-                                   call_delete_on_router, space_name, key, opts)
+    local vshard_router = vshard.router.static
+
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_delete_on_router,
+                                   space_name, key, opts)
 end
 
 return delete

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -64,7 +64,8 @@ local function call_delete_on_router(space_name, key, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, DeleteError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
@@ -60,9 +59,8 @@ local function call_delete_on_router(vshard_router, space_name, key, opts)
         timeout = '?number',
         bucket_id = '?number|cdata',
         fields = '?table',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
@@ -156,6 +154,11 @@ end
 --  Bucket ID
 --  (by default, it's vshard.router.bucket_id_strcrc32 of primary key)
 --
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
+--
 -- @return[1] object
 -- @treturn[2] nil
 -- @treturn[2] table Error description
@@ -165,9 +168,15 @@ function delete.call(space_name, key, opts)
         timeout = '?number',
         bucket_id = '?number|cdata',
         fields = '?table',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, DeleteError:new(err)
+    end
 
     return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_delete_on_router,
                                    space_name, key, opts)

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -84,7 +84,7 @@ local function call_get_on_router(space_name, key, opts)
     if opts.bucket_id == nil then
         local primary_index_parts = space.index[0].parts
 
-        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
         if err ~= nil then
             return nil, err
         end

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -67,7 +67,8 @@ local function call_get_on_router(space_name, key, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, GetError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
@@ -62,9 +61,8 @@ local function call_insert_on_router(vshard_router, space_name, original_tuple, 
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
         fields = '?table',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
@@ -139,6 +137,11 @@ end
 --  Bucket ID
 --  (by default, it's vshard.router.bucket_id_strcrc32 of primary key)
 --
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
+--
 -- @return[1] tuple
 -- @treturn[2] nil
 -- @treturn[2] table Error description
@@ -149,9 +152,15 @@ function insert.tuple(space_name, tuple, opts)
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
         fields = '?table',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, InsertError:new(err)
+    end
 
     return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_insert_on_router,
                                    space_name, tuple, opts)
@@ -180,9 +189,15 @@ function insert.object(space_name, obj, opts)
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
         fields = '?table',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, InsertError:new(err)
+    end
 
     -- insert can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -56,8 +56,8 @@ end
 -- returns result, err, need_reload
 -- need_reload indicates if reloading schema could help
 -- see crud.common.schema.wrap_func_reload()
-local function call_insert_on_router(space_name, original_tuple, opts)
-    dev_checks('string', 'table', {
+local function call_insert_on_router(vshard_router, space_name, original_tuple, opts)
+    dev_checks('table', 'string', 'table', {
         timeout = '?number',
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
@@ -66,7 +66,6 @@ local function call_insert_on_router(space_name, original_tuple, opts)
 
     opts = opts or {}
 
-    local vshard_router = vshard.router.static
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, InsertError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
@@ -74,7 +73,7 @@ local function call_insert_on_router(space_name, original_tuple, opts)
 
     local tuple = table.deepcopy(original_tuple)
 
-    local sharding_data, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
+    local sharding_data, err = sharding.tuple_set_and_return_bucket_id(vshard_router, tuple, space, opts.bucket_id)
     if err ~= nil then
         return nil, InsertError:new("Failed to get bucket ID: %s", err), const.NEED_SCHEMA_RELOAD
     end
@@ -92,7 +91,7 @@ local function call_insert_on_router(space_name, original_tuple, opts)
         timeout = opts.timeout,
     }
 
-    local storage_result, err = call.single(
+    local storage_result, err = call.single(vshard_router,
         sharding_data.bucket_id, INSERT_FUNC_NAME,
         {space_name, tuple, insert_on_storage_opts},
         call_opts
@@ -152,8 +151,10 @@ function insert.tuple(space_name, tuple, opts)
         fields = '?table',
     })
 
-    return schema.wrap_func_reload(sharding.wrap_method,
-                                   call_insert_on_router, space_name, tuple, opts)
+    local vshard_router = vshard.router.static
+
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_insert_on_router,
+                                   space_name, tuple, opts)
 end
 
 --- Inserts an object to the specified space
@@ -174,17 +175,25 @@ end
 -- @treturn[2] table Error description
 --
 function insert.object(space_name, obj, opts)
-    checks('string', 'table', '?table')
+    checks('string', 'table', {
+        timeout = '?number',
+        bucket_id = '?number|cdata',
+        add_space_schema_hash = '?boolean',
+        fields = '?table',
+    })
+
+    local vshard_router = vshard.router.static
 
     -- insert can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})
 
-    local tuple, err = utils.flatten_obj_reload(space_name, obj)
+    local tuple, err = utils.flatten_obj_reload(vshard_router, space_name, obj)
     if err ~= nil then
         return nil, InsertError:new("Failed to flatten object: %s", err)
     end
 
-    return insert.tuple(space_name, tuple, opts)
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_insert_on_router,
+                                   space_name, tuple, opts)
 end
 
 return insert

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -66,7 +66,8 @@ local function call_insert_on_router(space_name, original_tuple, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, InsertError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -133,7 +133,8 @@ local function call_insert_many_on_router(space_name, original_tuples, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, {InsertManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
     end

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
@@ -129,9 +128,8 @@ local function call_insert_many_on_router(vshard_router, space_name, original_tu
         add_space_schema_hash = '?boolean',
         stop_on_error = '?boolean',
         rollback_on_error = '?boolean',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
@@ -215,9 +213,15 @@ function insert_many.tuples(space_name, tuples, opts)
         add_space_schema_hash = '?boolean',
         stop_on_error = '?boolean',
         rollback_on_error = '?boolean',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, {InsertManyError:new(err)}
+    end
 
     return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_insert_many_on_router,
                                    space_name, tuples, opts)
@@ -246,9 +250,15 @@ function insert_many.objects(space_name, objs, opts)
         fields = '?table',
         stop_on_error = '?boolean',
         rollback_on_error = '?boolean',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, {InsertManyError:new(err)}
+    end
 
     -- insert can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -1,6 +1,7 @@
 local checks = require('checks')
 local errors = require('errors')
 local vshard = require('vshard')
+local log = require('log')
 
 local utils = require('crud.common.utils')
 local dev_checks = require('crud.common.dev_checks')
@@ -42,6 +43,11 @@ function len.call(space_name, opts)
     })
 
     opts = opts or {}
+
+    if type(space_name) == 'number' then
+        log.warn('Using space id in crud.len is deprecated and will be removed in future releases.' ..
+                 'Please, use space name instead.')
+    end
 
     local space = utils.get_space(space_name, vshard.router.routeall())
     if space == nil then

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -52,6 +52,11 @@ function len.call(space_name, opts)
     if type(space_name) == 'number' then
         log.warn('Using space id in crud.len is deprecated and will be removed in future releases.' ..
                  'Please, use space name instead.')
+
+        if opts.vshard_router ~= nil then
+            log.warn('Using space id in crud.len and custom vshard_router is not supported by statistics.' ..
+                     'Space labels may be inconsistent.')
+        end
     end
 
     local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -49,12 +49,13 @@ function len.call(space_name, opts)
                  'Please, use space name instead.')
     end
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, LenError:new("Space %q doesn't exist", space_name)
     end
 
-    local results, err = vshard.router.map_callrw(LEN_FUNC_NAME, {space_name}, opts)
+    local results, err = vshard_router:map_callrw(LEN_FUNC_NAME, {space_name}, opts)
 
     if err ~= nil then
         return nil, LenError:new("Failed to call len on storage-side: %s", err)

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -56,8 +56,8 @@ end
 -- returns result, err, need_reload
 -- need_reload indicates if reloading schema could help
 -- see crud.common.schema.wrap_func_reload()
-local function call_replace_on_router(space_name, original_tuple, opts)
-    dev_checks('string', 'table', {
+local function call_replace_on_router(vshard_router, space_name, original_tuple, opts)
+    dev_checks('table', 'string', 'table', {
         timeout = '?number',
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
@@ -66,7 +66,6 @@ local function call_replace_on_router(space_name, original_tuple, opts)
 
     opts = opts or {}
 
-    local vshard_router = vshard.router.static
     local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
         return nil, ReplaceError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
@@ -78,7 +77,7 @@ local function call_replace_on_router(space_name, original_tuple, opts)
 
     local tuple = table.deepcopy(original_tuple)
 
-    local sharding_data, err = sharding.tuple_set_and_return_bucket_id(tuple, space, opts.bucket_id)
+    local sharding_data, err = sharding.tuple_set_and_return_bucket_id(vshard_router, tuple, space, opts.bucket_id)
     if err ~= nil then
         return nil, ReplaceError:new("Failed to get bucket ID: %s", err), const.NEED_SCHEMA_RELOAD
     end
@@ -95,7 +94,7 @@ local function call_replace_on_router(space_name, original_tuple, opts)
         mode = 'write',
         timeout = opts.timeout,
     }
-    local storage_result, err = call.single(
+    local storage_result, err = call.single(vshard_router,
         sharding_data.bucket_id, REPLACE_FUNC_NAME,
         {space_name, tuple, replace_on_storage_opts},
         call_opts
@@ -155,8 +154,10 @@ function replace.tuple(space_name, tuple, opts)
         fields = '?table',
     })
 
-    return schema.wrap_func_reload(sharding.wrap_method,
-                                   call_replace_on_router, space_name, tuple, opts)
+    local vshard_router = vshard.router.static
+
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_replace_on_router,
+                                   space_name, tuple, opts)
 end
 
 --- Insert or replace an object in the specified space
@@ -177,17 +178,25 @@ end
 -- @treturn[2] table Error description
 --
 function replace.object(space_name, obj, opts)
-    checks('string', 'table', '?table')
+    checks('string', 'table', {
+        timeout = '?number',
+        bucket_id = '?number|cdata',
+        add_space_schema_hash = '?boolean',
+        fields = '?table',
+    })
+
+    local vshard_router = vshard.router.static
 
     -- replace can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})
 
-    local tuple, err = utils.flatten_obj_reload(space_name, obj)
+    local tuple, err = utils.flatten_obj_reload(vshard_router, space_name, obj)
     if err ~= nil then
         return nil, ReplaceError:new("Failed to flatten object: %s", err)
     end
 
-    return replace.tuple(space_name, tuple, opts)
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_replace_on_router,
+                                   space_name, tuple, opts)
 end
 
 return replace

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -66,7 +66,8 @@ local function call_replace_on_router(space_name, original_tuple, opts)
 
     opts = opts or {}
 
-    local space, err = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
         return nil, ReplaceError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
@@ -131,9 +130,8 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
         add_space_schema_hash = '?boolean',
         stop_on_error = '?boolean',
         rollback_on_error = '?boolean',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
@@ -217,9 +215,15 @@ function replace_many.tuples(space_name, tuples, opts)
         add_space_schema_hash = '?boolean',
         stop_on_error = '?boolean',
         rollback_on_error = '?boolean',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, {ReplaceManyError:new(err)}
+    end
 
     return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_replace_many_on_router,
                                    space_name, tuples, opts)
@@ -248,9 +252,15 @@ function replace_many.objects(space_name, objs, opts)
         fields = '?table',
         stop_on_error = '?boolean',
         rollback_on_error = '?boolean',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, {ReplaceManyError:new(err)}
+    end
 
     -- insert can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -135,7 +135,8 @@ local function call_replace_many_on_router(space_name, original_tuples, opts)
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, {ReplaceManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
     end

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -124,8 +124,8 @@ end
 -- returns result, err, need_reload
 -- need_reload indicates if reloading schema could help
 -- see crud.common.schema.wrap_func_reload()
-local function call_replace_many_on_router(space_name, original_tuples, opts)
-    dev_checks('string', 'table', {
+local function call_replace_many_on_router(vshard_router, space_name, original_tuples, opts)
+    dev_checks('table', 'string', 'table', {
         timeout = '?number',
         fields = '?table',
         add_space_schema_hash = '?boolean',
@@ -135,7 +135,6 @@ local function call_replace_many_on_router(space_name, original_tuples, opts)
 
     opts = opts or {}
 
-    local vshard_router = vshard.router.static
     local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, {ReplaceManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
@@ -154,14 +153,15 @@ local function call_replace_many_on_router(space_name, original_tuples, opts)
         tuples = tuples,
         space = space,
         execute_on_storage_opts = replace_many_on_storage_opts,
+        vshard_router = vshard_router,
     })
     if err ~= nil then
         return nil, {err}, const.NEED_SCHEMA_RELOAD
     end
 
-    local postprocessor = BatchPostprocessor:new()
+    local postprocessor = BatchPostprocessor:new(vshard_router)
 
-    local rows, errs = call.map(REPLACE_MANY_FUNC_NAME, nil, {
+    local rows, errs = call.map(vshard_router, REPLACE_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,
         mode = 'write',
         iter = iter,
@@ -219,8 +219,10 @@ function replace_many.tuples(space_name, tuples, opts)
         rollback_on_error = '?boolean',
     })
 
-    return schema.wrap_func_reload(sharding.wrap_method,
-                                   call_replace_many_on_router, space_name, tuples, opts)
+    local vshard_router = vshard.router.static
+
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_replace_many_on_router,
+                                   space_name, tuples, opts)
 end
 
 --- Replace batch of objects to the specified space
@@ -248,6 +250,8 @@ function replace_many.objects(space_name, objs, opts)
         rollback_on_error = '?boolean',
     })
 
+    local vshard_router = vshard.router.static
+
     -- insert can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})
 
@@ -256,7 +260,7 @@ function replace_many.objects(space_name, objs, opts)
 
     for _, obj in ipairs(objs) do
 
-        local tuple, err = utils.flatten_obj_reload(space_name, obj)
+        local tuple, err = utils.flatten_obj_reload(vshard_router, space_name, obj)
         if err ~= nil then
             local err_obj = ReplaceManyError:new("Failed to flatten object: %s", err)
             err_obj.operation_data = obj
@@ -275,7 +279,8 @@ function replace_many.objects(space_name, objs, opts)
         return nil, format_errs
     end
 
-    local res, errs = replace_many.tuples(space_name, tuples, opts)
+    local res, errs = schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_replace_many_on_router,
+                                              space_name, tuples, opts)
 
     if next(format_errs) ~= nil then
         if errs == nil then

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -43,7 +43,8 @@ local function build_select_iterator(space_name, user_conditions, opts)
         return nil, SelectError:new("Failed to parse conditions: %s", err)
     end
 
-    local replicasets, err = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets, err = vshard_router:routeall()
     if err ~= nil then
         return nil, SelectError:new("Failed to get all replicasets: %s", err)
     end

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -61,7 +61,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
 
     -- We don't need sharding info if bucket_id specified.
     if opts.bucket_id == nil then
-        sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
         if err ~= nil then
             return nil, err
         end

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -123,7 +123,7 @@ local function build_select_iterator(space_name, user_conditions, opts)
     local sharding_key_as_index_obj = nil
     -- We don't need sharding info if bucket_id specified.
     if opts.bucket_id == nil then
-        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
         if err ~= nil then
             return nil, err
         end

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -107,7 +107,8 @@ local function build_select_iterator(space_name, user_conditions, opts)
         return nil, SelectError:new("Failed to parse conditions: %s", err)
     end
 
-    local replicasets, err = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets, err = vshard_router:routeall()
     if err ~= nil then
         return nil, SelectError:new("Failed to get all replicasets: %s", err)
     end

--- a/crud/select/iterator.lua
+++ b/crud/select/iterator.lua
@@ -107,6 +107,7 @@ local function update_replicasets_tuples(iter, after_tuple, replicaset_uuid)
         field_names = iter.field_names,
         call_opts = iter.call_opts,
         sharding_hash = iter.sharding_hash,
+        vshard_router = iter.vshard_router,
     })
     if err ~= nil then
         if sharding.result_needs_sharding_reload(err) then

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -251,6 +251,7 @@ end
 
 local function resolve_space_name(space_id)
     local vshard_router = vshard.router.static
+
     local replicasets = vshard_router:routeall()
     if next(replicasets) == nil then
         log.warn('Failed to resolve space name for stats: no replicasets found')

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -252,15 +252,20 @@ end
 local function resolve_space_name(space_id)
     local vshard_router = vshard.router.static
 
+    if vshard_router == nil then
+        log.warn('Failed to resolve space name for stats: default vshard router not found')
+        return nil
+    end
+
     local replicasets = vshard_router:routeall()
     if next(replicasets) == nil then
-        log.warn('Failed to resolve space name for stats: no replicasets found')
+        log.warn('Failed to resolve space name for stats: no replicasets found with default router')
         return nil
     end
 
     local space = utils.get_space(space_id, replicasets)
     if space == nil then
-        log.warn('Failed to resolve space name for stats: no space found for id %d', space_id)
+        log.warn('Failed to resolve space name for stats: no space found for id %d with default router', space_id)
         return nil
     end
 

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -250,6 +250,7 @@ function stats.get(space_name)
 end
 
 local function resolve_space_name(space_id)
+    -- Resolving name with custom vshard router is not supported.
     local vshard_router = vshard.router.static
 
     if vshard_router == nil then

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -250,7 +250,8 @@ function stats.get(space_name)
 end
 
 local function resolve_space_name(space_id)
-    local replicasets = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets = vshard_router:routeall()
     if next(replicasets) == nil then
         log.warn('Failed to resolve space name for stats: no replicasets found')
         return nil

--- a/crud/truncate.lua
+++ b/crud/truncate.lua
@@ -49,7 +49,7 @@ function truncate.call(space_name, opts)
 
     local vshard_router = vshard.router.static
     local replicasets = vshard_router:routeall()
-    local _, err = call.map(TRUNCATE_FUNC_NAME, {space_name}, {
+    local _, err = call.map(vshard_router, TRUNCATE_FUNC_NAME, {space_name}, {
         mode = 'write',
         replicasets = replicasets,
         timeout = opts.timeout,

--- a/crud/truncate.lua
+++ b/crud/truncate.lua
@@ -47,7 +47,8 @@ function truncate.call(space_name, opts)
 
     opts = opts or {}
 
-    local replicasets = vshard.router.routeall()
+    local vshard_router = vshard.router.static
+    local replicasets = vshard_router:routeall()
     local _, err = call.map(TRUNCATE_FUNC_NAME, {space_name}, {
         mode = 'write',
         replicasets = replicasets,

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
@@ -82,9 +81,8 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
         timeout = '?number',
         bucket_id = '?number|cdata',
         fields = '?table',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
@@ -196,6 +194,11 @@ end
 --  Bucket ID
 --  (by default, it's vshard.router.bucket_id_strcrc32 of primary key)
 --
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
+--
 -- @return[1] object
 -- @treturn[2] nil
 -- @treturn[2] table Error description
@@ -205,9 +208,14 @@ function update.call(space_name, key, user_operations, opts)
         timeout = '?number',
         bucket_id = '?number|cdata',
         fields = '?table',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, UpdateError:new(err)
+    end
 
     return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_update_on_router,
                                    space_name, key, user_operations, opts)

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -109,7 +109,7 @@ local function call_update_on_router(space_name, key, user_operations, opts)
     if opts.bucket_id == nil then
         local primary_index_parts = space.index[0].parts
 
-        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(space_name)
+        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
         if err ~= nil then
             return nil, err
         end

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -86,7 +86,8 @@ local function call_update_on_router(space_name, key, user_operations, opts)
 
     opts = opts or {}
 
-    local space, err = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
         return nil, UpdateError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -64,7 +64,8 @@ local function call_upsert_on_router(space_name, original_tuple, user_operations
 
     opts = opts or {}
 
-    local space, err = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
         return nil, UpsertError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local vshard = require('vshard')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
@@ -60,9 +59,8 @@ local function call_upsert_on_router(vshard_router, space_name, original_tuple, 
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
         fields = '?table',
+        vshard_router = '?string|table',
     })
-
-    opts = opts or {}
 
     local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
@@ -153,6 +151,11 @@ end
 --  Bucket ID
 --  (by default, it's vshard.router.bucket_id_strcrc32 of primary key)
 --
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
+--
 -- @return[1] tuple
 -- @treturn[2] nil
 -- @treturn[2] table Error description
@@ -163,9 +166,15 @@ function upsert.tuple(space_name, tuple, user_operations, opts)
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
         fields = '?table',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, UpsertError:new(err)
+    end
 
     return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_upsert_on_router,
                                    space_name, tuple, user_operations, opts)
@@ -198,9 +207,16 @@ function upsert.object(space_name, obj, user_operations, opts)
         bucket_id = '?number|cdata',
         add_space_schema_hash = '?boolean',
         fields = '?table',
+        vshard_router = '?string|table',
     })
 
-    local vshard_router = vshard.router.static
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, UpsertError:new(err)
+    end
+
     -- upsert can fail if router uses outdated schema to flatten object
     opts = utils.merge_options(opts, {add_space_schema_hash = true})
 

--- a/crud/upsert_many.lua
+++ b/crud/upsert_many.lua
@@ -131,7 +131,8 @@ local function call_upsert_many_on_router(space_name, original_tuples_operation_
 
     opts = opts or {}
 
-    local space = utils.get_space(space_name, vshard.router.routeall())
+    local vshard_router = vshard.router.static
+    local space = utils.get_space(space_name, vshard_router:routeall())
     if space == nil then
         return nil, {UpsertManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
     end

--- a/doc/dev/schema.md
+++ b/doc/dev/schema.md
@@ -44,6 +44,11 @@ call.) Each ``net.box`` connection has space schema for an instance it
 is connected to. Router can access space schema by using ``net.box``
 connection object contents.
 
+Tarantool instance may have several vshard routers. For each request, only
+one router is used (specified in `vshard_router` option or a default one).
+Each router has its own ``net.box`` connections. Fetching and reload processes
+are different for each router and do not affect each other.
+
 ### When schema is used
 
 Space schema is used
@@ -163,6 +168,12 @@ module uses `_ddl_sharding_key` and `_ddl_sharding_func` spaces to fetch
 sharding schema: thus, you don't obliged to use ``ddl`` module and can
 setup only ``_ddl_*`` spaces manually, if you want. ``crud`` module uses
 plain Lua tables to store sharding info on routers and storages.
+
+Tarantool instance may have several vshard routers. For each request, only
+one router is used (specified in `vshard_router` option or a default one).
+Each router has its own ``net.box`` connections. Fetching and reload processes
+are different for each router and do not affect each other since they
+have separate caches.
 
 ### When schema is used
 

--- a/test/entrypoint/srv_vshard_custom.lua
+++ b/test/entrypoint/srv_vshard_custom.lua
@@ -24,6 +24,7 @@ package.preload['customers-storage'] = function()
                     },
                     if_not_exists = true,
                     engine = engine,
+                    id = 542,
                 })
 
                 customers_space:create_index('pk', {

--- a/test/entrypoint/srv_vshard_custom.lua
+++ b/test/entrypoint/srv_vshard_custom.lua
@@ -1,0 +1,249 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+_G.is_initialized = function() return false end
+
+local log = require('log')
+local errors = require('errors')
+local cartridge = require('cartridge')
+local ddl = require('ddl')
+
+package.preload['customers-storage'] = function()
+    return {
+        role_name = 'customers-storage',
+        init = function(opts)
+            local engine = os.getenv('ENGINE') or 'memtx'
+
+            if opts.is_master then
+                local customers_space = box.schema.space.create('customers', {
+                    format = {
+                        {name = 'id', is_nullable = false, type = 'unsigned'},
+                        {name = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                        {name = 'name', is_nullable = false, type = 'string'},
+                        {name = 'age', is_nullable = false, type = 'number'},
+                    },
+                    if_not_exists = true,
+                    engine = engine,
+                })
+
+                customers_space:create_index('pk', {
+                    parts = { {field = 'id'} },
+                    if_not_exists = true,
+                    unique = true,
+                })
+                customers_space:create_index('bucket_id', {
+                    parts = { {field = 'bucket_id'} },
+                    unique = false,
+                    if_not_exists = true,
+                })
+                customers_space:create_index('age', {
+                    parts = { {field = 'age'} },
+                    unique = false,
+                    if_not_exists = true,
+                })
+            end
+        end,
+        dependencies = { 'cartridge.roles.crud-storage' }
+    }
+end
+
+package.preload['customers-storage-ddl'] = function()
+    return {
+        role_name = 'customers-storage-ddl',
+        init = function()
+            local engine = os.getenv('ENGINE') or 'memtx'
+
+            local customers_schema = {
+                engine = engine,
+                temporary = false,
+                is_local = false,
+                format = {
+                    {name = 'id', is_nullable = false, type = 'unsigned'},
+                    {name = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                    {name = 'name', is_nullable = false, type = 'string'},
+                    {name = 'age', is_nullable = false, type = 'number'},
+                },
+                indexes = {
+                    {
+                        name = 'pk',
+                        type = 'TREE',
+                        unique = true,
+                        parts = {
+                            {path = 'id', is_nullable = false, type = 'unsigned'},
+                            {path = 'name', is_nullable = false, type = 'string'},
+                        },
+                    },
+                    {
+                        name = 'bucket_id',
+                        type = 'TREE',
+                        unique = false,
+                        parts = {
+                            {path = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                        },
+                    },
+                    {
+                        name = 'name',
+                        type = 'TREE',
+                        unique = false,
+                        parts = {
+                            {path = 'name', is_nullable = false, type = 'string'},
+                        },
+                    },
+                    {
+                        name = 'age',
+                        type = 'TREE',
+                        unique = false,
+                        parts = {
+                            {path = 'age', is_nullable = false, type = 'number'},
+                        },
+                    },
+                },
+                sharding_key = { 'name' }
+            }
+
+            local schema = {
+                spaces = {
+                    ['customers_ddl'] = customers_schema,
+                }
+            }
+
+            local _, err = ddl.set_schema(schema)
+            if err ~= nil then
+                error(err)
+            end
+        end,
+        dependencies = { 'cartridge.roles.crud-storage' }
+    }
+end
+
+package.preload['locations-storage'] = function()
+    return {
+        role_name = 'locations-storage',
+        init = function(opts)
+            local engine = os.getenv('ENGINE') or 'memtx'
+
+            if opts.is_master then
+                local locations_space = box.schema.space.create('locations', {
+                    format = {
+                        {name = 'name', is_nullable = false, type = 'string'},
+                        {name = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                        {name = 'type', is_nullable = false, type = 'string'},
+                        {name = 'workers', is_nullable = false, type = 'number'},
+                    },
+                    if_not_exists = true,
+                    engine = engine,
+                })
+
+                locations_space:create_index('pk', {
+                    parts = { {field = 'name'} },
+                    if_not_exists = true,
+                    unique = true,
+                })
+                locations_space:create_index('bucket_id', {
+                    parts = { {field = 'bucket_id'} },
+                    unique = false,
+                    if_not_exists = true,
+                })
+                locations_space:create_index('workers', {
+                    parts = { {field = 'workers'} },
+                    unique = false,
+                    if_not_exists = true,
+                })
+            end
+        end,
+        dependencies = { 'cartridge.roles.crud-storage' }
+    }
+end
+
+
+package.preload['locations-storage-ddl'] = function()
+    return {
+        role_name = 'locations-storage-ddl',
+        init = function()
+            local engine = os.getenv('ENGINE') or 'memtx'
+
+            local locations_schema = {
+                engine = engine,
+                temporary = false,
+                is_local = false,
+                format = {
+                    {name = 'name', is_nullable = false, type = 'string'},
+                    {name = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                    {name = 'type', is_nullable = false, type = 'string'},
+                    {name = 'workers', is_nullable = false, type = 'unsigned'},
+                },
+                indexes = {
+                    {
+                        name = 'pk',
+                        type = 'TREE',
+                        unique = true,
+                        parts = {
+                            {path = 'name', is_nullable = false, type = 'string'},
+                            {path = 'type', is_nullable = false, type = 'string'},
+                        },
+                    },
+                    {
+                        name = 'bucket_id',
+                        type = 'TREE',
+                        unique = false,
+                        parts = {
+                            {path = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                        },
+                    },
+                    {
+                        name = 'type',
+                        type = 'TREE',
+                        unique = false,
+                        parts = {
+                            {path = 'type', is_nullable = false, type = 'string'},
+                        },
+                    },
+                    {
+                        name = 'workers',
+                        type = 'TREE',
+                        unique = false,
+                        parts = {
+                            {path = 'workers', is_nullable = false, type = 'unsigned'},
+                        },
+                    },
+                },
+                sharding_key = { 'type' }
+            }
+
+            local schema = {
+                spaces = {
+                    ['locations_ddl'] = locations_schema,
+                }
+            }
+
+            local _, err = ddl.set_schema(schema)
+            if err ~= nil then
+                error(err)
+            end
+        end,
+        dependencies = { 'cartridge.roles.crud-storage' }
+    }
+end
+
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+    bucket_count = nil,
+    vshard_groups = {
+        'customers',
+        'locations',
+    },
+    roles = {
+        'customers-storage',
+        'customers-storage-ddl',
+        'locations-storage',
+        'locations-storage-ddl',
+        'cartridge.roles.crud-router',
+        'cartridge.roles.crud-storage',
+    },
+})
+
+if not ok then
+    log.error('%s', err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -334,9 +334,13 @@ end
 
 function helpers.get_sharding_key_cache(cluster)
     return cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local sharding_metadata_cache = require('crud.common.sharding.router_metadata_cache')
 
-        return sharding_metadata_cache[sharding_metadata_cache.SHARDING_KEY_MAP_NAME]
+        local vshard_router = vshard.router.static
+        local cache = sharding_metadata_cache.get_instance(vshard_router)
+
+        return cache[sharding_metadata_cache.SHARDING_KEY_MAP_NAME]
     ]])
 end
 
@@ -362,9 +366,13 @@ end
 -- but not the cache itself
 function helpers.get_sharding_func_cache_size(cluster)
     return cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local sharding_metadata_cache = require('crud.common.sharding.router_metadata_cache')
 
-        local cache, err = sharding_metadata_cache[sharding_metadata_cache.SHARDING_FUNC_MAP_NAME]
+        local vshard_router = vshard.router.static
+        local instance_cache = sharding_metadata_cache.get_instance(vshard_router)
+
+        local cache, err = instance_cache[sharding_metadata_cache.SHARDING_FUNC_MAP_NAME]
         if cache == nil then
             return nil, err
         end

--- a/test/integration/vshard_custom_test.lua
+++ b/test/integration/vshard_custom_test.lua
@@ -1,0 +1,1631 @@
+local fio = require('fio')
+
+local t = require('luatest')
+
+local helpers = require('test.helper')
+
+local pgroup = t.group('vshard_custom', {
+    {engine = 'memtx', option = 'group_name'},
+    {engine = 'memtx', option = 'router_object'},
+    {engine = 'vinyl', option = 'group_name'},
+    {engine = 'vinyl', option = 'router_object'},
+})
+
+pgroup.before_all(function(g)
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_vshard_custom'),
+        use_vshard = true,
+        replicasets = {
+            {
+                alias = 'router',
+                uuid = helpers.uuid('a'),
+                roles = { 'crud-router' },
+                servers = {{
+                    alias = 'router',
+                    http_port = 8081,
+                    advertise_port = 13301,
+                    instance_uuid = helpers.uuid('a', 'a', 1)
+                }},
+            },
+            {
+                alias = 'customers-storage-1',
+                uuid = helpers.uuid('b1'),
+                roles = { 'customers-storage', 'customers-storage-ddl' },
+                vshard_group = 'customers',
+                servers = {{
+                    alias = 'customers-storage-1',
+                    http_port = 8082,
+                    advertise_port = 13302,
+                    instance_uuid = helpers.uuid('b1', 'b1', 2)
+                }},
+            },
+            {
+                alias = 'customers-storage-2',
+                uuid = helpers.uuid('b2'),
+                roles = { 'customers-storage', 'customers-storage-ddl' },
+                vshard_group = 'customers',
+                servers = {{
+                    alias = 'customers-storage-2',
+                    http_port = 8083,
+                    advertise_port = 13303,
+                    instance_uuid = helpers.uuid('b2', 'b2', 2)
+                }},
+            },
+            {
+                alias = 'locations-storage-1',
+                uuid = helpers.uuid('c1'),
+                roles = { 'locations-storage', 'locations-storage-ddl' },
+                vshard_group = 'locations',
+                servers = {{
+                    alias = 'locations-storage-1',
+                    http_port = 8084,
+                    advertise_port = 13304,
+                    instance_uuid = helpers.uuid('c1', 'c1', 2)
+                }},
+            },
+            {
+                alias = 'locations-storage-2',
+                uuid = helpers.uuid('c2'),
+                roles = { 'locations-storage', 'locations-storage-ddl' },
+                vshard_group = 'locations',
+                servers = {{
+                    alias = 'locations-storage-2',
+                    http_port = 8085,
+                    advertise_port = 13305,
+                    instance_uuid = helpers.uuid('c2', 'c2', 2)
+                }},
+            },
+        },
+        env = {
+            ['ENGINE'] = g.params.engine,
+        },
+    })
+
+    g.cluster:start()
+    g.router = g.cluster:server('router').net_box
+end)
+
+pgroup.after_all(function(g) helpers.stop_cluster(g.cluster) end)
+
+pgroup.before_all(function(g)
+    g.router:eval([[
+        local checks = require('checks')
+        local cartridge = require('cartridge')
+        local router_service = cartridge.service_get('vshard-router')
+
+        local function prepare_data(space_name, vshard_router, tuple)
+            checks('string', 'string', 'table')
+
+            local router = router_service.get(vshard_router)
+            assert(router ~= nil)
+
+            local bucket_id_field = 2
+            local sharding_field
+            if space_name:find('ddl') ~= nil then
+                sharding_field = 3
+            else
+                sharding_field = 1
+            end
+
+            local bucket_id = router:bucket_id_strcrc32(tuple[sharding_field])
+            tuple[bucket_id_field] = bucket_id
+
+            local replicaset = router:route(bucket_id)
+            assert(replicaset ~= nil)
+
+            local space = replicaset.master.conn.space[space_name]
+            assert(space ~= nil)
+
+            local res, err = space:replace(tuple)
+
+            if err ~= nil then
+                error(err)
+            end
+
+            return res
+        end
+
+        rawset(_G, 'prepare_data', prepare_data)
+
+        local function call_wrapper_opts2(option, func, space_name, opts)
+            if option == 'router_object' and opts ~= nil and type(opts.vshard_router) == 'string' then
+                local router = router_service.get(opts.vshard_router)
+                opts.vshard_router = router
+            end
+
+            return crud[func](space_name, opts)
+        end
+
+        rawset(_G, 'call_wrapper_opts2', call_wrapper_opts2)
+
+        local function call_wrapper_opts3(option, func, space_name, arg, opts)
+            if option == 'router_object' and opts ~= nil and type(opts.vshard_router) == 'string' then
+                local router = router_service.get(opts.vshard_router)
+                opts.vshard_router = router
+            end
+
+            return crud[func](space_name, arg, opts)
+        end
+
+        rawset(_G, 'call_wrapper_opts3', call_wrapper_opts3)
+
+        local function call_wrapper_opts4(option, func, space_name, arg1, arg2, opts)
+            if option == 'router_object' and opts ~= nil and type(opts.vshard_router) == 'string' then
+                local router = router_service.get(opts.vshard_router)
+                opts.vshard_router = router
+            end
+
+            return crud[func](space_name, arg1, arg2, opts)
+        end
+
+        rawset(_G, 'call_wrapper_opts4', call_wrapper_opts4)
+
+        local function call_pairs_wrapper(option, space_name, arg1, opts)
+            if option == 'router_object' and opts ~= nil and type(opts.vshard_router) == 'string' then
+                local router = router_service.get(opts.vshard_router)
+                opts.vshard_router = router
+            end
+
+            local result = {}
+            for _, v in crud.pairs(space_name, arg1, opts) do
+                table.insert(result, v)
+            end
+
+            return result
+        end
+
+        rawset(_G, 'call_pairs_wrapper', call_pairs_wrapper)
+    ]])
+
+    g.call_router_opts2 = function(g, ...)
+        return g.router:call('call_wrapper_opts2', {g.params.option, ...})
+    end
+
+    g.call_router_opts3 = function(g, ...)
+        return g.router:call('call_wrapper_opts3', {g.params.option, ...})
+    end
+
+    g.call_router_opts4 = function(g, ...)
+        return g.router:call('call_wrapper_opts4', {g.params.option, ...})
+    end
+
+    g.call_router_pairs = function(g, ...)
+        return g.router:call('call_pairs_wrapper', {g.params.option, ...})
+    end
+end)
+
+pgroup.before_each(function(g)
+    helpers.truncate_space_on_cluster(g.cluster, 'customers')
+    helpers.truncate_space_on_cluster(g.cluster, 'customers_ddl')
+    helpers.truncate_space_on_cluster(g.cluster, 'locations')
+    helpers.truncate_space_on_cluster(g.cluster, 'locations_ddl')
+
+    g.router:call('prepare_data', {'customers', 'customers', {1, box.NULL, 'Akiyama Shun', 32}})
+    g.router:call('prepare_data', {'customers', 'customers', {2, box.NULL, 'Kazuma Kiryu', 41}})
+    g.router:call('prepare_data', {'customers_ddl', 'customers', {1, box.NULL, 'Akiyama Shun', 32}})
+    g.router:call('prepare_data', {'customers_ddl', 'customers', {2, box.NULL, 'Kazuma Kiryu', 41}})
+
+    g.router:call('prepare_data', {'locations', 'locations', {'Sky Finance', box.NULL, 'Credit company', 2}})
+    g.router:call('prepare_data', {'locations', 'locations', {'Sunflower', box.NULL, 'Orphanage', 1}})
+    g.router:call('prepare_data', {'locations_ddl', 'locations', {'Sky Finance', box.NULL, 'Credit company', 2}})
+    g.router:call('prepare_data', {'locations_ddl', 'locations', {'Sunflower', box.NULL, 'Orphanage', 1}})
+end)
+
+pgroup.test_call_min = function(g)
+    local result, err = g:call_router_opts3(
+        'min', 'customers', 'age', {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{1, 12477, 'Akiyama Shun', 32}})
+end
+
+pgroup.test_call_min_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'min', 'customers', 'age', {vshard_router = 'locations'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+end
+
+pgroup.test_call_min_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'min', 'customers', 'age')
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_min_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'min', 'customers', 'age', {vshard_router = {group = 'customers'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_max = function(g)
+    local result, err = g:call_router_opts3(
+        'max', 'locations', 'workers', {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Sky Finance', 26826, 'Credit company', 2}})
+end
+
+pgroup.test_call_max_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'max', 'locations', 'workers', {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_max_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'max', 'locations', 'workers')
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_max_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'max', 'locations', 'workers', {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_count_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'count', 'locations', {{'=', 'name', 'Sunflower'}}, {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(result, 1)
+end
+
+pgroup.test_call_count_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'count', 'customers_ddl', {{'=', 'age', 41}}, {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(result, 1)
+end
+
+pgroup.test_call_count_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'count', 'locations', {{'=', 'name', 'Sunflower'}}, {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_count_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'count', 'locations', {{'=', 'name', 'Sunflower'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_count_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'count', 'locations', {{'=', 'name', 'Sunflower'}}, {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.before_test('test_call_delete_with_default_sharding', function(g)
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Sky Finance'}
+    t.assert_equals(storage_result, {'Sky Finance', 26826, 'Credit company', 2})
+end)
+
+pgroup.test_call_delete_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'delete', 'locations', {'Sky Finance'}, {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    if g.params.engine == 'memtx' then
+        t.assert_items_equals(result.rows, {{'Sky Finance', 26826, 'Credit company', 2}})
+    else
+        t.assert_equals(#result.rows, 0)
+    end
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Sky Finance'}
+    t.assert_equals(storage_result, nil)
+end
+
+pgroup.before_test('test_call_delete_with_ddl_sharding', function(g)
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{2, 'Kazuma Kiryu'}
+    t.assert_equals(storage_result, {2, 8768, 'Kazuma Kiryu', 41})
+end)
+
+pgroup.test_call_delete_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'delete', 'customers_ddl', {2, 'Kazuma Kiryu'}, {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    if g.params.engine == 'memtx' then
+        t.assert_items_equals(result.rows, {{2, 8768, 'Kazuma Kiryu', 41}})
+    else
+        t.assert_equals(#result.rows, 0)
+    end
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{2, 'Kazuma Kiryu'}
+    t.assert_equals(storage_result, nil)
+end
+
+pgroup.test_call_delete_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'delete', 'locations', {'Sky Finance'}, {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_delete_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'delete', 'locations', {'Sky Finance'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_delete_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'delete', 'locations', {'Sky Finance'}, {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_get_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'get', 'locations', {'Sky Finance'}, {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Sky Finance', 26826, 'Credit company', 2}})
+end
+
+pgroup.test_call_get_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'get', 'customers_ddl', {2, 'Kazuma Kiryu'}, {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{2, 8768, 'Kazuma Kiryu', 41}})
+end
+
+pgroup.test_call_get_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'get', 'locations', {'Sky Finance'}, {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_get_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'get', 'locations', {'Sky Finance'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_get_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'get', 'locations', {'Sky Finance'}, {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_insert_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'insert',
+        'customers_ddl',
+        {4, box.NULL, 'Taiga Saejima', 45},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{4, 4344, 'Taiga Saejima', 45}})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_insert_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'insert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Okinawa Penitentiary No. 2', 19088, 'Prison', 100}})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_insert_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'insert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_insert_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'insert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_insert_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'insert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_insert_object_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'insert_object',
+        'customers_ddl',
+        {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{4, 4344, 'Taiga Saejima', 45}})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_insert_object_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'insert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Okinawa Penitentiary No. 2', 19088, 'Prison', 100}})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_insert_object_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'insert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_insert_object_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'insert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_insert_object_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'insert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_insert_many_with_default_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_many',
+        'customers',
+        {
+            {3, box.NULL, 'Masayoshi Tanimura', 29},
+            {4, box.NULL, 'Taiga Saejima', 45},
+        },
+        {vshard_router = 'customers'})
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                         {
+                             {3, 11804, 'Masayoshi Tanimura', 29},
+                             {4, 28161, 'Taiga Saejima', 45}
+                         })
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers']:get{3}
+    t.assert_equals(storage_result, {3, 11804, 'Masayoshi Tanimura', 29})
+
+    local storage = g.cluster:server('customers-storage-1').net_box
+    local storage_result = storage.space['customers']:get{4}
+    t.assert_equals(storage_result, {4, 28161, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_insert_many_with_ddl_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_many',
+        'locations_ddl',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}
+        },
+        {vshard_router = 'locations'})
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                    {
+                        {'Tokyo Police Department', 28259, 'Police', 40000},
+                        {'Okinawa Penitentiary No. 2', 6427, 'Prison', 100}
+                    })
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations_ddl']:get{'Tokyo Police Department', 'Police'}
+    t.assert_equals(storage_result, {'Tokyo Police Department', 28259, 'Police', 40000})
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations_ddl']:get{'Okinawa Penitentiary No. 2', 'Prison'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 6427, 'Prison', 100})
+end
+
+pgroup.test_call_insert_many_wrong_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_many',
+        'locations',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        },
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_insert_many_no_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_many',
+        'locations',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}
+        })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_insert_many_wrong_option = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_many',
+        'locations',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}
+        },
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_insert_object_many_with_default_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_object_many',
+        'locations',
+        {
+            {name = 'Tokyo Police Department', bucket_id = box.NULL, type = 'Police', workers = 40000},
+            {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100}
+        },
+        {vshard_router = 'locations'}
+    )
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                          {
+                              {'Tokyo Police Department', 9017, 'Police', 40000},
+                              {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100},
+                          })
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations']:get{'Tokyo Police Department'}
+    t.assert_equals(storage_result, {'Tokyo Police Department', 9017, 'Police', 40000})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_insert_object_many_with_ddl_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_object_many',
+        'customers_ddl',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        },
+        {vshard_router = 'customers'}
+    )
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                          {
+                              {3, 2900, 'Masayoshi Tanimura', 29},
+                              {4, 4344, 'Taiga Saejima', 45}
+                          })
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{3, 'Masayoshi Tanimura'}
+    t.assert_equals(storage_result, {3, 2900, 'Masayoshi Tanimura', 29})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_insert_object_many_wrong_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_object_many',
+        'customers',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        },
+        {vshard_router = 'locations'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err, "Space \"customers\" doesn't exist")
+end
+
+pgroup.test_call_insert_object_many_no_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_object_many',
+        'customers',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_insert_object_many_wrong_option = function(g)
+    local result, errs = g:call_router_opts3(
+        'insert_object_many',
+        'customers',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        },
+        {vshard_router = {group = 'customers'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_len = function(g)
+    local result, err = g:call_router_opts2(
+        'len', 'customers', {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(result, 2)
+end
+
+pgroup.test_call_len_wrong_router = function(g)
+    local result, err = g:call_router_opts2(
+        'len', 'customers', {vshard_router = 'locations'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+end
+
+pgroup.test_call_len_no_router = function(g)
+    local result, err = g:call_router_opts2(
+        'len', 'customers')
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_len_wrong_option = function(g)
+    local result, err = g:call_router_opts2(
+        'len', 'customers', {vshard_router = {group = 'customers'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_replace_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'replace',
+        'customers_ddl',
+        {4, box.NULL, 'Taiga Saejima', 45},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{4, 4344, 'Taiga Saejima', 45}})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_replace_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'replace',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Okinawa Penitentiary No. 2', 19088, 'Prison', 100}})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_replace_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'replace',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_replace_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'replace',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_replace_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'replace',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_replace_object_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'replace_object',
+        'customers_ddl',
+        {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{4, 4344, 'Taiga Saejima', 45}})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_replace_object_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'replace_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Okinawa Penitentiary No. 2', 19088, 'Prison', 100}})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_replace_object_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'replace_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_replace_object_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'replace_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_replace_object_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'replace_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_replace_many_with_default_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_many',
+        'customers',
+        {
+            {3, box.NULL, 'Masayoshi Tanimura', 29},
+            {4, box.NULL, 'Taiga Saejima', 45},
+        },
+        {vshard_router = 'customers'})
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                         {
+                             {3, 11804, 'Masayoshi Tanimura', 29},
+                             {4, 28161, 'Taiga Saejima', 45}
+                         })
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers']:get{3}
+    t.assert_equals(storage_result, {3, 11804, 'Masayoshi Tanimura', 29})
+
+    local storage = g.cluster:server('customers-storage-1').net_box
+    local storage_result = storage.space['customers']:get{4}
+    t.assert_equals(storage_result, {4, 28161, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_replace_many_with_ddl_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_many',
+        'locations_ddl',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}
+        },
+        {vshard_router = 'locations'})
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                    {
+                        {'Tokyo Police Department', 28259, 'Police', 40000},
+                        {'Okinawa Penitentiary No. 2', 6427, 'Prison', 100}
+                    })
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations_ddl']:get{'Tokyo Police Department', 'Police'}
+    t.assert_equals(storage_result, {'Tokyo Police Department', 28259, 'Police', 40000})
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations_ddl']:get{'Okinawa Penitentiary No. 2', 'Prison'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 6427, 'Prison', 100})
+end
+
+pgroup.test_call_replace_many_wrong_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_many',
+        'locations',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        },
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_replace_many_no_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_many',
+        'locations',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}
+        })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_replace_many_wrong_option = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_many',
+        'locations',
+        {
+            {'Tokyo Police Department', box.NULL, 'Police', 40000},
+            {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}
+        },
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_replace_object_many_with_default_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_object_many',
+        'locations',
+        {
+            {name = 'Tokyo Police Department', bucket_id = box.NULL, type = 'Police', workers = 40000},
+            {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100}
+        },
+        {vshard_router = 'locations'}
+    )
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                          {
+                              {'Tokyo Police Department', 9017, 'Police', 40000},
+                              {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100},
+                          })
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations']:get{'Tokyo Police Department'}
+    t.assert_equals(storage_result, {'Tokyo Police Department', 9017, 'Police', 40000})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_replace_object_many_with_ddl_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_object_many',
+        'customers_ddl',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        },
+        {vshard_router = 'customers'}
+    )
+
+    t.assert_equals(errs, nil)
+    t.assert_items_equals(result.rows,
+                          {
+                              {3, 2900, 'Masayoshi Tanimura', 29},
+                              {4, 4344, 'Taiga Saejima', 45}
+                          })
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{3, 'Masayoshi Tanimura'}
+    t.assert_equals(storage_result, {3, 2900, 'Masayoshi Tanimura', 29})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_replace_object_many_wrong_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_object_many',
+        'customers',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        },
+        {vshard_router = 'locations'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err, "Space \"customers\" doesn't exist")
+end
+
+pgroup.test_call_replace_object_many_no_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_object_many',
+        'customers',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_replace_object_many_wrong_option = function(g)
+    local result, errs = g:call_router_opts3(
+        'replace_object_many',
+        'customers',
+        {
+            {id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29},
+            {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        },
+        {vshard_router = {group = 'customers'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_select_with_default_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'select',
+        'locations',
+        {{'=', 'name', 'Sky Finance'}},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Sky Finance', 26826, 'Credit company', 2}})
+end
+
+pgroup.test_call_select_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts3(
+        'select',
+        'customers_ddl',
+        {{'=', 'id', 2}, {'=', 'name', 'Kazuma Kiryu'}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{2, 8768, 'Kazuma Kiryu', 41}})
+end
+
+pgroup.test_call_select_wrong_router = function(g)
+    local result, err = g:call_router_opts3(
+        'select',
+        'locations',
+        {{'=', 'name', 'Sky Finance'}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_select_no_router = function(g)
+    local result, err = g:call_router_opts3(
+        'select', 'locations', {{'=', 'name', 'Sky Finance'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_select_wrong_option = function(g)
+    local result, err = g:call_router_opts3(
+        'select', 'locations', {{'=', 'name', 'Sky Finance'}}, {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_pairs_with_default_sharding = function(g)
+    local result, err = g:call_router_pairs(
+        'locations',
+        {{'=', 'name', 'Sky Finance'}},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result, {{'Sky Finance', 26826, 'Credit company', 2}})
+end
+
+pgroup.test_call_pairs_with_ddl_sharding = function(g)
+    local result, err = g:call_router_pairs(
+        'customers_ddl',
+        {{'=', 'id', 2}, {'=', 'name', 'Kazuma Kiryu'}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result, {{2, 8768, 'Kazuma Kiryu', 41}})
+end
+
+pgroup.test_call_pairs_wrong_router = function(g)
+    t.assert_error_msg_contains(
+        "Space \"locations\" doesn't exist",
+        g.call_router_pairs, g, 'locations', {{'=', 'name', 'Sky Finance'}}, {vshard_router = 'customers'})
+end
+
+pgroup.test_call_pairs_no_router = function(g)
+    t.assert_error_msg_contains(
+        "Default vshard group is not found and custom is not specified with opts.vshard_router",
+        g.call_router_pairs, g, 'locations', {{'=', 'name', 'Sky Finance'}})
+end
+
+pgroup.test_call_pairs_wrong_option = function(g)
+    t.assert_error_msg_contains(
+        "Invalid opts.vshard_router table value, a vshard router instance has been expected",
+        g.call_router_pairs, g, 'locations', {{'=', 'name', 'Sky Finance'}}, {vshard_router = {group = 'locations'}})
+end
+
+pgroup.before_test('test_call_truncate', function(g)
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Sky Finance'}
+    t.assert_equals(storage_result, {'Sky Finance', 26826, 'Credit company', 2})
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations']:get{'Sunflower'}
+    t.assert_equals(storage_result, {'Sunflower', 12261, 'Orphanage', 1})
+end)
+
+pgroup.test_call_truncate = function(g)
+    local result, err = g:call_router_opts2(
+        'truncate', 'locations', {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(result, true)
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Sky Finance'}
+    t.assert_equals(storage_result, nil)
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations']:get{'Sunflower'}
+    t.assert_equals(storage_result, nil)
+end
+
+pgroup.test_call_truncate_wrong_router = function(g)
+    local result, err = g:call_router_opts2(
+        'truncate', 'customers', {vshard_router = 'locations'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"customers\" doesn't exist")
+end
+
+pgroup.test_call_truncate_no_router = function(g)
+    local result, err = g:call_router_opts2(
+        'truncate', 'customers')
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_truncate_wrong_option = function(g)
+    local result, err = g:call_router_opts2(
+        'truncate', 'customers', {vshard_router = {group = 'customers'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_update_with_default_sharding = function(g)
+    local result, err = g:call_router_opts4(
+        'update',
+        'locations',
+        {'Sky Finance'},
+        {{'-', 'workers', 1}},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{'Sky Finance', 26826, 'Credit company', 1}})
+end
+
+pgroup.test_call_update_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts4(
+        'update',
+        'customers_ddl',
+        {2, 'Kazuma Kiryu'},
+        {{'+', 'age', 1}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {{2, 8768, 'Kazuma Kiryu', 42}})
+end
+
+pgroup.test_call_update_wrong_router = function(g)
+    local result, err = g:call_router_opts4(
+        'update',
+        'locations',
+        {'Sky Finance'},
+        {{'-', 'workers', 1}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_update_no_router = function(g)
+    local result, err = g:call_router_opts4(
+        'update',
+        'locations',
+        {'Sky Finance'},
+        {{'-', 'workers', 1}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_update_wrong_option = function(g)
+    local result, err = g:call_router_opts4(
+        'update',
+        'locations',
+        {'Sky Finance'},
+        {{'-', 'workers', 1}},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_upsert_with_default_sharding = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert',
+        'customers_ddl',
+        {4, box.NULL, 'Taiga Saejima', 45},
+        {{'+', 'age', 1}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_upsert_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {{'-', 'workers', 1}},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_upsert_wrong_router = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {{'-', 'workers', 1}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_upsert_no_router = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {{'-', 'workers', 1}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_upsert_wrong_option = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert',
+        'locations',
+        {'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100},
+        {{'-', 'workers', 1}},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_upsert_object_with_default_sharding = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert_object',
+        'customers_ddl',
+        {id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45},
+        {{'+', 'age', 1}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_upsert_object_with_ddl_sharding = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {{'-', 'workers', 1}},
+        {vshard_router = 'locations'})
+
+    t.assert_equals(err, nil)
+    t.assert_items_equals(result.rows, {})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_upsert_object_wrong_router = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {{'-', 'workers', 1}},
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_upsert_object_no_router = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {{'-', 'workers', 1}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_upsert_object_wrong_option = function(g)
+    local result, err = g:call_router_opts4(
+        'upsert_object',
+        'locations',
+        {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+        {{'-', 'workers', 1}},
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_upsert_many_with_default_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_many',
+        'customers',
+        {
+            {{3, box.NULL, 'Masayoshi Tanimura', 29}, {{'+', 'age', 1}}},
+            {{4, box.NULL, 'Taiga Saejima', 45}, {{'+', 'age', 1}}}
+        },
+        {vshard_router = 'customers'})
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.rows, nil)
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers']:get{3}
+    t.assert_equals(storage_result, {3, 11804, 'Masayoshi Tanimura', 29})
+
+    local storage = g.cluster:server('customers-storage-1').net_box
+    local storage_result = storage.space['customers']:get{4}
+    t.assert_equals(storage_result, {4, 28161, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_upsert_many_with_ddl_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_many',
+        'locations_ddl',
+        {
+            {{'Tokyo Police Department', box.NULL, 'Police', 40000}, {{'-', 'workers', 1}}},
+            {{'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}, {{'-', 'workers', 1}}}
+        },
+        {vshard_router = 'locations'})
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.rows, nil)
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations_ddl']:get{'Tokyo Police Department', 'Police'}
+    t.assert_equals(storage_result, {'Tokyo Police Department', 28259, 'Police', 40000})
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations_ddl']:get{'Okinawa Penitentiary No. 2', 'Prison'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 6427, 'Prison', 100})
+end
+
+pgroup.test_call_upsert_many_wrong_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_many',
+        'locations',
+        {
+            {{'Tokyo Police Department', box.NULL, 'Police', 40000}, {{'-', 'workers', 1}}},
+            {{'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}, {{'-', 'workers', 1}}}
+        },
+        {vshard_router = 'customers'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err, "Space \"locations\" doesn't exist")
+end
+
+pgroup.test_call_upsert_many_no_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_many',
+        'locations',
+        {
+            {{'Tokyo Police Department', box.NULL, 'Police', 40000}, {{'-', 'workers', 1}}},
+            {{'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}, {{'-', 'workers', 1}}}
+        })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_upsert_many_wrong_option = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_many',
+        'locations',
+        {
+            {{'Tokyo Police Department', box.NULL, 'Police', 40000}, {{'-', 'workers', 1}}},
+            {{'Okinawa Penitentiary No. 2', box.NULL, 'Prison', 100}, {{'-', 'workers', 1}}}
+        },
+        {vshard_router = {group = 'locations'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end
+
+pgroup.test_call_upsert_object_many_with_default_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_object_many',
+        'locations',
+        {
+            {
+                {name = 'Tokyo Police Department', bucket_id = box.NULL, type = 'Police', workers = 40000},
+                {{'-', 'workers', 1}}
+            },
+            {
+                {name = 'Okinawa Penitentiary No. 2', bucket_id = box.NULL, type = 'Prison', workers = 100},
+                {{'-', 'workers', 1}}
+            }
+        },
+        {vshard_router = 'locations'}
+    )
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.rows, nil)
+
+    local storage = g.cluster:server('locations-storage-2').net_box
+    local storage_result = storage.space['locations']:get{'Tokyo Police Department'}
+    t.assert_equals(storage_result, {'Tokyo Police Department', 9017, 'Police', 40000})
+
+    local storage = g.cluster:server('locations-storage-1').net_box
+    local storage_result = storage.space['locations']:get{'Okinawa Penitentiary No. 2'}
+    t.assert_equals(storage_result, {'Okinawa Penitentiary No. 2', 19088, 'Prison', 100})
+end
+
+pgroup.test_call_upsert_object_many_with_ddl_sharding = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_object_many',
+        'customers_ddl',
+        {
+            {{id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29}, {{'+', 'age', 1}}},
+            {{id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45}, {{'+', 'age', 1}}},
+        },
+        {vshard_router = 'customers'}
+    )
+
+    t.assert_equals(errs, nil)
+    t.assert_equals(result.rows, nil)
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{3, 'Masayoshi Tanimura'}
+    t.assert_equals(storage_result, {3, 2900, 'Masayoshi Tanimura', 29})
+
+    local storage = g.cluster:server('customers-storage-2').net_box
+    local storage_result = storage.space['customers_ddl']:get{4, 'Taiga Saejima'}
+    t.assert_equals(storage_result, {4, 4344, 'Taiga Saejima', 45})
+end
+
+pgroup.test_call_upsert_object_many_wrong_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_object_many',
+        'customers',
+        {
+            {{id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29}, {{'+', 'age', 1}}},
+            {{id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45}, {{'+', 'age', 1}}},
+        },
+        {vshard_router = 'locations'})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err, "Space \"customers\" doesn't exist")
+end
+
+pgroup.test_call_upsert_object_many_no_router = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_object_many',
+        'customers',
+        {
+            {{id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29}, {{'+', 'age', 1}}},
+            {{id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45}, {{'+', 'age', 1}}},
+        })
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Default vshard group is not found and custom is not specified with opts.vshard_router")
+end
+
+pgroup.test_call_upsert_object_many_wrong_option = function(g)
+    local result, errs = g:call_router_opts3(
+        'upsert_object_many',
+        'customers',
+        {
+            {{id = 3, bucket_id = box.NULL, name = 'Masayoshi Tanimura', age = 29}, {{'+', 'age', 1}}},
+            {{id = 4, bucket_id = box.NULL, name = 'Taiga Saejima', age = 45}, {{'+', 'age', 1}}},
+        },
+        {vshard_router = {group = 'customers'}})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(errs[1].err,
+                          "Invalid opts.vshard_router table value, a vshard router instance has been expected")
+end

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -61,8 +61,10 @@ end
 
 g.test_map_non_existent_func = function()
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.map('non_existent_func', nil, {mode = 'write'})
+
+        return call.map(vshard.router.static, 'non_existent_func', nil, {mode = 'write'})
     ]])
 
     t.assert_equals(results, nil)
@@ -72,8 +74,10 @@ end
 
 g.test_single_non_existent_func = function()
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.single(1, 'non_existent_func', nil, {mode = 'write'})
+
+        return call.single(vshard.router.static, 1, 'non_existent_func', nil, {mode = 'write'})
     ]])
 
     t.assert_equals(results, nil)
@@ -83,8 +87,10 @@ end
 
 g.test_map_invalid_mode = function()
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.map('say_hi_politely', nil, {mode = 'invalid'})
+
+        return call.map(vshard.router.static, 'say_hi_politely', nil, {mode = 'invalid'})
     ]])
 
     t.assert_equals(results, nil)
@@ -93,8 +99,10 @@ end
 
 g.test_single_invalid_mode = function()
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.single(1, 'say_hi_politely', nil, {mode = 'invalid'})
+
+        return call.single(vshard.router.static, 1, 'say_hi_politely', nil, {mode = 'invalid'})
     ]])
 
     t.assert_equals(results, nil)
@@ -103,8 +111,10 @@ end
 
 g.test_map_no_args = function()
     local results_map, err  = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.map('say_hi_politely', nil, {mode = 'write'})
+
+        return call.map(vshard.router.static, 'say_hi_politely', nil, {mode = 'write'})
     ]])
 
     t.assert_equals(err, nil)
@@ -115,8 +125,10 @@ end
 
 g.test_args = function()
     local results_map, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.map('say_hi_politely', {'dokshina'}, {mode = 'write'})
+
+        return call.map(vshard.router.static, 'say_hi_politely', {'dokshina'}, {mode = 'write'})
     ]])
 
     t.assert_equals(err, nil)
@@ -129,11 +141,12 @@ g.test_timeout = function()
     local timeout = 0.2
 
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
 
         local say_hi_timeout, call_timeout = ...
 
-        return call.map('say_hi_sleepily', {say_hi_timeout}, {
+        return call.map(vshard.router.static, 'say_hi_sleepily', {say_hi_timeout}, {
             mode = 'write',
             timeout = call_timeout,
         })
@@ -147,9 +160,11 @@ end
 local function check_single_vshard_call(g, exp_vshard_call, opts)
     g.clear_vshard_calls()
     local _, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
+
         local opts = ...
-        return call.single(1, 'say_hi_politely', {'dokshina'}, opts)
+        return call.single(vshard.router.static, 1, 'say_hi_politely', {'dokshina'}, opts)
     ]], {opts})
     t.assert_equals(err, nil)
     local vshard_calls = g.get_vshard_calls()
@@ -159,9 +174,11 @@ end
 local function check_map_vshard_call(g, exp_vshard_call, opts)
     g.clear_vshard_calls()
     local _, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
+
         local opts = ...
-        return call.map('say_hi_politely', {'dokshina'}, opts)
+        return call.map(vshard.router.static, 'say_hi_politely', {'dokshina'}, opts)
     ]], {opts})
     t.assert_equals(err, nil)
     local vshard_calls = g.get_vshard_calls()
@@ -249,8 +266,10 @@ end
 g.test_any_vshard_call = function()
     g.clear_vshard_calls()
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
-        return call.any('say_hi_politely', {'dude'}, {})
+
+        return call.any(vshard.router.static, 'say_hi_politely', {'dude'}, {})
     ]])
 
     t.assert_equals(results, 'HI, dude! I am s2-master')
@@ -261,11 +280,12 @@ g.test_any_vshard_call_timeout = function()
     local timeout = 0.2
 
     local results, err = g.cluster.main_server.net_box:eval([[
+        local vshard = require('vshard')
         local call = require('crud.common.call')
 
         local say_hi_timeout, call_timeout = ...
 
-        return call.any('say_hi_sleepily', {say_hi_timeout}, {
+        return call.any(vshard.router.static, 'say_hi_sleepily', {say_hi_timeout}, {
             timeout = call_timeout,
         })
     ]], {timeout + 0.1, timeout})

--- a/test/unit/sharding_metadata_test.lua
+++ b/test/unit/sharding_metadata_test.lua
@@ -4,7 +4,7 @@ local sharding_metadata_module = require('crud.common.sharding.sharding_metadata
 local sharding_key_module = require('crud.common.sharding.sharding_key')
 local sharding_func_module = require('crud.common.sharding.sharding_func')
 local sharding_utils = require('crud.common.sharding.utils')
-local cache = require('crud.common.sharding.router_metadata_cache')
+local router_cache = require('crud.common.sharding.router_metadata_cache')
 local storage_cache = require('crud.common.sharding.storage_metadata_cache')
 local utils = require('crud.common.utils')
 
@@ -56,7 +56,7 @@ g.after_each(function()
     end
 
     box.space.fetch_on_storage:drop()
-    cache.drop_caches()
+    router_cache.drop_caches()
     storage_cache.drop_caches()
 end)
 
@@ -298,7 +298,8 @@ g.test_is_part_of_pk_positive = function()
     }
 
     local is_part_of_pk = sharding_key_module.internal.is_part_of_pk
-    local res = is_part_of_pk(space_name, index_parts, sharding_key_as_index_obj)
+    local cache = router_cache.get_instance({name = 'dummy'})
+    local res = is_part_of_pk(cache, space_name, index_parts, sharding_key_as_index_obj)
     t.assert_equals(res, true)
 end
 
@@ -315,7 +316,8 @@ g.test_is_part_of_pk_negative = function()
     }
 
     local is_part_of_pk = sharding_key_module.internal.is_part_of_pk
-    local res = is_part_of_pk(space_name, index_parts, sharding_key_as_index_obj)
+    local cache = router_cache.get_instance({name = 'dummy'})
+    local res = is_part_of_pk(cache, space_name, index_parts, sharding_key_as_index_obj)
     t.assert_equals(res, false)
 end
 


### PR DESCRIPTION
### readme: fix args description

### changelog: use single format

After discussion with Ecosystem team, we decided not to specify PR in CHANGELOG entries if there is a related issue. This patch make last CHANGELOG entries consistent.

### api: deprecate using space id in len

Part of #255

### internal: use vshard router object

This patch is the groundwork for vshard groups and custom routers
support.

Test runs have shown that this patch do not affects the performance of
crud requests.

Part of #44

### internal: rework replicasets schema reload

This patch is the groundwork for vshard groups and custom routers
support.

After this patch, schema reload works per vshard router object.

Test runs have shown that this patch do not affects the performance of
crud requests.

Part of #44

### internal: rework sharding schema reload

This patch is the groundwork for vshard groups and custom routers
support.

After this patch, sharding schema reload works per vshard router object.

Test runs have shown that this patch do not affects the performance of
crud requests.

Part of #44

### internal: use single router object

This patch is the groundwork for vshard groups and custom routers
support.

After this patch, vshard router object is retrieved only in the single
point of a request. (Except for name resolving in statistics.)

Test runs have shown that this patch do not affects the performance of
crud requests.

Part of #44

### api: support vshard groups

This patch adds Cartridge vshard groups [1] and non-default vshard router [2] support to CRUD operations.

To specify Cartridge vshard group, pass vshard group name with `vshard_router` option of a crud operation.
```lua
crud.select('customers_ddl',
            {{'=', 'age', 41}},
            {vshard_router = 'customers'})
```

To use non-default vshard router, pass vshard router object with `vshard_router` option of a crud operation.
```lua
local router = vshard.router.new(cfg)

crud.select('customers_ddl',
            {{'=', 'age', 41}},
            {vshard_router = router})
```

If `vshard_router` is not specified, default vshard router is used to process the request. If default vshard router is not found (for example, if it is a Cartridge application with vshard groups) and option is not specified, the error is returned.

1. https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#using-multiple-vshard-storage-groups
2. https://www.tarantool.io/ru/doc/latest/reference/reference_rock/vshard/vshard_router/#router-api-new

Closes #44

### stats: warn for using id with custom router

CRUD stats are separated by space name. If space id is passed instead of name (only `crud.len` allows this), space name is resolved with net_box schema. Since, after resolving #44, non-default vshard routers and Cartridge vshard groups are supported, to resolve the name we must know what vshard router should be used. Since using space id for `crud.len` is deprecated now, we won't support name resolve for operations with custom router statistics. Instead of this, a warning will be logged. `crud.len` statistics will be signed by space name or space id casted to string depending on is there a default router with space schema or not.

Follows up #44, part of #255

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation
