### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 13-09-22
 
 ### Added
 * Support `vshard_router` option in operations for Cartridge vshard groups


### PR DESCRIPTION
## Overview

This release introduces vshard group and non-default vshard routers support.

To use a space Cartridge vshard group, pass group name to a `vshard_group` request option.

```lua
local res, err = crud.select('customers',
                             {{'<=', 'age', 35}},
                             {first = 10, vshard_group = 'hot'})
```

To use non-default vshard router, pass router object to a `vshard_group` request option.

```lua
local my_router = vshard.router.new(name, cfg)
local res, err = crud.select('customers',
                             {{'<=', 'age', 35}},
                             {first = 10, vshard_group = my_router})
```

## New features

* vshard group and non-default vshard routers support (#44).

## Changes

* Deprecate using space id in crud.len (#255).