### PR TITLE
api: rework NonInitialized error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* Rework `NonInitialized` error message to be more helpful for
+  troubleshooting (#326).
+
 ## [0.14.0] - 13-09-22
 
 ### Added

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -707,8 +707,10 @@ function utils.update_storage_call_error_description(err, func_name, replicaset_
     if err.type == 'ClientError' and type(err.message) == 'string' then
         if err.message == string.format("Procedure '%s' is not defined", func_name) then
             if func_name:startswith('_crud.') then
-                err = NotInitializedError:new("crud isn't initialized on replicaset: %q",
-                    replicaset_uuid or "Unknown")
+                err = NotInitializedError:new("Function %s is not registered: " ..
+                    "crud isn't initialized on replicaset %q or crud module versions mismatch " ..
+                    "between router and storage",
+                    func_name, replicaset_uuid or "Unknown")
             else
                 err = NotInitializedError:new("Function %s is not registered", func_name)
             end

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -1987,7 +1987,9 @@ pgroup.test_storage_uninit_select_error_text = function(g)
     t.assert_equals(obj, nil)
     t.assert_str_contains(err.str, 'SelectError')
     t.assert_str_contains(err.str, 'NotInitialized')
+    t.assert_str_contains(err.str, "Function _crud.select_on_storage is not registered")
     t.assert_str_contains(err.str, "crud isn't initialized on replicaset")
+    t.assert_str_contains(err.str, "or crud module versions mismatch between router and storage")
 end
 
 pgroup.before_test('test_storage_uninit_get_error_text', function(g)
@@ -2015,5 +2017,7 @@ pgroup.test_storage_uninit_get_error_text = function(g)
     t.assert_equals(obj, nil)
     t.assert_str_contains(err.str, 'GetError')
     t.assert_str_contains(err.str, 'NotInitialized')
+    t.assert_str_contains(err.str, "Function _crud.get_on_storage is not registered")
     t.assert_str_contains(err.str, "crud isn't initialized on replicaset")
+    t.assert_str_contains(err.str, "or crud module versions mismatch between router and storage")
 end


### PR DESCRIPTION
Rework `NonInitialized` error message to be more helpful for troubleshooting.

Follows #229, closes #326

I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation (change is too small to be worth documenting)
