### PR TITLE
CI health updates

### DIFF
--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -9,7 +9,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Tarantool CE
       uses: tarantool/setup-tarantool@v2
       with:
-        tarantool-version: '2.6'
+        tarantool-version: '2.10'
 
     - name: Setup luacheck
       run: tarantoolctl rocks install luacheck 0.25.0

--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Setup Tarantool
-      uses: tarantool/setup-tarantool@v1
+    - name: Setup Tarantool CE
+      uses: tarantool/setup-tarantool@v2
       with:
         tarantool-version: '2.6'
 

--- a/.github/workflows/push_rockspec.yaml
+++ b/.github/workflows/push_rockspec.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   push-scm-rockspec:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@master
@@ -23,7 +23,7 @@ jobs:
           files: ${{ env.ROCK_NAME }}-scm-1.rockspec
 
   push-tagged-rockspec:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-20.04
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -29,7 +29,9 @@ jobs:
             coveralls: true
             metrics-version: "0.12.0"
       fail-fast: false
-    runs-on: [ubuntu-latest]
+    # Can't install older versions on 22.04,
+    # see https://github.com/tarantool/setup-tarantool/issues/36
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
 
@@ -80,7 +82,7 @@ jobs:
         tarantool-version: ["1.10", "2.8"]
         metrics-version: ["0.12.0"]
       fail-fast: false
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
 
@@ -113,7 +115,7 @@ jobs:
         bundle_version: [ "1.10.11-0-gf0b0e7ecf-r422", "2.7.3-0-gdddf926c3-r422" ]
         metrics-version: ["", "0.12.0"]
       fail-fast: false
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -25,7 +25,7 @@ jobs:
             metrics-version: "0.1.8"
           - tarantool-version: "2.8"
             metrics-version: "0.10.0"
-          - tarantool-version: "2.8"
+          - tarantool-version: "2.10"
             coveralls: true
             metrics-version: "0.12.0"
       fail-fast: false
@@ -79,7 +79,7 @@ jobs:
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.8"]
+        tarantool-version: ["1.10", "2.10"]
         metrics-version: ["0.12.0"]
       fail-fast: false
     runs-on: ubuntu-20.04
@@ -112,7 +112,11 @@ jobs:
     if: github.event_name == 'push'
     strategy:
       matrix:
-        bundle_version: [ "1.10.11-0-gf0b0e7ecf-r422", "2.7.3-0-gdddf926c3-r422" ]
+        tarantool-version:
+          - folder: "1.10"
+            bundle: "tarantool-enterprise-sdk-1.10.13-48-r523"
+          - folder: "2.10"
+            bundle: "tarantool-enterprise-sdk-nogc64-2.10.4-0-r523.linux.x86_64"
         metrics-version: ["", "0.12.0"]
       fail-fast: false
     runs-on: ubuntu-20.04
@@ -121,9 +125,9 @@ jobs:
 
       - name: Install requirements for enterprise
         run: |
-          curl -O -L https://tarantool:${{ secrets.DOWNLOAD_TOKEN }}@download.tarantool.io/enterprise/tarantool-enterprise-bundle-${{ matrix.bundle_version }}.tar.gz
-          tar -xzf tarantool-enterprise-bundle-${{ matrix.bundle_version }}.tar.gz
-          rm -f tarantool-enterprise-bundle-${{ matrix.bundle_version }}.tar.gz
+          curl -O -L https://tarantool:${{ secrets.DOWNLOAD_TOKEN }}@download.tarantool.io/enterprise/release/linux/x86_64/${{ matrix.tarantool-version.folder }}/${{ matrix.tarantool-version.bundle }}.tar.gz
+          tar -xzf ${{ matrix.tarantool-version.bundle }}.tar.gz
+          rm -f ${{ matrix.tarantool-version.bundle }}.tar.gz
           sudo cp tarantool-enterprise/tarantool /usr/bin/tarantool
           source tarantool-enterprise/env.sh
           tarantool --version

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup Tarantool CE
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool-version }}
 
@@ -86,8 +86,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Setup Tarantool CE 
-        uses: tarantool/setup-tarantool@v1
+      - name: Setup Tarantool CE
+        uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool-version }}
 


### PR DESCRIPTION
### ci: bump Tarantool used on lint

### ci: bump setup-tarantool action

tarantool/setup-tarantool@v1 is based on Node.js 12 which is deprecated
in GitHub Actions now [1].

1. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### ci: run on ubuntu-20.04

ubuntu-latest is now ubuntu-22.04 instead of 20.04 [1]. For reasons yet
unknown, setup-tarantool action not works on ubuntu-22.04 runners [2].
After the issue will be fixed, we may return back to ubuntu-latest.

1. https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/
2. https://github.com/tarantool/setup-tarantool/issues/36

I didn't forget about

- [x] Tests (are still green)
- Changelog (not related to a package)
- [x] Documentation (changes in comments)
