### PR TITLE
ci: add reusable testing workflow for crud module

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -1,0 +1,47 @@
+name: Reusable test
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the Tarantool build artifact
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Clone the crud module
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository_owner }}/crud
+
+      - name: Download the Tarantool build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      # All dependencies for tarantool are already installed in Ubuntu 20.04.
+      # Check package dependencies when migrating to other OS version.
+      - name: Install Tarantool
+        run: |
+          sudo dpkg -i tarantool_*.deb tarantool-common_*.deb tarantool-dev_*.deb
+          tarantool --version
+
+      - name: Install requirements
+        run: ./deps.sh
+
+      - name: Install metrics
+        run: tarantoolctl rocks install metrics 0.12.0
+
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
+      - run: cmake -S . -B build
+
+      - name: Run regression tests
+        run: make -C build luatest-no-coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ add_custom_target(luatest
   COMMENT "Run regression tests"
 )
 
+add_custom_target(luatest-no-coverage
+  COMMAND ${LUATEST} -v
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Run regression tests without coverage"
+)
+
 set(PERFORMANCE_TESTS_SUBDIR "test/performance")
 
 add_custom_target(performance


### PR DESCRIPTION
Add reusable testing workflow for integration
testing of crud module.

Part of tarantool/tarantool#6620

I didn't forget about

- [Tests](https://github.com/tarantool/tarantool/actions/runs/3749354667/jobs/6367850717)
- [Tested negatively here](https://github.com/tarantool/tarantool/actions/runs/3749505598/jobs/6368187258) 