### PR TITLE
internal: master conn check for get space utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added validation of the master presence in replicaset and the 
   master connection to the `utils.get_space` method before 
   receiving the space from the connection (#331).
+* Fixed fiber cancel on schema reload timeout in `call_reload_schema`.
 
 ## [0.14.1] - 10-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+* Added validation of the master presence in replicaset and the 
+  master connection to the `utils.get_space` method before 
+  receiving the space from the connection (#331).
 
 ## [0.14.1] - 10-11-22
 

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -74,7 +74,10 @@ local function call_get_border_on_router(vshard_router, border_name, space_name,
     })
 
     local replicasets = vshard_router:routeall()
-    local space = utils.get_space(space_name, replicasets)
+    local space, err = utils.get_space(space_name, replicasets)
+    if err ~= nil then
+        return nil, BorderError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, BorderError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -37,7 +37,7 @@ local function call_reload_schema(replicasets)
     for _ = 1,replicasets_num do
         if channel:get(const.RELOAD_SCHEMA_TIMEOUT) == nil then
             for _, f in ipairs(fibers) do
-                if fiber:status() ~= 'dead' then
+                if f:status() ~= 'dead' then
                     f:cancel()
                 end
             end

--- a/crud/count.lua
+++ b/crud/count.lua
@@ -137,7 +137,10 @@ local function call_count_on_router(vshard_router, space_name, user_conditions, 
         return nil, CountError:new("Failed to get router replicasets: %s", err)
     end
 
-    local space = utils.get_space(space_name, replicasets)
+    local space, err = utils.get_space(space_name, replicasets)
+    if err ~= nil then
+        return nil, CountError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, CountError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -62,7 +62,10 @@ local function call_delete_on_router(vshard_router, space_name, key, opts)
         vshard_router = '?string|table',
     })
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, DeleteError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, DeleteError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -65,7 +65,10 @@ local function call_get_on_router(vshard_router, space_name, key, opts)
         vshard_router = '?string|table',
     })
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, GetError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, GetError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -64,7 +64,10 @@ local function call_insert_on_router(vshard_router, space_name, original_tuple, 
         vshard_router = '?string|table',
     })
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, InsertError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, InsertError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -131,7 +131,12 @@ local function call_insert_many_on_router(vshard_router, space_name, original_tu
         vshard_router = '?string|table',
     })
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, {
+            InsertManyError:new("An error occurred during the operation: %s", err)
+        }, const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, {InsertManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
     end

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -64,7 +64,10 @@ function len.call(space_name, opts)
         return nil, LenError:new(err)
     end
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, LenError:new("An error occurred during the operation: %s", err)
+    end
     if space == nil then
         return nil, LenError:new("Space %q doesn't exist", space_name)
     end

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -66,9 +66,8 @@ local function call_replace_on_router(vshard_router, space_name, original_tuple,
 
     local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
-        return nil, ReplaceError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
+        return nil, ReplaceError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
     end
-
     if space == nil then
         return nil, ReplaceError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -133,7 +133,12 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
         vshard_router = '?string|table',
     })
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, {
+            ReplaceManyError:new("An error occurred during the operation: %s", err)
+        }, const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, {ReplaceManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
     end

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -47,7 +47,10 @@ local function build_select_iterator(vshard_router, space_name, user_conditions,
         return nil, SelectError:new("Failed to get router replicasets: %s", err)
     end
 
-    local space = utils.get_space(space_name, replicasets)
+    local space, err = utils.get_space(space_name, replicasets)
+    if err ~= nil then
+        return nil, SelectError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, SelectError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -112,7 +112,10 @@ local function build_select_iterator(vshard_router, space_name, user_conditions,
         return nil, SelectError:new("Failed to get router replicasets: %s", err)
     end
 
-    local space = utils.get_space(space_name, replicasets)
+    local space, err = utils.get_space(space_name, replicasets)
+    if err ~= nil then
+        return nil, SelectError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, SelectError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -264,7 +264,11 @@ local function resolve_space_name(space_id)
         return nil
     end
 
-    local space = utils.get_space(space_id, replicasets)
+    local space, err = utils.get_space(space_id, replicasets)
+    if err ~= nil then
+        log.warn("An error occurred during getting space: %s", err)
+        return nil
+    end
     if space == nil then
         log.warn('Failed to resolve space name for stats: no space found for id %d with default router', space_id)
         return nil

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -86,9 +86,8 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
 
     local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
-        return nil, UpdateError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
+        return nil, UpdateError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
     end
-
     if space == nil then
         return nil, UpdateError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -64,9 +64,8 @@ local function call_upsert_on_router(vshard_router, space_name, original_tuple, 
 
     local space, err = utils.get_space(space_name, vshard_router:routeall())
     if err ~= nil then
-        return nil, UpsertError:new("Failed to get space %q: %s", space_name, err), const.NEED_SCHEMA_RELOAD
+        return nil, UpsertError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
     end
-
     if space == nil then
         return nil, UpsertError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
     end

--- a/crud/upsert_many.lua
+++ b/crud/upsert_many.lua
@@ -129,7 +129,12 @@ local function call_upsert_many_on_router(vshard_router, space_name, original_tu
         vshard_router = '?string|table',
     })
 
-    local space = utils.get_space(space_name, vshard_router:routeall())
+    local space, err = utils.get_space(space_name, vshard_router:routeall())
+    if err ~= nil then
+        return nil, {
+            UpsertManyError:new("An error occurred during the operation: %s", err)
+        }, const.NEED_SCHEMA_RELOAD
+    end
     if space == nil then
         return nil, {UpsertManyError:new("Space %q doesn't exist", space_name)}, const.NEED_SCHEMA_RELOAD
     end


### PR DESCRIPTION
Added validation of the connection to the `utils.get_space` method before receiving the space through the connection.

Error before patch:

```
...
str: 'SelectError: ...app/.rocks/share/tarantool/crud/common/sharding/init.lua:183:
    ...repro/myapp/.rocks/share/tarantool/crud/common/utils.lua:100: attempt to index
    field ''space'' (a nil value)'
...
```

Now:

```
...
str: 'SelectError: An error occurred during the operation: "GetSpaceError: The connection
    to the master of replicaset 548fb6ff-d686-4298-ad17-7f81fa19588c is not valid:
    connect, called on fd 40, aka 127.0.0.1:58334: Connection refused"'
...
```

Closes #331