### PR TITLE
api: forbid using space id in len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   replicaset and for the master connection (#95).
 
 ### Changed
+* **Breaking**: forbid using space id in `crud.len` (#255).
 
 ### Fixed
 * Added validation of the master presence in replicaset and the 

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -1,6 +1,5 @@
 local checks = require('checks')
 local errors = require('errors')
-local log = require('log')
 
 local utils = require('crud.common.utils')
 local dev_checks = require('crud.common.dev_checks')
@@ -42,22 +41,12 @@ end
 -- @treturn[2] table Error description
 --
 function len.call(space_name, opts)
-    checks('string|number', {
+    checks('string', {
         timeout = '?number',
         vshard_router = '?string|table',
     })
 
     opts = opts or {}
-
-    if type(space_name) == 'number' then
-        log.warn('Using space id in crud.len is deprecated and will be removed in future releases.' ..
-                 'Please, use space name instead.')
-
-        if opts.vshard_router ~= nil then
-            log.warn('Using space id in crud.len and custom vshard_router is not supported by statistics.' ..
-                     'Space labels may be inconsistent.')
-        end
-    end
 
     local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
     if err ~= nil then

--- a/test/entrypoint/srv_vshard_custom.lua
+++ b/test/entrypoint/srv_vshard_custom.lua
@@ -24,7 +24,6 @@ package.preload['customers-storage'] = function()
                     },
                     if_not_exists = true,
                     engine = engine,
-                    id = 542,
                 })
 
                 customers_space:create_index('pk', {

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -16,9 +16,7 @@ local group_metrics = t.group('stats_metrics_integration', {
 
 local helpers = require('test.helper')
 
-local space_id = 542
 local space_name = 'customers'
-local non_existing_space_id = 100500
 local non_existing_space_name = 'non_existing_space'
 local new_space_name = 'newspace'
 
@@ -749,24 +747,6 @@ for name, case in pairs(select_cases) do
         t.assert_equals(map_reduces_diff, case.map_reduces,
             'Expected count of map reduces planned')
     end
-end
-
-
-pgroup.test_resolve_name_from_id = function(g)
-    local op = 'len'
-    g.router:call('crud.len', { space_id })
-
-    local stats = get_stats(g, space_name)
-    t.assert_not_equals(stats[op], nil, "Statistics is filled by name")
-end
-
-
-pgroup.test_resolve_nonexisting_space_from_id = function(g)
-    local op = 'len'
-    g.router:call('crud.len', { non_existing_space_id })
-
-    local stats = get_stats(g, tostring(non_existing_space_id))
-    t.assert_not_equals(stats[op], nil, "Statistics is filled by id as string")
 end
 
 

--- a/test/integration/vshard_custom_test.lua
+++ b/test/integration/vshard_custom_test.lua
@@ -1,7 +1,6 @@
 local fio = require('fio')
 
 local t = require('luatest')
-local luatest_capture = require('luatest.capture')
 
 local helpers = require('test.helper')
 
@@ -1630,31 +1629,3 @@ pgroup.test_call_upsert_object_many_wrong_option = function(g)
     t.assert_str_contains(errs[1].err,
                           "Invalid opts.vshard_router table value, a vshard router instance has been expected")
 end
-
-pgroup.before_test('test_call_len_by_space_id_with_stats', function(g)
-    g.router:eval('crud.cfg{stats = true}')
-end)
-
-pgroup.test_call_len_by_space_id_with_stats = function(g)
-    local capture = luatest_capture:new()
-    capture:enable()
-
-    local result, err = g:call_router_opts2('len', 542, {vshard_router = 'customers'})
-    t.assert_equals(err, nil)
-    t.assert_equals(result, 2)
-
-    local captured = helpers.fflush_main_server_stdout(g.cluster, capture)
-    capture:disable()
-
-    t.assert_str_contains(captured,
-                          "Using space id in crud.len and custom vshard_router is not supported by statistics.")
-
-    local result, err = g.router:call('crud.stats')
-    t.assert_equals(err, nil)
-    t.assert_type(result.spaces["542"], 'table')
-    t.assert_equals(result.spaces["542"]["len"]["ok"]["count"], 1)
-end
-
-pgroup.after_test('test_call_len_by_space_id_with_stats', function(g)
-    g.router:eval('crud.cfg{stats = false}')
-end)


### PR DESCRIPTION
Using space id instead of a space name in sharded systems may be dangerous until one sets all space id manually. This is a breaking change. The feature was deprecated since 0.14.0.

I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation (it seems like there are no traces left already)

Closes #255
