### PR TITLE
cartridge: clusterwide configuration for crud.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Added timeout condition for the validation of master presence in 
   replicaset and for the master connection (#95).
+* Support Cartridge clusterwide configuration for `crud.cfg` (#332).
 
 ### Changed
 * **Breaking**: forbid using space id in `crud.len` (#255).

--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,18 @@ return {
 
 4. Don't forget to bootstrap vshard.
 
+5. Configure the statistics with clusterwide configuration
+   (see `crud.cfg` options in [statistics](#statistics) section):
+```yaml
+crud:
+  stats: true
+  stats_driver: metrics
+  stats_quantiles: false
+  stats_quantile_tolerated_error: 0.001
+  stats_quantile_age_buckets_count: 5
+  stats_quantile_max_age_time: 180
+```
+
 Now your cluster contains storages that are configured to be used for
 CRUD-operations.
 You can simply call CRUD functions on the router to insert, select, and update

--- a/cartridge/roles/crud-router.lua
+++ b/cartridge/roles/crud-router.lua
@@ -1,5 +1,10 @@
+local errors = require('errors')
+
 local crud = require('crud')
 local stash = require('crud.common.stash')
+local stats = require('crud.stats')
+
+local RoleConfigurationError = errors.new_class('RoleConfigurationError', {capture_stack = false})
 
 local function init()
     crud.init_router()
@@ -10,10 +15,73 @@ local function stop()
     crud.stop_router()
 end
 
+local cfg_types = {
+    stats = 'boolean',
+    stats_driver = 'string',
+    stats_quantiles = 'boolean',
+    stats_quantile_tolerated_error = 'number',
+    stats_quantile_age_buckets_count = 'number',
+    stats_quantile_max_age_time = 'number',
+}
+
+local cfg_values = {
+    stats_driver = function(value)
+        RoleConfigurationError:assert(
+            stats.is_driver_supported(value),
+            'Invalid crud configuration field "stats_driver" value: %q is not supported',
+            value
+        )
+    end,
+}
+
+local function validate_config(conf_new, _)
+    local crud_cfg = conf_new['crud']
+
+    if crud_cfg == nil then
+        return true
+    end
+
+    RoleConfigurationError:assert(
+        type(crud_cfg) == 'table',
+        'Configuration "crud" section must be a table'
+    )
+
+    RoleConfigurationError:assert(
+        crud_cfg.crud == nil,
+        '"crud" section is already presented as a name of "crud.yml", ' ..
+        'do not use it as a top-level section name'
+    )
+
+    for name, value in pairs(crud_cfg) do
+        RoleConfigurationError:assert(
+            cfg_types[name] ~= nil,
+            'Unknown crud configuration field %q', name
+        )
+
+        RoleConfigurationError:assert(
+            type(value) == cfg_types[name],
+            'Invalid crud configuration field %q type: expected %s, got %s',
+            name, cfg_types[name], type(value)
+        )
+
+        if cfg_values[name] ~= nil then
+            cfg_values[name](value)
+        end
+    end
+
+    return true
+end
+
+local function apply_config(conf)
+    crud.cfg(conf['crud'])
+end
+
 return {
     role_name = 'crud-router',
     init = init,
     stop = stop,
+    validate_config = validate_config,
+    apply_config = apply_config,
     implies_router = true,
     dependencies = {'cartridge.roles.vshard-router'},
 }

--- a/cartridge/roles/crud-router.lua
+++ b/cartridge/roles/crud-router.lua
@@ -1,7 +1,6 @@
 local crud = require('crud')
 local stash = require('crud.common.stash')
 
--- removes routes that changed in config and adds new routes
 local function init()
     crud.init_router()
     stash.setup_cartridge_reload()

--- a/crud/cfg.lua
+++ b/crud/cfg.lua
@@ -155,8 +155,12 @@ local function __call(self, opts)
         stats_quantile_age_buckets_count = '?number',
         stats_quantile_max_age_time = '?number',
     })
+    -- Value validation would be performed in stats checks, if required.
 
     opts = table.deepcopy(opts) or {}
+    -- opts from Cartridge clusterwide configuration is read-only,
+    -- but we want to work with copy anyway.
+    setmetatable(opts, {})
 
     configure_stats(cfg, opts)
 

--- a/crud/stats/init.lua
+++ b/crud/stats/init.lua
@@ -58,6 +58,18 @@ function stats.get_default_driver()
     end
 end
 
+--- Check if provided driver is supported.
+--
+-- @function is_driver_supported
+--
+-- @string opts.driver
+--
+-- @treturn boolean Returns `true` or `false`.
+--
+function stats.is_driver_supported(driver)
+    return drivers[driver] ~= nil
+end
+
 --- Initializes statistics registry, enables callbacks and wrappers.
 --
 --  If already enabled, do nothing.
@@ -124,9 +136,8 @@ function stats.enable(opts)
     end
 
     StatsError:assert(
-        drivers[opts.driver] ~= nil,
-        'Unsupported driver: %s', opts.driver
-    )
+        stats.is_driver_supported(opts.driver),
+        'Unsupported driver: %s', opts.driver)
 
     if opts.quantiles == nil then
         opts.quantiles = false


### PR DESCRIPTION
After this patch, user may set `crud.cfg` with Cartridge clusterwide configuration of `cartridge.roles.crud-router` role [1]. The behavior is the same as in Lua `crud.cfg` call.

1. https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #332
