### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-* Added timeout condition for the validation of master presence in 
+* Add timeout condition for the validation of master presence in 
   replicaset and for the master connection (#95).
 * Support Cartridge clusterwide configuration for `crud.cfg` (#332).
 
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking**: forbid using space id in `crud.len` (#255).
 
 ### Fixed
-* Added validation of the master presence in replicaset and the 
+* Add validation of the master presence in replicaset and the 
   master connection to the `utils.get_space` method before 
   receiving the space from the connection (#331).
-* Fixed fiber cancel on schema reload timeout in `call_reload_schema`.
+* Fix fiber cancel on schema reload timeout in `call_reload_schema` (PR #337).
 
 ## [0.14.1] - 10-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 02-02-23
 
 ### Added
 * Add timeout condition for the validation of master presence in 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add validation of the master presence in replicaset and the 
   master connection to the `utils.get_space` method before 
   receiving the space from the connection (#331).
-* Fix fiber cancel on schema reload timeout in `call_reload_schema` (PR #337).
+* Fix fiber cancel on schema reload timeout in `call_reload_schema` (PR #336).
 
 ## [0.14.1] - 10-11-22
 


### PR DESCRIPTION
### Overview

This release introduces a breaking change with removing a deprecated feature: `crud.len(space_id)`.

This release also introduces a Cartridge clusterwide config to setup `crud.cfg`.

### Breaking changes

You cannot use space id as a space identifier in `crud.len` anymore. Use space name instead.

### New features

* Timeout condition for the validation of master presence in replicaset and for the master connection (#95).
* Cartridge clusterwide configuration for `crud.cfg` (#332).

### Changes

* Forbid using space id in `crud.len` (#255).

### Fixes

* Add validation of the master presence in replicaset and the master connection to the `utils.get_space` method before receiving the space from the connection (#331).
* Fix fiber cancel on schema reload timeout in `call_reload_schema` (PR #336).

I didn't forget about

- Tests
- [x] Changelog
- Documentation
