### PR TITLE
coverage: fix loaded function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * Yield on select/pairs storage tuple lookup (#312).
 
+### Fixed
+* Loaded functions misleading coverage (#249).
+
 ## [1.1.0] - 13-03-23
 
 ### Added

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -217,7 +217,7 @@ function utils.flatten(object, space_format, bucket_id, skip_nullability_check)
         fieldmap = fieldmap,
         NULL = box.NULL,
     }
-    flatten_func = assert(load(code, '@flatten', 't', env))
+    flatten_func = assert(load(code, nil, 't', env))
 
     flatten_functions_cache[space_format] = flatten_func
     local data, err = flatten_func(object, bucket_id, skip_nullability_check)


### PR DESCRIPTION
Now we load flatten functions for spaces with `@flatten` source. Source starting with @ assumes that it describes the file name, yet here it isn't. Then luacov fails to find "flatten" file on coverage info build.

When we do not specify source explicitly, the whole string became the source. It will not confuse luacov anymore (it just ignores them), and it's more helpful for debug.

1. https://www.lua.org/manual/5.2/manual.html#pdf-load

Closes #249

I didn't forget about

- Tests (still green)
- [x] Changelog
- Documentation