### PR TITLE
test: rework DEV environment variable naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * Yield on select/pairs storage tuple lookup (#312).
+* Naming of `DEV` environment variable to `TARANTOOL_CRUD_ENABLE_INTERNAL_CHECKS` (#250).
 
 ### Fixed
 * Loaded functions misleading coverage (#249).

--- a/crud/common/dev_checks.lua
+++ b/crud/common/dev_checks.lua
@@ -2,7 +2,7 @@ local checks = require('checks')
 
 local dev_checks = function() end
 
-if os.getenv('DEV') == 'ON' then
+if os.getenv('TARANTOOL_CRUD_ENABLE_INTERNAL_CHECKS') == 'ON' then
     dev_checks = checks
 end
 

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -10,8 +10,8 @@ local fio = require('fio')
 local crud = require('crud')
 local crud_utils = require('crud.common.utils')
 
-if os.getenv('DEV') == nil then
-    os.setenv('DEV', 'ON')
+if os.getenv('TARANTOOL_CRUD_ENABLE_INTERNAL_CHECKS') == nil then
+    os.setenv('TARANTOOL_CRUD_ENABLE_INTERNAL_CHECKS', 'ON')
 end
 
 local helpers = {}
@@ -478,7 +478,7 @@ function helpers.get_map_reduces_stat(router, space_name)
 end
 
 function helpers.disable_dev_checks()
-    os.setenv('DEV', 'OFF')
+    os.setenv('TARANTOOL_CRUD_ENABLE_INTERNAL_CHECKS', 'OFF')
 end
 
 function helpers.count_on_replace_triggers(server, space_name)


### PR DESCRIPTION
Change `DEV` environment variable naming to `TARANTOOL_CRUD_ENABLE_INTERNAL_CHECKS` used to enabling `checks()` in tests. This will prevent possible intersections with other environment variables due to common `DEV` naming.

- Tests (still green)
- [x] Changelog
- Documentation (internal)

Closes #250
