### PR TITLE
schema: fix stale schema for metadata generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `upsert`, `upsert_object`, `upsert_many`, `upsert_object_many`,
   `update`, `delete`. (#267).
 
+### Fixed
+* Crud DML operations returning stale schema for metadata generation.
+  Now you may use `fetch_latest_metadata` flag to work with latest schema (#236).
+
 ## [1.1.1] - 24-03-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ where:
     the sole responsibility of the developer
   * `noreturn` (`?boolean`) - suppress successfully processed tuple
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array contains one inserted row, error.
 
@@ -303,6 +307,10 @@ where:
     the sole responsibility of the developer
   * `noreturn` (`?boolean`) - suppress successfully processed tuples
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array with inserted rows, array of errors.
 Each error object can contain field `operation_data`.
@@ -441,6 +449,10 @@ where:
   * `vshard_router` (`?string|table`) - Cartridge vshard group name or
     vshard router instance. Set this parameter if your space is not
     a part of the default vshard cluster
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array contains one row, error.
 
@@ -480,6 +492,10 @@ where:
     a part of the default vshard cluster
   * `noreturn` (`?boolean`) - suppress successfully processed tuple
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array contains one updated row, error.
 
@@ -518,6 +534,10 @@ where:
     a part of the default vshard cluster
   * `noreturn` (`?boolean`) - suppress successfully processed tuple
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array contains one deleted row (empty for vinyl), error.
 
@@ -567,6 +587,10 @@ where:
     the sole responsibility of the developer
   * `noreturn` (`?boolean`) - suppress successfully processed tuple
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns inserted or replaced rows and metadata or nil with error.
 
@@ -634,6 +658,10 @@ where:
     the sole responsibility of the developer
   * `noreturn` (`?boolean`) - suppress successfully processed tuples
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array with inserted/replaced rows, array of errors.
 Each error object can contain field `operation_data`.
@@ -772,6 +800,10 @@ where:
     a part of the default vshard cluster
   * `noreturn` (`?boolean`) - suppress successfully processed tuple
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and empty array of rows or nil, error.
 
@@ -835,6 +867,10 @@ where:
     a part of the default vshard cluster
   * `noreturn` (`?boolean`) - suppress successfully processed tuples
     (first return value is `nil`). `false` by default
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 Returns metadata and array of errors.
 Each error object can contain field `operation_data`.
@@ -977,6 +1013,10 @@ where:
     a part of the default vshard cluster
   * `yield_every` (`?number`) - number of tuples processed on storage to yield after,
     `yield_every` should be > 0, default value is 1000
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise 
+    it may not take into account the latest migration of the data format. 
+    Performance overhead is up to 15%. `false` by default
 
 
 Returns metadata and array of rows, error.

--- a/crud/common/map_call_cases/base_postprocessor.lua
+++ b/crud/common/map_call_cases/base_postprocessor.lua
@@ -13,6 +13,7 @@ function BasePostprocessor:new(vshard_router)
         early_exit = false,
         errs = nil,
         vshard_router = vshard_router,
+        storage_info = {},
     }
 
     setmetatable(postprocessor, self)
@@ -52,6 +53,14 @@ function BasePostprocessor:collect(result_info, err_info)
         wrapper_args = '?table',
     })
 
+    if result_info.value ~= nil and type(result_info.value[1]) == 'table' then
+        if result_info.value[1].storage_info ~= nil then
+            self.storage_info[result_info.key] = {
+                replica_schema_version = result_info.value[1].storage_info.replica_schema_version
+            }
+        end
+    end
+
     local err = err_info.err
     if err == nil and result_info.value[1] == nil then
         err = result_info.value[2]
@@ -78,8 +87,9 @@ end
 --
 -- @return[1] table results
 -- @return[2] table errs
+-- @return[3] table storage_info
 function BasePostprocessor:get()
-    return self.results, self.errs
+    return self.results, self.errs, self.storage_info
 end
 
 return BasePostprocessor

--- a/crud/common/map_call_cases/batch_postprocessor.lua
+++ b/crud/common/map_call_cases/batch_postprocessor.lua
@@ -39,6 +39,10 @@ function BatchPostprocessor:collect(result_info, err_info)
         wrapper_args = '?table',
     })
 
+    if result_info.value ~= nil then
+        self.storage_info[result_info.key] = {replica_schema_version = result_info.value[3]}
+    end
+
     local errs = {err_info.err}
     if err_info.err == nil then
         errs = result_info.value[2]

--- a/crud/common/stash.lua
+++ b/crud/common/stash.lua
@@ -20,12 +20,16 @@ local stash = {}
 -- @tfield string stats_metrics_registry
 --  Stash for metrics rocks statistics registry.
 --
+-- @tfield string select_module_compat_info
+--  Stash for select compatability version registry.
+--
 stash.name = {
     cfg = '__crud_cfg',
     stats_internal = '__crud_stats_internal',
     stats_local_registry = '__crud_stats_local_registry',
     stats_metrics_registry = '__crud_stats_metrics_registry',
     ddl_triggers = '__crud_ddl_spaces_triggers',
+    select_module_compat_info = '__select_module_compat_info',
 }
 
 --- Setup Tarantool Cartridge reload.

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -82,6 +82,9 @@ local function call_delete_on_router(vshard_router, space_name, key, opts)
 
     local sharding_key = key
     if opts.bucket_id == nil then
+        if space.index[0] == nil then
+            return nil, DeleteError:new("Cannot fetch primary index parts"), const.NEED_SCHEMA_RELOAD
+        end
         local primary_index_parts = space.index[0].parts
 
         local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -22,6 +22,7 @@ local function insert_on_storage(space_name, tuple, opts)
         sharding_func_hash = '?number',
         skip_sharding_hash_check = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}
@@ -47,6 +48,7 @@ local function insert_on_storage(space_name, tuple, opts)
         add_space_schema_hash = opts.add_space_schema_hash,
         field_names = opts.fields,
         noreturn = opts.noreturn,
+        fetch_latest_metadata = opts.fetch_latest_metadata,
     })
 end
 
@@ -66,9 +68,10 @@ local function call_insert_on_router(vshard_router, space_name, original_tuple, 
         vshard_router = '?string|table',
         skip_nullability_check_on_flatten = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
-    local space, err = utils.get_space(space_name, vshard_router, opts.timeout)
+    local space, err, netbox_schema_version = utils.get_space(space_name, vshard_router, opts.timeout)
     if err ~= nil then
         return nil, InsertError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
     end
@@ -90,6 +93,7 @@ local function call_insert_on_router(vshard_router, space_name, original_tuple, 
         sharding_key_hash = sharding_data.sharding_key_hash,
         skip_sharding_hash_check = sharding_data.skip_sharding_hash_check,
         noreturn = opts.noreturn,
+        fetch_latest_metadata = opts.fetch_latest_metadata,
     }
 
     local call_opts = {
@@ -128,6 +132,14 @@ local function call_insert_on_router(vshard_router, space_name, original_tuple, 
     end
 
     local tuple = storage_result.res
+
+    if opts.fetch_latest_metadata == true then
+        -- This option is temporary and is related to [1], [2].
+        -- [1] https://github.com/tarantool/crud/issues/236
+        -- [2] https://github.com/tarantool/crud/issues/361
+        space = utils.fetch_latest_metadata_when_single_storage(space, space_name, netbox_schema_version,
+                                                                vshard_router, opts, storage_result.storage_info)
+    end
 
     return utils.format_result({tuple}, space, opts.fields)
 end
@@ -169,6 +181,7 @@ function insert.tuple(space_name, tuple, opts)
         fields = '?table',
         vshard_router = '?string|table',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}
@@ -208,6 +221,7 @@ function insert.object(space_name, obj, opts)
         vshard_router = '?string|table',
         skip_nullability_check_on_flatten = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -28,6 +28,7 @@ local function replace_many_on_storage(space_name, tuples, opts)
         sharding_func_hash = '?number',
         skip_sharding_hash_check = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}
@@ -48,6 +49,7 @@ local function replace_many_on_storage(space_name, tuples, opts)
 
     local inserted_tuples = {}
     local errs = {}
+    local replica_schema_version = nil
 
     box.begin()
     for i, tuple in ipairs(tuples) do
@@ -58,7 +60,12 @@ local function replace_many_on_storage(space_name, tuples, opts)
             add_space_schema_hash = opts.add_space_schema_hash,
             field_names = opts.fields,
             noreturn = opts.noreturn,
+            fetch_latest_metadata = opts.fetch_latest_metadata,
         })
+
+        if opts.fetch_latest_metadata then
+            replica_schema_version = insert_result.storage_info.replica_schema_version
+        end
 
         table.insert(errs, err)
 
@@ -85,12 +92,12 @@ local function replace_many_on_storage(space_name, tuples, opts)
                                 batching_utils.rollback_on_error_msg, inserted_tuples)
                     end
 
-                    return nil, errs
+                    return nil, errs, replica_schema_version
                 end
 
                 box.commit()
 
-                return inserted_tuples, errs
+                return inserted_tuples, errs, replica_schema_version
             end
         end
 
@@ -105,17 +112,17 @@ local function replace_many_on_storage(space_name, tuples, opts)
                         batching_utils.rollback_on_error_msg, inserted_tuples)
             end
 
-            return nil, errs
+            return nil, errs, replica_schema_version
         end
 
         box.commit()
 
-        return inserted_tuples, errs
+        return inserted_tuples, errs, replica_schema_version
     end
 
     box.commit()
 
-    return inserted_tuples
+    return inserted_tuples, nil, replica_schema_version
 end
 
 function replace_many.init()
@@ -135,9 +142,10 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
         vshard_router = '?string|table',
         skip_nullability_check_on_flatten = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
-    local space, err = utils.get_space(space_name, vshard_router, opts.timeout)
+    local space, err, netbox_schema_version = utils.get_space(space_name, vshard_router, opts.timeout)
     if err ~= nil then
         return nil, {
             ReplaceManyError:new("An error occurred during the operation: %s", err)
@@ -155,6 +163,7 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
         stop_on_error = opts.stop_on_error,
         rollback_on_error = opts.rollback_on_error,
         noreturn = opts.noreturn,
+        fetch_latest_metadata = opts.fetch_latest_metadata,
     }
 
     local iter, err = BatchInsertIterator:new({
@@ -169,7 +178,7 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
 
     local postprocessor = BatchPostprocessor:new(vshard_router)
 
-    local rows, errs = call.map(vshard_router, REPLACE_MANY_FUNC_NAME, nil, {
+    local rows, errs, storages_info = call.map(vshard_router, REPLACE_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,
         mode = 'write',
         iter = iter,
@@ -189,6 +198,14 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
 
     if next(rows) == nil then
         return nil, errs
+    end
+
+    if opts.fetch_latest_metadata == true then
+        -- This option is temporary and is related to [1], [2].
+        -- [1] https://github.com/tarantool/crud/issues/236
+        -- [2] https://github.com/tarantool/crud/issues/361
+        space = utils.fetch_latest_metadata_when_map_storages(space, space_name, vshard_router, opts,
+                                                              storages_info, netbox_schema_version)
     end
 
     local res, err = utils.format_result(rows, space, opts.fields)
@@ -227,6 +244,7 @@ function replace_many.tuples(space_name, tuples, opts)
         rollback_on_error = '?boolean',
         vshard_router = '?string|table',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}
@@ -266,6 +284,7 @@ function replace_many.objects(space_name, objs, opts)
         vshard_router = '?string|table',
         skip_nullability_check_on_flatten = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -1,5 +1,6 @@
 local errors = require('errors')
 
+local stash = require('crud.common.stash')
 local utils = require('crud.common.utils')
 local sharding = require('crud.common.sharding')
 local select_executor = require('crud.select.executor')
@@ -11,20 +12,15 @@ local SelectError = errors.new_class('SelectError')
 
 local select_module
 
+local select_module_compat_info = stash.get(stash.name.select_module_compat_info)
 local has_merger = (utils.tarantool_supports_external_merger() and
     package.search('tuple.merger')) or utils.tarantool_has_builtin_merger()
 if has_merger then
     select_module = require('crud.select.compat.select')
+    select_module_compat_info.has_merger = true
 else
     select_module = require('crud.select.compat.select_old')
-end
-
-local function make_cursor(data)
-    local last_tuple = data[#data]
-
-    return {
-        after_tuple = last_tuple,
-    }
+    select_module_compat_info.has_merger = false
 end
 
 function checkers.vshard_call_mode(p)
@@ -43,16 +39,31 @@ local function select_on_storage(space_name, index_id, conditions, opts)
         sharding_func_hash = '?number',
         skip_sharding_hash_check = '?boolean',
         yield_every = '?number',
+        fetch_latest_metadata = '?boolean',
     })
+
+    local cursor = {}
+    if opts.fetch_latest_metadata then
+        local replica_schema_version
+        if box.info.schema_version ~= nil then
+            replica_schema_version = box.info.schema_version
+        else
+            replica_schema_version = box.internal.schema_version()
+        end
+        cursor.storage_info = {
+            replica_uuid = box.info().uuid,
+            replica_schema_version = replica_schema_version,
+        }
+    end
 
     local space = box.space[space_name]
     if space == nil then
-        return nil, SelectError:new("Space %q doesn't exist", space_name)
+        return cursor, SelectError:new("Space %q doesn't exist", space_name)
     end
 
     local index = space.index[index_id]
     if index == nil then
-        return nil, SelectError:new("Index with ID %s doesn't exist", index_id)
+        return cursor, SelectError:new("Index with ID %s doesn't exist", index_id)
     end
 
     local _, err = sharding.check_sharding_hash(space_name,
@@ -69,7 +80,7 @@ local function select_on_storage(space_name, index_id, conditions, opts)
         scan_condition_num = opts.scan_condition_num,
     })
     if err ~= nil then
-        return nil, SelectError:new("Failed to generate tuples filter: %s", err)
+        return cursor, SelectError:new("Failed to generate tuples filter: %s", err)
     end
 
     -- execute select
@@ -81,14 +92,14 @@ local function select_on_storage(space_name, index_id, conditions, opts)
         yield_every = opts.yield_every,
     })
     if err ~= nil then
-        return nil, SelectError:new("Failed to execute select: %s", err)
+        return cursor, SelectError:new("Failed to execute select: %s", err)
     end
 
-    local cursor
     if resp.tuples_fetched < opts.limit or opts.limit == 0 then
-        cursor = {is_end = true}
+        cursor.is_end = true
     else
-        cursor = make_cursor(resp.tuples)
+        local last_tuple = resp.tuples[#resp.tuples]
+        cursor.after_tuple = last_tuple
     end
 
     cursor.stats = {
@@ -98,7 +109,18 @@ local function select_on_storage(space_name, index_id, conditions, opts)
 
     -- getting tuples with user defined fields (if `fields` option is specified)
     -- and fields that are needed for comparison on router (primary key + scan key)
-    return cursor, schema.filter_tuples_fields(resp.tuples, opts.field_names)
+    local filtered_tuples = schema.filter_tuples_fields(resp.tuples, opts.field_names)
+
+    local result = {cursor, filtered_tuples}
+
+    local select_module_compat_info = stash.get(stash.name.select_module_compat_info)
+    if not select_module_compat_info.has_merger then
+        if opts.fetch_latest_metadata then
+            result[3] = cursor.storage_info.replica_schema_version
+        end
+    end
+
+    return unpack(result)
 end
 
 function select_module.init()

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -22,6 +22,7 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
         sharding_func_hash = '?number',
         skip_sharding_hash_check = '?boolean',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}
@@ -46,6 +47,7 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
         add_space_schema_hash = false,
         field_names = field_names,
         noreturn = opts.noreturn,
+        fetch_latest_metadata = opts.fetch_latest_metadata,
     })
 
     if err ~= nil then
@@ -85,9 +87,10 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
         fields = '?table',
         vshard_router = '?string|table',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
-    local space, err = utils.get_space(space_name, vshard_router, opts.timeout)
+    local space, err, netbox_schema_version = utils.get_space(space_name, vshard_router, opts.timeout)
     if err ~= nil then
         return nil, UpdateError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
     end
@@ -144,6 +147,7 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
         sharding_key_hash = sharding_key_hash,
         skip_sharding_hash_check = skip_sharding_hash_check,
         noreturn = opts.noreturn,
+        fetch_latest_metadata = opts.fetch_latest_metadata,
     }
 
     local call_opts = {
@@ -176,6 +180,14 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
     end
 
     local tuple = storage_result.res
+
+    if opts.fetch_latest_metadata == true then
+        -- This option is temporary and is related to [1], [2].
+        -- [1] https://github.com/tarantool/crud/issues/236
+        -- [2] https://github.com/tarantool/crud/issues/361
+        space = utils.fetch_latest_metadata_when_single_storage(space, space_name, netbox_schema_version,
+                                                                vshard_router, opts, storage_result.storage_info)
+    end
 
     return utils.format_result({tuple}, space, opts.fields)
 end
@@ -220,6 +232,7 @@ function update.call(space_name, key, user_operations, opts)
         fields = '?table',
         vshard_router = '?string|table',
         noreturn = '?boolean',
+        fetch_latest_metadata = '?boolean',
     })
 
     opts = opts or {}

--- a/doc/dev/schema.md
+++ b/doc/dev/schema.md
@@ -15,6 +15,7 @@ is obtained, used and reloaded.
   - [When schema is used](#when-schema-is-used)
   - [How schema is reloaded](#how-schema-is-reloaded)
   - [When schema is reloaded and operation is retried](#when-schema-is-reloaded-and-operation-is-retried)
+  - [When schema is reloaded depending on the user option](#when-schema-is-reloaded-depending-on-the-user-option)
   - [Alternative approaches](#alternative-approaches)
 - [Sharding schema](#sharding-schema)
   - [How schema is stored](#how-schema-is-stored-1)
@@ -136,6 +137,16 @@ function crud.insert_object_many(args)
     return reload_schema_wrapper(call_insert_many_func, space_name, flatten_obj_array, opts)
 end
 ```
+
+### When schema is reloaded depending on the user option
+
+Related link: [PR#359](https://github.com/tarantool/crud/pull/359)
+
+Conditionally if the flag `fetch_latest_metadata` for DML operation that
+return metadata (or uses metadata directly) is used.
+Before receiving the space format, a mismatch check will be performed between the scheme version
+on all involved storage and the scheme version in the net_box connection of the router.
+In case of mismatch, the schema reload will be triggered.
 
 ### Alternative approaches
 

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -411,7 +411,7 @@ pgroup.test_intermediate_nullable_fields_update = function(g)
 
     helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'}, function(server)
         for i = 1, 12 do
-            server.net_box:call('add_extra_field', {'extra_' .. tostring(i)})
+            server.net_box:call('add_extra_field', {'developers', 'extra_' .. tostring(i)})
         end
     end)
 
@@ -488,6 +488,241 @@ pgroup.test_intermediate_nullable_fields_update = function(g)
             extra_12 = 'extra_value_12'
         }
     })
+end
+
+local gh_236_metadata_field_name = {
+    crud_update = 'extra_gh_236_update',
+    crud_insert = 'extra_gh_236_insert',
+    crud_insert_object = 'extra_gh_236_insert_object',
+    crud_insert_many = 'extra_gh_236_insert_many',
+    crud_insert_object_many = 'extra_gh_236_insert_object_many',
+    crud_replace = 'extra_gh_236_replace',
+    crud_replace_object = 'extra_gh_236_replace_object',
+    crud_replace_many = 'extra_gh_236_replace_many',
+    crud_replace_object_many = 'extra_gh_236_replace_object_many',
+    crud_get = 'extra_gh_236_get',
+    crud_delete = 'extra_gh_236_delete',
+    crud_upsert = 'extra_gh_236_upsert',
+    crud_upsert_object = 'extra_gh_236_upsert_object',
+    crud_upsert_many = 'extra_gh_236_upsert_many',
+    crud_upsert_object_many = 'extra_gh_236_upsert_object_many',
+    crud_max = 'extra_gh_236_max',
+    crud_min = 'extra_gh_236_min',
+    crud_select = 'extra_gh_236_select',
+    crud_pairs = 'extra_gh_236_pairs',
+}
+
+local gh_236_cases = {
+    crud_update = {
+        operation_name = 'crud.update',
+        input = {'countries', 3,
+            {{'=', gh_236_metadata_field_name.crud_update, 'testing'}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_insert = {
+        operation_name = 'crud.insert',
+        input = {'countries', {3, box.NULL, 'vatican', 825},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_insert_object = {
+        operation_name = 'crud.insert_object',
+        input = {'countries',
+            {id=3, bucket_id = box.NULL, name = 'vatican', population = 825},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_insert_many = {
+        operation_name = 'crud.insert_many',
+        input = {'countries', {{3, box.NULL, 'vatican', 825}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_insert_object_many = {
+        operation_name = 'crud.insert_object_many',
+        input = {'countries',
+            {{id=3, bucket_id = box.NULL, name = 'vatican', population = 825}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_replace = {
+        operation_name = 'crud.replace',
+        input = {'countries', {3, box.NULL, 'vatican', 825},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_replace_object = {
+        operation_name = 'crud.replace_object',
+        input = {'countries',
+            {id=3, bucket_id = box.NULL, name = 'vatican', population = 825},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_replace_many = {
+        operation_name = 'crud.replace_many',
+        input = {'countries', {{3, box.NULL, 'vatican', 825}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_replace_object_many = {
+        operation_name = 'crud.replace_object_many',
+        input = {'countries',
+            {{id=3, bucket_id = box.NULL, name = 'vatican', population = 825}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_get = {
+        operation_name = 'crud.get',
+        input = {'countries', 3, {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_delete = {
+        operation_name = 'crud.delete',
+        input = {'countries', 3, {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_upsert = {
+        operation_name = 'crud.upsert',
+        input = {'countries',
+            {3, box.NULL, 'vatican', 825}, {{'+', 'population', 1}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_upsert_object = {
+        operation_name = 'crud.upsert_object',
+        input = {'countries',
+            {id=3, bucket_id = box.NULL, name = 'vatican', population = 825},
+            {{'+', 'population', 1}},
+            {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_upsert_many = {
+        operation_name = 'crud.upsert_many',
+        input = {'countries',
+        {
+            {{3, box.NULL, 'vatican', 825},
+            {{'+', 'population', 1}}}
+        },
+        {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_upsert_object_many = {
+        operation_name = 'crud.upsert_object_many',
+        input = {'countries',
+        {
+            {
+                {id=3, bucket_id = box.NULL, name = 'vatican', population = 825},
+                {{'+', 'population', 1}}
+            }
+        },
+        {fetch_latest_metadata = true}},
+        need_pre_insert_data = false,
+    },
+    crud_max = {
+        operation_name = 'crud.max',
+        input = {'countries', 'id', {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_min = {
+        operation_name = 'crud.min',
+        input = {'countries', 'id', {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_select = {
+        operation_name = 'crud.select',
+        input = {'countries', {}, {fetch_latest_metadata = true}},
+        need_pre_insert_data = true,
+    },
+    crud_pairs = {
+        operation_name = 'crud.pairs',
+        input = { --[[ hardcoded inside eval --]] },
+        need_pre_insert_data = true,
+    },
+}
+
+local gh_236_case_prepare = function(g)
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'},
+            function(server)
+                server.net_box:call('create_space_for_gh_326_cases')
+    end)
+end
+
+local gh_236_case_after = function(g)
+    helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'},
+            function(server)
+                server.net_box:call('drop_space_for_gh_326_cases')
+    end)
+end
+
+for case_name, case in pairs(gh_236_cases) do
+    -- These tests check the relevance of metadata when crud DML operation working.
+    -- The reproduction of the bug in the issue [1] was detected when working
+    -- with bucket_id 2804 (id = 3 at countries space), which base on another
+    -- storage relative to bucket 477 (id = 1 at countries space).
+    -- Related to the issue [2].
+    -- [1] https://github.com/tarantool/crud/issues/236
+    -- [2] https://github.com/tarantool/crud/issues/361
+
+    local test_name = ('test_gh_236_dml_operation_return_actual_metadata_%s'):format(case_name)
+
+    pgroup.before_test(test_name, gh_236_case_prepare)
+    pgroup[test_name] = function(g)
+        local result, err
+
+        -- Perform request to fetch initial space format.
+        result, err = g.cluster.main_server.net_box:call(
+            'crud.delete', {'countries', 3})
+        t.assert_not_equals(result, nil)
+        t.assert_equals(err, nil)
+
+        if case.need_pre_insert_data then
+            result, err = g.cluster.main_server.net_box:call(
+                'crud.insert', {'countries', {3, box.NULL, 'vatican', 825, 'extra_test_data'}})
+            t.assert_equals(err, nil)
+            t.assert_not_equals(result, nil)
+        end
+
+        -- Schema migration.
+        helpers.call_on_servers(g.cluster, {'s1-master', 's2-master'},
+            function(server)
+                server.net_box:call('add_extra_field',
+                    {'countries', gh_236_metadata_field_name[case_name]})
+        end)
+
+        if case.operation_name ~= 'crud.pairs' then
+            result, err = g.cluster.main_server.net_box:call(case.operation_name, case.input)
+            t.assert_equals(err, nil)
+            local found_extra_field = false
+            for _, v in pairs(result.metadata) do
+                if v.name == gh_236_metadata_field_name[case_name] then
+                    found_extra_field = true
+                end
+            end
+            t.assert_equals(found_extra_field, true,
+                string.format('cannot find the expected metadata for case: %s',
+                            case.operation_name))
+        else
+            local object = g.cluster.main_server.net_box:eval([[
+                local objects = {}
+                for _, object in crud.pairs('countries', nil,
+                        {fetch_latest_metadata = true, use_tomap = true}) do
+                    table.insert(objects, object)
+                end
+                return objects[1]
+            ]])
+            local found_extra_field = false
+            for field_name, _ in pairs(object) do
+                if field_name == gh_236_metadata_field_name[case_name] then
+                    found_extra_field = true
+                end
+            end
+            t.assert_equals(found_extra_field, true,
+                string.format('cannot find the expected metadata for case: %s',
+                              case.operation_name))
+        end
+    end
+    pgroup.after_test(test_name, gh_236_case_after)
 end
 
 pgroup.test_object_with_nullable_fields = function(g)


### PR DESCRIPTION
Corrects using of an stale schema to generate metadata during `crud.update`, `crud.insert`, `crud.insert_*`, `crud.replace`, `crud.replace_*`, `crud.upsert`, `crud.upsert_*`, `crud.delete`, `crud.max`, `crud.min`, `crud.select`,`crud.pairs`, `crud.get` working.

If the implemented `fetch_latest_metadata` option is used, it is guaranteed that the metadata will be up-to-date. Before receiving the space format, a mismatch check will be performed between the scheme version on all involved storage and the scheme version in the net_box connection of the router. In case of mismatch, the schema reload will be triggered.

- [x] Tests
- [x] Changelog
- [x] Documentation

Related with #361 
Closes #236 
