### PR TITLE
release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.3.0] - 27-09-23
 
 ### Added
 * Read view support for select and pairs (#343).

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.2.0'
+return '1.3.0'


### PR DESCRIPTION
## Overview

This release introduces read view support for select and pairs. A read view is an in-memory snapshot of data on instance that isn't  affected by future data modifications. For a sharded cluster, we open a read view on each storage when one is requested from the router. Read views are supported for Tarantool Enterprise since 2.11.

## New features
  * Read view support for select and pairs (#343).
