### PR TITLE
readview: fix garbagecollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+* `crud.readview` resource cleanup on garbage collect (#379).
+
 ## [1.3.0] - 27-09-23
 
 ### Added


### PR DESCRIPTION
Added workaround for garbagecollection of readview because for tarantool lua (and lua 5.1) __gc metamethod only works for cdata types.

See https://github.com/tarantool/tarantool/issues/5770

What has been done? Why? What problem is being solved?

I didn't forget about

- [ x] Tests
- [ x] Changelog
- [ not need] Documentation

