### PR TITLE
crud: add execution access to a VShard user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `crud.readview` resource cleanup on garbage collect (#379).
 * `doc/playground.lua` does not work with Tarantool 3 (#371).
 * Tests with Tarantool 3 (#364).
+* VShard storage user have not execution rights for internal functions (#366).
 
 ## [1.3.0] - 27-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   You could to specify an environment variable `CARTIRDGE_VERSION` to install
   the `cartridge` and run tests cases with it.
 * Return explicit error for `*_many` call with no tuples/objects (#377).
+* Quickstart section in the README.md focuses on usage with `vshard` instead of
+  `Cartridge` (#366).
 
 ### Fixed
 * `crud.readview` resource cleanup on garbage collect (#379).

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ project:
   ```shell
   $ tt rocks install crud
   ```
-
-  And add the [initialization code](#API) to storage and router instance files.
+* Add the [crud initialization code](#API) to router and storage instances
+  initialization code for [VShard](https://github.com/tarantool/vshard).
 * Add crud into dependencies of a Cartridge application and add crud roles into
   dependencies of your roles (see [Cartridge roles](#cartridge-roles) section).
 * Add crud into dependencies of your application (rockspec, RPM spec -- depends
@@ -82,12 +82,19 @@ project:
 ## API
 
 The CRUD operations should be called from router.
-All storage replica sets should call `crud.init_storage()`
-(or enable the `crud-storage` role)
+
+All VShard storages should call `crud.init_storage()` after
+`vshard.storage.cfg()` (or enable the `crud-storage` role for Cartridge)
 first to initialize storage-side functions that are used to manipulate data
 across the cluster.
-All routers should call `crud.init_router()` (or enable the `crud-router` role)
-to make `crud` functions callable via `net.box`.
+
+All VShard routers should call `crud.init_router()` after `vshard.router.cfg()`
+(or enable the `crud-router` role for Cartridge) to make `crud` functions
+callable via `net.box`.
+
+You can check out an example of the configuration for local development
+(a single instance that combines router and storage) in
+[playground.lua](./doc/playground.lua).
 
 All operations return a table that contains rows (tuples) and metadata
 (space format).

--- a/README.md
+++ b/README.md
@@ -86,11 +86,14 @@ The CRUD operations should be called from router.
 All VShard storages should call `crud.init_storage()` after
 `vshard.storage.cfg()` (or enable the `crud-storage` role for Cartridge)
 first to initialize storage-side functions that are used to manipulate data
-across the cluster.
+across the cluster. The storage-side functions have the same access
+as a user calling `crud.init_storage()`. Therefore, if `crud` do not have
+enough access to modify some space, then you need to give access to the user.
 
 All VShard routers should call `crud.init_router()` after `vshard.router.cfg()`
 (or enable the `crud-router` role for Cartridge) to make `crud` functions
-callable via `net.box`.
+callable via `net.box`. If a user is allowed to execute `crud` functions on
+the router-side then the user does not need additional access on storages.
 
 You can check out an example of the configuration for local development
 (a single instance that combines router and storage) in

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -13,7 +13,8 @@ local BorderError = errors.new_class('BorderError', {capture_stack = false})
 
 local borders = {}
 
-local STAT_FUNC_NAME = '_crud.get_border_on_storage'
+local STAT_FUNC_NAME = 'get_border_on_storage'
+local CRUD_STAT_FUNC_NAME = utils.get_storage_call(STAT_FUNC_NAME)
 
 
 local function get_border_on_storage(border_name, space_name, index_id, field_names, fetch_latest_metadata)
@@ -42,8 +43,8 @@ local function get_border_on_storage(border_name, space_name, index_id, field_na
     })
 end
 
-function borders.init()
-   _G._crud.get_border_on_storage = get_border_on_storage
+function borders.init(user)
+    utils.init_storage_call(user, STAT_FUNC_NAME, get_border_on_storage)
 end
 
 local is_closer
@@ -111,7 +112,7 @@ local function call_get_border_on_router(vshard_router, border_name, space_name,
         timeout = opts.timeout,
     }
     local results, err, storages_info = call.map(vshard_router,
-        STAT_FUNC_NAME,
+        CRUD_STAT_FUNC_NAME,
         {border_name, space_name, index.id, field_names, opts.fetch_latest_metadata},
         call_opts
     )

--- a/crud/common/sharding/sharding_metadata.lua
+++ b/crud/common/sharding/sharding_metadata.lua
@@ -4,6 +4,7 @@ local log = require('log')
 
 local call = require('crud.common.call')
 local const = require('crud.common.const')
+local utils = require('crud.common.utils')
 local dev_checks = require('crud.common.dev_checks')
 local router_cache = require('crud.common.sharding.router_metadata_cache')
 local storage_cache = require('crud.common.sharding.storage_metadata_cache')
@@ -13,7 +14,8 @@ local sharding_utils = require('crud.common.sharding.utils')
 
 local FetchShardingMetadataError = errors.new_class('FetchShardingMetadataError', {capture_stack = false})
 
-local FETCH_FUNC_NAME = '_crud.fetch_on_storage'
+local FETCH_FUNC_NAME = 'fetch_on_storage'
+local CRUD_FETCH_FUNC_NAME = utils.get_storage_call(FETCH_FUNC_NAME)
 
 local sharding_metadata_module = {}
 
@@ -107,7 +109,7 @@ local _fetch_on_router = locked(function(vshard_router, space_name, metadata_map
         return
     end
 
-    local metadata_map, err = call.any(vshard_router, FETCH_FUNC_NAME, {}, {
+    local metadata_map, err = call.any(vshard_router, CRUD_FETCH_FUNC_NAME, {}, {
         timeout = timeout
     })
     if err ~= nil then
@@ -212,8 +214,8 @@ function sharding_metadata_module.reload_sharding_cache(vshard_router, space_nam
     end
 end
 
-function sharding_metadata_module.init()
-   _G._crud.fetch_on_storage = sharding_metadata_module.fetch_on_storage
+function sharding_metadata_module.init(user)
+    utils.init_storage_call(user, FETCH_FUNC_NAME, sharding_metadata_module.fetch_on_storage)
 end
 
 return sharding_metadata_module

--- a/crud/count.lua
+++ b/crud/count.lua
@@ -17,7 +17,8 @@ local compare_conditions = require('crud.compare.conditions')
 
 local CountError = errors.new_class('CountError', {capture_stack = false})
 
-local COUNT_FUNC_NAME = '_crud.count_on_storage'
+local COUNT_FUNC_NAME = 'count_on_storage'
+local CRUD_COUNT_FUNC_NAME = utils.get_storage_call(COUNT_FUNC_NAME)
 
 local count = {}
 
@@ -85,8 +86,8 @@ local function count_on_storage(space_name, index_id, conditions, opts)
     return tuples_count
 end
 
-function count.init()
-    _G._crud.count_on_storage = count_on_storage
+function count.init(user)
+    utils.init_storage_call(user, COUNT_FUNC_NAME, count_on_storage)
 end
 
 local check_count_safety_rl = ratelimit.new()
@@ -240,7 +241,7 @@ local function call_count_on_router(vshard_router, space_name, user_conditions, 
         skip_sharding_hash_check = skip_sharding_hash_check,
     }
 
-    local results, err = call.map(vshard_router, COUNT_FUNC_NAME, {
+    local results, err = call.map(vshard_router, CRUD_COUNT_FUNC_NAME, {
         space_name, plan.index_id, plan.conditions, count_opts
     }, call_opts)
 

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -14,7 +14,8 @@ local DeleteError = errors.new_class('DeleteError', {capture_stack = false})
 
 local delete = {}
 
-local DELETE_FUNC_NAME = '_crud.delete_on_storage'
+local DELETE_FUNC_NAME = 'delete_on_storage'
+local CRUD_DELETE_FUNC_NAME = utils.get_storage_call(DELETE_FUNC_NAME)
 
 local function delete_on_storage(space_name, key, field_names, opts)
     dev_checks('string', '?', '?table', {
@@ -51,8 +52,8 @@ local function delete_on_storage(space_name, key, field_names, opts)
     })
 end
 
-function delete.init()
-   _G._crud.delete_on_storage = delete_on_storage
+function delete.init(user)
+    utils.init_storage_call(user, DELETE_FUNC_NAME, delete_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -127,7 +128,7 @@ local function call_delete_on_router(vshard_router, space_name, key, opts)
     }
 
     local storage_result, err = call.single(vshard_router,
-        bucket_id_data.bucket_id, DELETE_FUNC_NAME,
+        bucket_id_data.bucket_id, CRUD_DELETE_FUNC_NAME,
         {space_name, key, opts.fields, delete_on_storage_opts},
         call_opts
     )

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -14,7 +14,8 @@ local GetError = errors.new_class('GetError', {capture_stack = false})
 
 local get = {}
 
-local GET_FUNC_NAME = '_crud.get_on_storage'
+local GET_FUNC_NAME = 'get_on_storage'
+local CRUD_GET_FUNC_NAME = utils.get_storage_call(GET_FUNC_NAME)
 
 local function get_on_storage(space_name, key, field_names, opts)
     dev_checks('string', '?', '?table', {
@@ -49,8 +50,8 @@ local function get_on_storage(space_name, key, field_names, opts)
     })
 end
 
-function get.init()
-   _G._crud.get_on_storage = get_on_storage
+function get.init(user)
+    utils.init_storage_call(user, GET_FUNC_NAME, get_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -125,7 +126,7 @@ local function call_get_on_router(vshard_router, space_name, key, opts)
     }
 
     local storage_result, err = call.single(vshard_router,
-        bucket_id_data.bucket_id, GET_FUNC_NAME,
+        bucket_id_data.bucket_id, CRUD_GET_FUNC_NAME,
         {space_name, key, opts.fields, get_on_storage_opts},
         call_opts
     )

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -12,7 +12,8 @@ local InsertError = errors.new_class('InsertError', {capture_stack = false})
 
 local insert = {}
 
-local INSERT_FUNC_NAME = '_crud.insert_on_storage'
+local INSERT_FUNC_NAME = 'insert_on_storage'
+local CRUD_INSERT_FUNC_NAME = utils.get_storage_call(INSERT_FUNC_NAME)
 
 local function insert_on_storage(space_name, tuple, opts)
     dev_checks('string', 'table', {
@@ -52,8 +53,8 @@ local function insert_on_storage(space_name, tuple, opts)
     })
 end
 
-function insert.init()
-   _G._crud.insert_on_storage = insert_on_storage
+function insert.init(user)
+    utils.init_storage_call(user, INSERT_FUNC_NAME, insert_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -102,7 +103,7 @@ local function call_insert_on_router(vshard_router, space_name, original_tuple, 
     }
 
     local storage_result, err = call.single(vshard_router,
-        sharding_data.bucket_id, INSERT_FUNC_NAME,
+        sharding_data.bucket_id, CRUD_INSERT_FUNC_NAME,
         {space_name, tuple, insert_on_storage_opts},
         call_opts
     )

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -16,7 +16,8 @@ local InsertManyError = errors.new_class('InsertManyError', {capture_stack = fal
 
 local insert_many = {}
 
-local INSERT_MANY_FUNC_NAME = '_crud.insert_many_on_storage'
+local INSERT_MANY_FUNC_NAME = 'insert_many_on_storage'
+local CRUD_INSERT_MANY_FUNC_NAME = utils.get_storage_call(INSERT_MANY_FUNC_NAME)
 
 local function insert_many_on_storage(space_name, tuples, opts)
     dev_checks('string', 'table', {
@@ -122,8 +123,8 @@ local function insert_many_on_storage(space_name, tuples, opts)
     return inserted_tuples, nil, replica_schema_version
 end
 
-function insert_many.init()
-    _G._crud.insert_many_on_storage = insert_many_on_storage
+function insert_many.init(user)
+    utils.init_storage_call(user, INSERT_MANY_FUNC_NAME, insert_many_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -175,7 +176,7 @@ local function call_insert_many_on_router(vshard_router, space_name, original_tu
 
     local postprocessor = BatchPostprocessor:new(vshard_router)
 
-    local rows, errs, storages_info = call.map(vshard_router, INSERT_MANY_FUNC_NAME, nil, {
+    local rows, errs, storages_info = call.map(vshard_router, CRUD_INSERT_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,
         mode = 'write',
         iter = iter,

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -8,7 +8,8 @@ local LenError = errors.new_class('LenError', {capture_stack = false})
 
 local len = {}
 
-local LEN_FUNC_NAME = '_crud.len_on_storage'
+local LEN_FUNC_NAME = 'len_on_storage'
+local CRUD_LEN_FUNC_NAME = utils.get_storage_call(LEN_FUNC_NAME)
 
 local function len_on_storage(space_name)
     dev_checks('string|number')
@@ -16,8 +17,8 @@ local function len_on_storage(space_name)
     return box.space[space_name]:len()
 end
 
-function len.init()
-    _G._crud.len_on_storage = len_on_storage
+function len.init(user)
+    utils.init_storage_call(user, LEN_FUNC_NAME, len_on_storage)
 end
 
 --- Calculates the number of tuples in the space for memtx engine
@@ -61,7 +62,7 @@ function len.call(space_name, opts)
         return nil, LenError:new("Space %q doesn't exist", space_name)
     end
 
-    local results, err = vshard_router:map_callrw(LEN_FUNC_NAME, {space_name}, opts)
+    local results, err = vshard_router:map_callrw(CRUD_LEN_FUNC_NAME, {space_name}, opts)
 
     if err ~= nil then
         return nil, LenError:new("Failed to call len on storage-side: %s", err)

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -12,7 +12,8 @@ local ReplaceError = errors.new_class('ReplaceError', { capture_stack = false })
 
 local replace = {}
 
-local REPLACE_FUNC_NAME = '_crud.replace_on_storage'
+local REPLACE_FUNC_NAME = 'replace_on_storage'
+local CRUD_REPLACE_FUNC_NAME = utils.get_storage_call(REPLACE_FUNC_NAME)
 
 local function replace_on_storage(space_name, tuple, opts)
     dev_checks('string', 'table', {
@@ -52,8 +53,8 @@ local function replace_on_storage(space_name, tuple, opts)
     })
 end
 
-function replace.init()
-   _G._crud.replace_on_storage = replace_on_storage
+function replace.init(user)
+    utils.init_storage_call(user, REPLACE_FUNC_NAME, replace_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -101,7 +102,7 @@ local function call_replace_on_router(vshard_router, space_name, original_tuple,
         timeout = opts.timeout,
     }
     local storage_result, err = call.single(vshard_router,
-        sharding_data.bucket_id, REPLACE_FUNC_NAME,
+        sharding_data.bucket_id, CRUD_REPLACE_FUNC_NAME,
         {space_name, tuple, replace_on_storage_opts},
         call_opts
     )

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -16,7 +16,8 @@ local ReplaceManyError = errors.new_class('ReplaceManyError', {capture_stack = f
 
 local replace_many = {}
 
-local REPLACE_MANY_FUNC_NAME = '_crud.replace_many_on_storage'
+local REPLACE_MANY_FUNC_NAME = 'replace_many_on_storage'
+local CRUD_REPLACE_MANY_FUNC_NAME = utils.get_storage_call(REPLACE_MANY_FUNC_NAME)
 
 local function replace_many_on_storage(space_name, tuples, opts)
     dev_checks('string', 'table', {
@@ -125,8 +126,8 @@ local function replace_many_on_storage(space_name, tuples, opts)
     return inserted_tuples, nil, replica_schema_version
 end
 
-function replace_many.init()
-    _G._crud.replace_many_on_storage = replace_many_on_storage
+function replace_many.init(user)
+    utils.init_storage_call(user, REPLACE_MANY_FUNC_NAME, replace_many_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -178,7 +179,7 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
 
     local postprocessor = BatchPostprocessor:new(vshard_router)
 
-    local rows, errs, storages_info = call.map(vshard_router, REPLACE_MANY_FUNC_NAME, nil, {
+    local rows, errs, storages_info = call.map(vshard_router, CRUD_REPLACE_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,
         mode = 'write',
         iter = iter,

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -12,6 +12,8 @@ local SelectError = errors.new_class('SelectError')
 
 local select_module
 
+local SELECT_FUNC_NAME = 'select_on_storage'
+
 local select_module_compat_info = stash.get(stash.name.select_module_compat_info)
 local has_merger = (utils.tarantool_supports_external_merger() and
     package.search('tuple.merger')) or utils.tarantool_has_builtin_merger()
@@ -123,8 +125,8 @@ local function select_on_storage(space_name, index_id, conditions, opts)
     return unpack(result)
 end
 
-function select_module.init()
-   _G._crud.select_on_storage = select_on_storage
+function select_module.init(user)
+    utils.init_storage_call(user, SELECT_FUNC_NAME, select_on_storage)
 end
 
 return select_module

--- a/crud/select/compat/common.lua
+++ b/crud/select/compat/common.lua
@@ -1,10 +1,11 @@
 local ratelimit = require('crud.ratelimit')
+local utils = require('crud.common.utils')
 local check_select_safety_rl = ratelimit.new()
 
 local common = {}
 
-common.SELECT_FUNC_NAME = '_crud.select_on_storage'
-common.READVIEW_SELECT_FUNC_NAME ='_crud.select_readview_on_storage'
+common.SELECT_FUNC_NAME = utils.get_storage_call('select_on_storage')
+common.READVIEW_SELECT_FUNC_NAME = utils.get_storage_call('select_readview_on_storage')
 common.DEFAULT_BATCH_SIZE = 100
 
 common.check_select_safety = function(space_name, plan, opts)

--- a/crud/truncate.lua
+++ b/crud/truncate.lua
@@ -9,7 +9,8 @@ local TruncateError = errors.new_class('TruncateError', {capture_stack = false})
 
 local truncate = {}
 
-local TRUNCATE_FUNC_NAME = '_crud.truncate_on_storage'
+local TRUNCATE_FUNC_NAME = 'truncate_on_storage'
+local CRUD_TRUNCATE_FUNC_NAME = utils.get_storage_call(TRUNCATE_FUNC_NAME)
 
 local function truncate_on_storage(space_name)
     dev_checks('string')
@@ -22,8 +23,8 @@ local function truncate_on_storage(space_name)
     return space:truncate()
 end
 
-function truncate.init()
-   _G._crud.truncate_on_storage = truncate_on_storage
+function truncate.init(user)
+    utils.init_storage_call(user, TRUNCATE_FUNC_NAME, truncate_on_storage)
 end
 
 --- Truncates specified space
@@ -59,7 +60,7 @@ function truncate.call(space_name, opts)
     end
 
     local replicasets = vshard_router:routeall()
-    local _, err = call.map(vshard_router, TRUNCATE_FUNC_NAME, {space_name}, {
+    local _, err = call.map(vshard_router, CRUD_TRUNCATE_FUNC_NAME, {space_name}, {
         mode = 'write',
         replicasets = replicasets,
         timeout = opts.timeout,

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -14,7 +14,8 @@ local UpdateError = errors.new_class('UpdateError', {capture_stack = false})
 
 local update = {}
 
-local UPDATE_FUNC_NAME = '_crud.update_on_storage'
+local UPDATE_FUNC_NAME = 'update_on_storage'
+local CRUD_UPDATE_FUNC_NAME = utils.get_storage_call(UPDATE_FUNC_NAME)
 
 local function update_on_storage(space_name, key, operations, field_names, opts)
     dev_checks('string', '?', 'table', '?table', {
@@ -73,8 +74,8 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
     return res, err
 end
 
-function update.init()
-   _G._crud.update_on_storage = update_on_storage
+function update.init(user)
+    utils.init_storage_call(user, UPDATE_FUNC_NAME, update_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -156,7 +157,7 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
     }
 
     local storage_result, err = call.single(vshard_router,
-        bucket_id_data.bucket_id, UPDATE_FUNC_NAME,
+        bucket_id_data.bucket_id, CRUD_UPDATE_FUNC_NAME,
         {space_name, key, operations, opts.fields, update_on_storage_opts},
         call_opts
     )

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -12,7 +12,8 @@ local UpsertError = errors.new_class('UpsertError', { capture_stack = false})
 
 local upsert = {}
 
-local UPSERT_FUNC_NAME = '_crud.upsert_on_storage'
+local UPSERT_FUNC_NAME = 'upsert_on_storage'
+local CRUD_UPSERT_FUNC_NAME = utils.get_storage_call(UPSERT_FUNC_NAME)
 
 local function upsert_on_storage(space_name, tuple, operations, opts)
     dev_checks('string', 'table', 'table', {
@@ -49,8 +50,8 @@ local function upsert_on_storage(space_name, tuple, operations, opts)
     })
 end
 
-function upsert.init()
-   _G._crud.upsert_on_storage = upsert_on_storage
+function upsert.init(user)
+    utils.init_storage_call(user, UPSERT_FUNC_NAME, upsert_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -107,7 +108,7 @@ local function call_upsert_on_router(vshard_router, space_name, original_tuple, 
     }
 
     local storage_result, err = call.single(vshard_router,
-        sharding_data.bucket_id, UPSERT_FUNC_NAME,
+        sharding_data.bucket_id, CRUD_UPSERT_FUNC_NAME,
         {space_name, tuple, operations, upsert_on_storage_opts},
         call_opts
     )

--- a/crud/upsert_many.lua
+++ b/crud/upsert_many.lua
@@ -16,7 +16,8 @@ local UpsertManyError = errors.new_class('UpsertManyError', {capture_stack = fal
 
 local upsert_many = {}
 
-local UPSERT_MANY_FUNC_NAME = '_crud.upsert_many_on_storage'
+local UPSERT_MANY_FUNC_NAME = 'upsert_many_on_storage'
+local CRUD_UPSERT_MANY_FUNC_NAME = utils.get_storage_call(UPSERT_MANY_FUNC_NAME)
 
 local function upsert_many_on_storage(space_name, tuples, operations, opts)
     dev_checks('string', 'table', 'table', {
@@ -119,8 +120,8 @@ local function upsert_many_on_storage(space_name, tuples, operations, opts)
     return nil, nil, replica_schema_version
 end
 
-function upsert_many.init()
-    _G._crud.upsert_many_on_storage = upsert_many_on_storage
+function upsert_many.init(user)
+    utils.init_storage_call(user, UPSERT_MANY_FUNC_NAME, upsert_many_on_storage)
 end
 
 -- returns result, err, need_reload
@@ -189,7 +190,7 @@ local function call_upsert_many_on_router(vshard_router, space_name, original_tu
 
     local postprocessor = BatchPostprocessor:new(vshard_router)
 
-    local _, errs, storages_info = call.map(vshard_router, UPSERT_MANY_FUNC_NAME, nil, {
+    local _, errs, storages_info = call.map(vshard_router, CRUD_UPSERT_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,
         mode = 'write',
         iter = iter,

--- a/doc/playground.lua
+++ b/doc/playground.lua
@@ -43,9 +43,6 @@ end
 
 -- Setup vshard.
 _G.vshard = vshard
-box.once('guest', function()
-    box.schema.user.grant('guest', 'super')
-end)
 local uri = 'guest@localhost:3301'
 local cfg = {
     bucket_count = 3000,

--- a/test/entrypoint/srv_say_hi/all_init.lua
+++ b/test/entrypoint/srv_say_hi/all_init.lua
@@ -1,11 +1,24 @@
 local fiber = require('fiber')
 
+-- Adds execution rights to a function for a vshard storage user.
+local function add_storage_execute(func_name)
+    if type(box.cfg) ~= 'table' then
+        -- Cartridge, unit tests.
+        return
+    end
+    if box.cfg.read_only == false and box.schema.user.exists('storage') then
+        box.schema.func.create(func_name, {setuid = true})
+        box.schema.user.grant('storage', 'execute', 'function', func_name)
+    end
+end
+
 return function()
     rawset(_G, 'say_hi_politely', function (to_name)
        to_name = to_name or "handsome"
        local my_alias = box.info.id
        return string.format("HI, %s! I am %s", to_name, my_alias)
     end)
+    add_storage_execute('say_hi_politely')
 
     rawset(_G, 'say_hi_sleepily', function (time_to_sleep)
        if time_to_sleep ~= nil then
@@ -14,12 +27,14 @@ return function()
 
        return "HI"
     end)
+    add_storage_execute('say_hi_sleepily')
 
     rawset(_G, 'vshard_calls', {})
 
     rawset(_G, 'clear_vshard_calls', function()
         table.clear(_G.vshard_calls)
     end)
+    add_storage_execute('clear_vshard_calls')
 
     rawset(_G, 'patch_vshard_calls', function(vshard_call_names)
         local vshard = require('vshard')
@@ -42,4 +57,7 @@ return function()
             end
         end
     end)
+    add_storage_execute('patch_vshard_calls')
+
+    add_storage_execute('non_existent_func')
 end

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -727,14 +727,16 @@ function helpers.start_cluster(g, cartridge_cfg, vshard_cfg)
             ['ENGINE'] = g.params.engine
         }
 
+        g.cfg = cfg
         g.cluster = helpers.Cluster:new(cfg)
         g.cluster:start()
     elseif g.params.backend == helpers.backend.VSHARD then
         local cfg = table.deepcopy(vshard_cfg)
         cfg.engine = g.params.engine
 
-        local global_cfg = vtest.config_new(cfg)
-        vtest.cluster_new(g, global_cfg)
+        g.cfg = vtest.config_new(cfg)
+        vtest.cluster_new(g, g.cfg)
+        g.cfg.engine = nil
     end
 end
 

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2308,9 +2308,10 @@ pgroup.test_stop_select = function(g)
     g.cluster:server('s2-master'):start()
 
     if g.params.backend == helpers.backend.VSHARD then
-        g.cluster:server('s2-master'):exec(function()
+        g.cluster:server('s2-master'):exec(function(cfg)
+            require('vshard.storage').cfg(cfg, box.info.uuid)
             require('crud').init_storage()
-        end)
+        end, {g.cfg})
     end
 
     local _, err = g.cluster.main_server.net_box:eval([[

--- a/test/integration/storages_state_test.lua
+++ b/test/integration/storages_state_test.lua
@@ -76,10 +76,9 @@ pgroup.test_crud_storage_status_of_stopped_servers = function(g)
 end
 
 pgroup.after_test('test_crud_storage_status_of_stopped_servers', function(g)
-    g.cluster:server("s2-replica"):start()
-    g.cluster:server("s2-replica"):exec(function()
-        require('crud').init_storage()
-    end)
+    helpers.stop_cluster(g.cluster, g.params.backend)
+    g.cluster = nil
+    helpers.start_default_cluster(g, 'srv_select')
 end)
 
 pgroup.test_disabled_storage_role = function(g)

--- a/test/unit/select_executor_test.lua
+++ b/test/unit/select_executor_test.lua
@@ -1,5 +1,3 @@
-local crud = require('crud')
-
 local select_plan = require('crud.compare.plan')
 local select_executor = require('crud.select.executor')
 local select_filters = require('crud.compare.filters')
@@ -56,8 +54,6 @@ g.before_all = function()
         unique = false,
         if_not_exists = true,
     })
-
-    crud.init_storage()
 end
 
 g.after_each(function()

--- a/test/vshard_helpers/vtest.lua
+++ b/test/vshard_helpers/vtest.lua
@@ -393,7 +393,7 @@ local function cluster_new(g, cfg)
 
             cfg.engine = nil
             require('vshard.storage').cfg(cfg, box.info.uuid)
-            box.schema.user.grant('storage', 'super')
+            box.schema.user.grant('storage', 'write,read', 'universe')
 
             box.session.su(user)
         end, {cfg})


### PR DESCRIPTION
The patch adds execution access on a stroage for crud functions to a VShard storage user in the VShard manner [[1](https://github.com/tarantool/vshard/blob/b3c27b32637863e9a03503e641bb7c8c69779a00/vshard/storage/init.lua#L777-L780)].

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #366
