### PR TITLE
crud: store the cursor's `after_tuple` explicitly as a Lua table

### DIFF
--- a/crud/readview.lua
+++ b/crud/readview.lua
@@ -168,7 +168,7 @@ local function select_readview_on_storage(space_name, index_id, conditions, opts
         cursor.is_end = true
     else
         local last_tuple = resp.tuples[#resp.tuples]
-        cursor.after_tuple = last_tuple
+        cursor.after_tuple = last_tuple:totable()
     end
 
     cursor.stats = {

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -99,7 +99,7 @@ local function select_on_storage(space_name, index_id, conditions, opts)
         cursor.is_end = true
     else
         local last_tuple = resp.tuples[#resp.tuples]
-        cursor.after_tuple = last_tuple
+        cursor.after_tuple = last_tuple:totable()
     end
 
     cursor.stats = {


### PR DESCRIPTION
In scope of tarantool/tarantool#8147, a new context-dependent extension for box tuples, `MP_TUPLE`, is introduced. If the merger's buffer source is used, raw MsgPack is received, which does not allow for passing the context required for decoding `MP_TUPLE`.

At the same time, all box tuples are now encoded as `MP_TUPLE` by default. If the merger's tuple chunk can be decoded by manually skipping the extension header of `MP_TUPLE` and the tuple format of individual tuples, the cursor is decoded using the Lua `msgpack` library, which cannot handle `MP_TUPLE`s without a decoding context.

The cursor's `after_tuple` field is a box tuple, so in order to overcome the limitation above, we need to explicitly convert it to a Lua table.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Needed for tarantool/tarantool#8147
