### PR TITLE
test: fix flaky cached schema case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1739,7 +1739,10 @@ where:
     vshard router instance. Set this parameter if your space is not
     a part of the default vshard cluster
   * `cached` (`?boolean`) - if `false`, reloads storages schema on call;
-    if `true`, return last known schema; default value is `false`
+    if `true`, return last known schema; default value is `false`.
+    Beware that consequent calls with `cached=true` do not guarantee
+    the same result if schema had chaned since net.box connections
+    still may perform reload on internal ping or any other request
 
 Returns space schema (or spaces schema map), error.
 


### PR DESCRIPTION
We cannot guarantee that cached schema is always the old one since net.box may reload the schema, see [1] for example of fail.

1. https://github.com/tarantool/crud/actions/runs/6531939885/job/17734151700

- [x] Tests

