### PR TITLE
release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.0] - 16-10-23
 
 ### Added
 * Space schema introspection API `crud.schema` (#380).
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `doc/playground.lua` does not work with Tarantool 3 (#371).
 * Tests with Tarantool 3 (#364).
 * VShard storage user have not execution rights for internal functions (#366).
+* Compatibility with Tarantool 3.0 tuple objects (#387).
 
 ## [1.3.0] - 27-09-23
 

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.3.0'
+return '1.4.0'


### PR DESCRIPTION
This release improves experience for VShard clusters users and Tarantool 3 users. It also introduces schema introspection API.

### New features

* Space schema introspection API `crud.schema` (#380).

### Bugfixes

* Return explicit error for `*_many` call with no tuples/objects (#377).
* `crud.readview` resource cleanup on garbage collect (#379).
* VShard storage user have not execution rights for internal functions (#366).
* Compatibility with Tarantool 3.0 tuple objects (#387).

### Infrastructure

* `deps.sh` installs the `vshard` instead of the `cartridge` by default (#364). You could to specify an environment variable `CARTIRDGE_VERSION` to install the `cartridge` and run tests cases with it.
* `doc/playground.lua` does not work with Tarantool 3 (#371).
* Tests with Tarantool 3 (#364).
* Quickstart section in the README.md focuses on usage with `vshard` instead of `Cartridge` (#366).