### PR TITLE
release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.1] - 23-10-23
 
 ### Changed
 * Dropped external tuple merger and tuple keydef modules installation from the

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.4.0'
+return '1.4.1'


### PR DESCRIPTION
## Overview

This release introduces various fixes for future Tarantool 3 patches related to tuples over network.

## Changes

* Dropped external tuple merger and tuple keydef modules installation from the package build (#390).

## Fixes
* Compatibility with Tarantool 3.0 binary protocol change (#390).
* Compatibility with Tarantool 3.0 tuple objects (#390).
