### PR TITLE
Support vshard names as keys

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -37,13 +37,13 @@ jobs:
             cartridge-version: "2.8.0"
           - tarantool-version: "2.11"
             metrics-version: "1.0.0"
-            vshard-version: "0.1.24"
+            vshard-version: "0.1.25"
           - tarantool-version: "2.11"
             external-merger-version: "0.0.5"
             external-keydef-version: "0.0.4"
           - tarantool-version: "master"
             metrics-version: "1.0.0"
-            vshard-version: "0.1.24"
+            vshard-version: "0.1.25"
       fail-fast: false
     # Can't install older versions on 22.04,
     # see https://github.com/tarantool/setup-tarantool/issues/36
@@ -141,7 +141,7 @@ jobs:
         include:
           - tarantool-version: "master"
             metrics-version: "1.0.0"
-            vshard-version: "0.1.24"
+            vshard-version: "0.1.25"
       fail-fast: false
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `mode` option for `crud.min` and `crud.max` (#404).
+
 ### Fixed
 * Compatibility with vshard 0.1.25 `name_as_key` identification mode
   for Tarantool 3.0 (#403).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+* Compatibility with vshard 0.1.25 `name_as_key` identification mode
+  for Tarantool 3.0 (#403).
+
 ## [1.4.1] - 23-10-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1100,9 +1100,33 @@ See more examples of pairs queries [here.](https://github.com/tarantool/crud/blo
 
 ### Min and max
 
+`CRUD` supports operations to get the minimum (maximum) object from the space index
+
+```lua
+local objects, err = crud.min(space_name, index_id, opts)
+local objects, err = crud.max(space_name, index_id, opts)
+```
+
+where:
+
+* `space_name` (`string`) - name of the space
+* `index_id` (`?string|number`) - index name or index id. Primary index by default
+* `opts`:
+  * `timeout` (`?number`) - `vshard.call` timeout (in seconds)
+  * `fields` (`?table`) - field names for getting only a subset of fields
+  * `mode` (`?string`, `read` or `write`) - if `write` is specified then `select` is
+    performed on master, default value is `read`
+  * `vshard_router` (`?string|table`) - Cartridge vshard group name or
+    vshard router instance. Set this parameter if your space is not
+    a part of the default vshard cluster
+  * `fetch_latest_metadata` (`?boolean`) - guarantees the
+    up-to-date metadata (space format) in first return value, otherwise
+    it may not take into account the latest migration of the data format.
+    Performance overhead is up to 15%. `false` by default
+
 ```lua
 -- Find the minimum value in the specified index
-local result, err = crud.min(space_name, 'age', opts)
+local result, err = crud.min('customers', 'age')
 ---
 - metadata:
   - {'name': 'id', 'type': 'unsigned'}
@@ -1113,7 +1137,7 @@ local result, err = crud.min(space_name, 'age', opts)
   - [1, 477, 'Elizabeth', 12]
 
 -- Find the maximum value in the specified index
-local result, err = crud.max(space_name, 'age', opts)
+local result, err = crud.max('customers', 'age')
 ---
 - metadata:
   - {'name': 'id', 'type': 'unsigned'}

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -72,6 +72,7 @@ local function call_get_border_on_router(vshard_router, border_name, space_name,
     checks('table', 'string', 'string', '?string|number', {
         timeout = '?number',
         fields = '?table',
+        mode = '?string',
         vshard_router = '?string|table',
         fetch_latest_metadata = '?boolean',
     })
@@ -107,7 +108,7 @@ local function call_get_border_on_router(vshard_router, border_name, space_name,
         return nil, BorderError:new("Failed to get router replicasets: %s", err)
     end
     local call_opts = {
-        mode = 'read',
+        mode = opts.mode or 'read',
         replicasets = replicasets,
         timeout = opts.timeout,
     }

--- a/crud/readview.lua
+++ b/crud/readview.lua
@@ -260,16 +260,16 @@ function Readview_obj:close(opts)
 
     local errors = {}
     for _, replicaset in pairs(replicasets) do
-        for replica_uuid, replica in pairs(replicaset.replicas) do
+        for _, replica in pairs(replicaset.replicas) do
             for _, value in pairs(self._uuid) do
-                if replica_uuid == value.uuid then
+                if replica.uuid == value.uuid then
                     local replica_result, replica_err = replica.conn:call(CRUD_CLOSE_FUNC_NAME,
                     {self._uuid}, {timeout = opts.timeout})
                     if replica_err ~= nil then
                         table.insert(errors, ReadviewError:new("Failed to close Readview on storage: %s", replica_err))
                     end
                     if replica_err == nil and (not replica_result) then
-                        table.insert(errors, ReadviewError:new("Readview was not found on storage: %s", replica_uuid))
+                        table.insert(errors, ReadviewError:new("Readview was not found on storage: %s", replica.uuid))
                     end
                 end
             end

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -59,6 +59,7 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
         return res, nil
     end
 
+    -- Relevant for Tarantool older than 2.8.1.
     -- We can only add fields to end of the tuple.
     -- If schema is updated and nullable fields are added, then we will get error.
     -- Therefore, we need to add filling of intermediate nullable fields.
@@ -68,6 +69,8 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
         res, err = schema.wrap_box_space_func_result(space, 'update', {key, operations}, {
             add_space_schema_hash = false,
             field_names = field_names,
+            noreturn = opts.noreturn,
+            fetch_latest_metadata = opts.fetch_latest_metadata,
         })
     end
 

--- a/test/integration/borders_test.lua
+++ b/test/integration/borders_test.lua
@@ -128,61 +128,73 @@ pgroup.test_min = function(g)
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
     -- by primary
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers'})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', nil, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1}))
 
     -- by primary, index ID is specified
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers', 0})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 0, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1}))
 
     -- by primary with fields
-    local result, err = g.cluster.main_server.net_box:call('crud.min',
-        {'customers', nil, {fields = {'name', 'last_name'}}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', nil, {fields = {'name', 'last_name'}, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{name = "Elizabeth", last_name = "Jackson"}})
 
     -- by age index
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers', 'age_index'})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 'age_index', {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4}))
 
     -- by age index, index ID is specified
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers', 2})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 2, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4}))
 
     -- by age index with fields
-    local result, err = g.cluster.main_server.net_box:call('crud.min',
-        {'customers', 'age_index', {fields = {'name', 'last_name'}}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 'age_index', {fields = {'name', 'last_name'}, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{name = "William", last_name = "White"}})
 
     -- by composite index full_name
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers', 'full_name'})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 'full_name', {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {3}))
 
     -- by composite index full_name, index ID is specified
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers', 5})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 5, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {3}))
 
     -- by composite index full_name with fields
-    local result, err = g.cluster.main_server.net_box:call('crud.min',
-        {'customers', 'full_name', {fields = {'name', 'last_name'}}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 'full_name', {fields = {'name', 'last_name'}, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{name = "David", last_name = "Smith"}})
@@ -208,61 +220,73 @@ pgroup.test_max = function(g)
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
     -- by primary
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers'})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', nil, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4}))
 
     -- by primary, index ID is specified
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers', 0})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 0, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4}))
 
     -- by primary with fields
-    local result, err = g.cluster.main_server.net_box:call('crud.max',
-        {'customers', nil, {fields = {'name', 'last_name'}}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', nil, {fields = {'name', 'last_name'}, mode = 'write'}
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{name = "William", last_name = "White"}})
 
     -- by age index
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers', 'age_index'})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 'age_index', {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2}))
 
     -- by age index, index ID is specified
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers', 2})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 2, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2}))
 
     -- by age index with fields
-    local result, err = g.cluster.main_server.net_box:call('crud.max',
-        {'customers', 'age_index', {fields = {'name', 'last_name'}}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 'age_index', {fields = {'name', 'last_name'}, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{name = "Mary", last_name = "Brown"}})
 
     -- by composite index full_name
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers', 'full_name'})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 'full_name', {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4}))
 
     -- by composite index full_name, index ID is specified
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers', 5})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 5, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {4}))
 
     -- by composite index full_name with fields
-    local result, err = g.cluster.main_server.net_box:call('crud.max',
-        {'customers', 'full_name', {fields = {'name', 'last_name'}}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 'full_name', {fields = {'name', 'last_name'}, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {{name = "William", last_name = "White"}})
@@ -290,13 +314,17 @@ pgroup.test_equal_secondary_keys = function(g)
     table.sort(customers, function(obj1, obj2) return obj1.id < obj2.id end)
 
     -- min
-    local result, err = g.cluster.main_server.net_box:call('crud.min', {'customers', 'age_index'})
+    local result, err = g.cluster.main_server.net_box:call('crud.min', {
+        'customers', 'age_index', {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {1}))
 
     -- max
-    local result, err = g.cluster.main_server.net_box:call('crud.max', {'customers', 'age_index'})
+    local result, err = g.cluster.main_server.net_box:call('crud.max', {
+        'customers', 'age_index', {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     local objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, helpers.get_objects_by_idxs(customers, {2}))
@@ -320,7 +348,7 @@ pgroup.test_opts_not_damaged = function(g)
     })
 
     -- min
-    local min_opts = {timeout = 1, fields = {'name', 'age'}}
+    local min_opts = {timeout = 1, fields = {'name', 'age'}, mode = 'write'}
     local new_min_opts, err = g.cluster.main_server:eval([[
         local crud = require('crud')
 
@@ -335,7 +363,7 @@ pgroup.test_opts_not_damaged = function(g)
     t.assert_equals(new_min_opts, min_opts)
 
     -- max
-    local max_opts = {timeout = 1, fields = {'name', 'age'}}
+    local max_opts = {timeout = 1, fields = {'name', 'age'}, mode = 'write'}
     local new_max_opts, err = g.cluster.main_server:eval([[
         local crud = require('crud')
 

--- a/test/integration/cartridge_reload_test.lua
+++ b/test/integration/cartridge_reload_test.lua
@@ -99,7 +99,9 @@ function g.test_router()
 
     g.highload_fiber:cancel()
 
-    local result, err = g.router.net_box:call('crud.select', {'customers', nil, {fullscan = true}})
+    local result, err = g.router.net_box:call('crud.select', {
+        'customers', nil, {fullscan = true, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     t.assert_items_include(result.rows, g.insertions_passed)
 end
@@ -132,7 +134,9 @@ function g.test_storage()
 
     g.highload_fiber:cancel()
 
-    local result, err = g.router.net_box:call('crud.select', {'customers', nil, {fullscan = true}})
+    local result, err = g.router.net_box:call('crud.select', {
+        'customers', nil, {fullscan = true, mode = 'write'},
+    })
     t.assert_equals(err, nil)
     t.assert_items_include(result.rows, g.insertions_passed)
 end

--- a/test/integration/count_test.lua
+++ b/test/integration/count_test.lua
@@ -89,17 +89,17 @@ local count_safety_cases = {
     nil_and_nil_opts = {
         has_crit = true,
         user_conditions = nil,
-        opts = nil,
+        opts = {mode = 'write'},
     },
     fullscan_false = {
         has_crit = true,
         user_conditions = nil,
-        opts = {fullscan = false},
+        opts = {fullscan = false, mode = 'write'},
     },
     fullscan_true = {
         has_crit = false,
         user_conditions = nil,
-        opts = {fullscan = true},
+        opts = {fullscan = true, mode = 'write'},
     },
     non_equal_conditions = {
         has_crit = true,
@@ -109,7 +109,7 @@ local count_safety_cases = {
             {'>', 'age', 20},
             {'<', 'age', 30},
         },
-        opts = nil,
+        opts = {mode = 'write'},
     },
     equal_condition = {
         has_crit = false,
@@ -118,7 +118,7 @@ local count_safety_cases = {
             {'<=', 'last_name', 'Z'},
             {'=', 'age', 25},
         },
-        opts = nil,
+        opts = {mode = 'write'},
     },
     equal_condition2 = {
         has_crit = false,
@@ -127,7 +127,7 @@ local count_safety_cases = {
             {'<=', 'last_name', 'Z'},
             {'==', 'age', 25},
         },
-        opts = nil,
+        opts = {mode = 'write'},
     },
 }
 
@@ -179,9 +179,9 @@ pgroup.test_count_all = function(g)
         },
     })
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', nil, {fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', nil, {fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 5)
@@ -215,9 +215,9 @@ pgroup.test_count_all_with_yield_every = function(g)
         },
     })
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', nil, {yield_every = 1, fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', nil, {yield_every = 1, fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 5)
@@ -251,9 +251,9 @@ pgroup.test_count_all_with_yield_every_0 = function(g)
         },
     })
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', nil, {yield_every = 0, fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', nil, {yield_every = 0, fullscan = true, mode = 'write'}
+    })
 
     t.assert_equals(result, nil)
     t.assert_str_contains(err.err, "yield_every should be > 0")
@@ -289,9 +289,9 @@ pgroup.test_count_by_primary_index = function(g)
 
     local conditions = {{'==', 'id_index', 3}}
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
@@ -331,9 +331,9 @@ pgroup.test_eq_condition_with_index = function(g)
 
     local expected_len = 2
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -373,9 +373,9 @@ pgroup.test_ge_condition_with_index = function(g)
 
     local expected_len = 3
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions, {fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -415,9 +415,9 @@ pgroup.test_gt_condition_with_index = function(g)
 
     local expected_len = 1
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions, {fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -457,9 +457,9 @@ pgroup.test_le_condition_with_index = function(g)
 
     local expected_len = 4
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions, {fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -499,9 +499,9 @@ pgroup.test_lt_condition_with_index = function(g)
 
     local expected_len = 2
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions, {fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -543,9 +543,9 @@ pgroup.test_multiple_conditions = function(g)
 
     local expected_len = 2
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -565,17 +565,17 @@ pgroup.test_multipart_primary_index = function(g)
     })
 
     local conditions = {{'=', 'primary', 0}}
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'coord', conditions}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'coord', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 3)
 
     local conditions = {{'=', 'primary', {0, 2}}}
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'coord', conditions}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'coord', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
@@ -649,7 +649,7 @@ pgroup.test_count_no_map_reduce = function(g)
     local result, err = g.cluster.main_server.net_box:call('crud.count', {
         'customers',
         nil,
-        {bucket_id = 2804, timeout = 1, fullscan = true},
+        {bucket_id = 2804, timeout = 1, fullscan = true, mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
@@ -663,7 +663,7 @@ pgroup.test_count_no_map_reduce = function(g)
     local result, err = g.cluster.main_server.net_box:call('crud.count', {
         'customers',
         {{'==', 'age', 81}},
-        {bucket_id = 1161, timeout = 1},
+        {bucket_id = 1161, timeout = 1, mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
@@ -709,9 +709,9 @@ pgroup.test_count_timeout = function(g)
     local timeout = 4
     local begin = clock.proc()
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count',
-            {'customers', conditions, {timeout = timeout, fullscan = true}}
-    )
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {timeout = timeout, fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
@@ -751,7 +751,9 @@ pgroup.test_composite_index = function(g)
     }
 
     -- no after
-    local result, err = g.cluster.main_server.net_box:call('crud.count', {'customers', conditions, {fullscan = true}})
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {fullscan = true, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 4)
@@ -761,7 +763,9 @@ pgroup.test_composite_index = function(g)
         {'==', 'full_name', "Elizabeth"},
     }
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count', {'customers', conditions})
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 3)
@@ -781,7 +785,9 @@ pgroup.test_composite_primary_index = function(g)
 
     local conditions = {{'=', 'id', {5, 'Ukrainian', 55}}}
 
-    local result, err = g.cluster.main_server.net_box:call('crud.count', {'book_translation', conditions})
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'book_translation', conditions, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
 end
@@ -815,7 +821,9 @@ pgroup.test_count_by_full_sharding_key = function(g)
     })
 
     local conditions = {{'==', 'id', 3}}
-    local result, err = g.cluster.main_server.net_box:call('crud.count', {'customers', conditions})
+    local result, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers', conditions, {mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
@@ -846,14 +854,14 @@ pgroup.test_count_force_map_call = function(g)
     })
 
     local result, err = g.cluster.main_server.net_box:call('crud.count', {
-        'customers', {{'==', 'id', key}},
+        'customers', {{'==', 'id', key}}, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
     t.assert_equals(result, 1)
 
     result, err = g.cluster.main_server.net_box:call('crud.count', {
-        'customers', {{'==', 'id', key}}, {force_map_call = true}
+        'customers', {{'==', 'id', key}}, {force_map_call = true, mode = 'write'},
     })
 
     t.assert_equals(err, nil)

--- a/test/integration/custom_bucket_id_test.lua
+++ b/test/integration/custom_bucket_id_test.lua
@@ -39,7 +39,7 @@ end
 
 local function check_get(g, space_name, id, bucket_id, tuple)
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        space_name, id,
+        space_name, id, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -48,7 +48,7 @@ local function check_get(g, space_name, id, bucket_id, tuple)
 
     -- get w/ right bucket_id
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        space_name, id, {bucket_id = bucket_id}
+        space_name, id, {bucket_id = bucket_id, mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -119,7 +119,7 @@ pgroup.test_delete = function(g)
 
     -- get w/ right bucket_id
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        'customers', tuple[1], {bucket_id = bucket_id},
+        'customers', tuple[1], {bucket_id = bucket_id, mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -137,7 +137,7 @@ pgroup.test_delete = function(g)
 
     -- get w/ right bucket_id
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        'customers', tuple[1], {bucket_id = bucket_id},
+        'customers', tuple[1], {bucket_id = bucket_id, mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -548,7 +548,7 @@ pgroup.test_select = function(g)
 
     -- select w/ right bucket_id
     local result, err = g.cluster.main_server.net_box:call('crud.select', {
-        'customers', conditions, {bucket_id = bucket_id},
+        'customers', conditions, {bucket_id = bucket_id, mode = 'write'},
     })
 
     t.assert_equals(err, nil)

--- a/test/integration/ddl_sharding_func_test.lua
+++ b/test/integration/ddl_sharding_func_test.lua
@@ -474,7 +474,7 @@ pgroup.test_select = function(g)
 
     local conditions = {{'==', 'id', 18}}
     local result, err = g.cluster.main_server.net_box:call('crud.select', {
-        g.params.space_name, conditions,
+        g.params.space_name, conditions, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -494,7 +494,7 @@ pgroup.test_select = function(g)
     -- but tuple is on s1 replicaset -> result will be empty
     local conditions = {{'==', 'id', 19}}
     local result, err = g.cluster.main_server.net_box:call('crud.select', {
-        g.params.space_name, conditions,
+        g.params.space_name, conditions, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -571,7 +571,7 @@ pgroup.test_get = function(g)
 
     -- Get a tuple.
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        g.params.space_name, {12, 'Ivan'},
+        g.params.space_name, {12, 'Ivan'}, {mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_equals(result.rows, {{12, 2, 'Ivan', 20}})
@@ -588,7 +588,7 @@ pgroup.test_get = function(g)
     -- select will be performed on s2 replicaset
     -- but tuple is on s1 replicaset -> result will be empty
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        g.params.space_name, {18, 'Ivan'},
+        g.params.space_name, {18, 'Ivan'}, {mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_equals(result.rows, {})
@@ -654,7 +654,7 @@ pgroup.test_count = function(g)
 
     local conditions = {{'==', 'id', 18}}
     local result, err = g.cluster.main_server.net_box:call('crud.count', {
-        g.params.space_name, conditions,
+        g.params.space_name, conditions, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -674,7 +674,7 @@ pgroup.test_count = function(g)
     -- count = 0
     local conditions = {{'==', 'id', 19}}
     local result, err = g.cluster.main_server.net_box:call('crud.count', {
-        g.params.space_name, conditions,
+        g.params.space_name, conditions, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -861,12 +861,12 @@ local known_bucket_id_read_cases = {
     get = {
         func = 'crud.get',
         input_2 = known_bucket_id_key,
-        input_3 = {bucket_id = known_bucket_id},
+        input_3 = {bucket_id = known_bucket_id, mode = 'write'},
     },
     select = {
         func = 'crud.select',
         input_2 = {{ '==', 'id', known_bucket_id_key}},
-        input_3 = {bucket_id = known_bucket_id},
+        input_3 = {bucket_id = known_bucket_id, mode = 'write'},
     },
 }
 
@@ -903,7 +903,7 @@ pgroup.test_gh_278_pairs_with_explicit_bucket_id_and_ddl = function(g)
     ]], {
         g.params.space_name,
         {{ '==', 'id', known_bucket_id_key}},
-        {bucket_id = known_bucket_id}
+        {bucket_id = known_bucket_id, mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -916,13 +916,11 @@ pgroup.before_test(
     prepare_known_bucket_id_data)
 
 pgroup.test_gh_278_count_with_explicit_bucket_id_and_ddl = function(g)
-    local obj, err = g.cluster.main_server.net_box:call(
-        'crud.count',
-        {
-            g.params.space_name,
-            {{ '==', 'id', known_bucket_id_key}},
-            {bucket_id = known_bucket_id}
-        })
+    local obj, err = g.cluster.main_server.net_box:call('crud.count', {
+        g.params.space_name,
+        {{ '==', 'id', known_bucket_id_key}},
+        {bucket_id = known_bucket_id, mode = 'write'},
+    })
 
     t.assert_equals(err, nil)
     t.assert_is_not(obj, nil)
@@ -1000,7 +998,7 @@ for name, case in pairs(vshard_cases) do
 
         local conditions = {{'==', 'id', 1}}
         local result, err = g.cluster.main_server.net_box:call('crud.select', {
-            space_name, conditions,
+            space_name, conditions, {mode = 'write'},
         })
 
         t.assert_equals(err, nil)

--- a/test/integration/ddl_sharding_info_reload_test.lua
+++ b/test/integration/ddl_sharding_info_reload_test.lua
@@ -612,6 +612,7 @@ pgroup_key_change.test_select = function(g)
         {
             'customers',
             {{'==', 'id', 1}, {'==', 'name', 'Emma'}, {'==', 'age', 22}},
+            {mode = 'write'},
         })
     t.assert_equals(err, nil)
     t.assert_equals(obj.rows, {test_customers_age_tuple})
@@ -631,6 +632,7 @@ pgroup_key_change.test_count = function(g)
         {
             'customers',
             {{'==', 'id', 1}, {'==', 'name', 'Emma'}, {'==', 'age', 22}},
+            {mode = 'write'},
         })
     t.assert_equals(err, nil)
     t.assert_equals(obj, 1)
@@ -824,9 +826,9 @@ pgroup_func_change.test_select = function(g)
     end)
 
     -- Assert operation bucket_id is computed based on updated ddl info.
-    local obj, err = g.cluster.main_server.net_box:call(
-        'crud.select',
-        {'customers_pk', {{'==', 'id', 1}}})
+    local obj, err = g.cluster.main_server.net_box:call('crud.select', {
+        'customers_pk', {{'==', 'id', 1}}, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     t.assert_equals(obj.rows, {test_customers_pk_func_tuple})
 end
@@ -841,7 +843,9 @@ pgroup_func_change.test_get = function(g)
     end)
 
     -- Assert operation bucket_id is computed based on updated ddl info.
-    local obj, err = g.cluster.main_server.net_box:call('crud.get', {'customers_pk', 1})
+    local obj, err = g.cluster.main_server.net_box:call('crud.get', {
+        'customers_pk', 1, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     t.assert_equals(obj.rows, {test_customers_pk_func_tuple})
 end
@@ -856,9 +860,9 @@ pgroup_func_change.test_count = function(g)
     end)
 
     -- Assert operation bucket_id is computed based on updated ddl info.
-    local obj, err = g.cluster.main_server.net_box:call(
-        'crud.count',
-        {'customers_pk', {{'==', 'id', 1}}})
+    local obj, err = g.cluster.main_server.net_box:call('crud.count', {
+        'customers_pk', {{'==', 'id', 1}}, {mode = 'write'},
+    })
     t.assert_equals(err, nil)
     t.assert_equals(obj, 1)
 end

--- a/test/integration/ddl_sharding_key_test.lua
+++ b/test/integration/ddl_sharding_key_test.lua
@@ -463,7 +463,7 @@ pgroup.test_select = function(g)
 
     local conditions = {{'==', 'name', 'Ptolemy'}}
     local result, err = g.cluster.main_server.net_box:call('crud.select', {
-        'customers_name_key', conditions,
+        'customers_name_key', conditions, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -482,7 +482,7 @@ pgroup.test_count = function(g)
 
     local conditions = {{'==', 'name', 'Ptolemy'}}
     local result, err = g.cluster.main_server.net_box:call('crud.count', {
-        'customers_name_key', conditions,
+        'customers_name_key', conditions, {mode = 'write'}
     })
 
     t.assert_equals(err, nil)
@@ -561,7 +561,7 @@ for name, case in pairs(cases) do
         local map_reduces_before = helpers.get_map_reduces_stat(router, case.space_name)
 
         local result, err = router:call('crud.select', {
-            case.space_name, case.conditions
+            case.space_name, case.conditions, {mode = 'write'},
         })
         t.assert_equals(err, nil)
         t.assert_not_equals(result, nil)
@@ -581,7 +581,7 @@ pgroup.test_select_for_part_of_sharding_key_will_lead_to_map_reduce = function(g
     local map_reduces_before = helpers.get_map_reduces_stat(router, space_name)
 
     local result, err = router:call('crud.select', {
-        space_name, {{'==', 'age', 58}},
+        space_name, {{'==', 'age', 58}}, {mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_not_equals(result, nil)
@@ -607,7 +607,7 @@ pgroup.test_select_secondary_idx = function(g)
     local conditions = {{'==', 'name', 'Ivan'}}
 
     local result, err = g.cluster.main_server.net_box:call('crud.select', {
-        'customers_secondary_idx_name_key', conditions,
+        'customers_secondary_idx_name_key', conditions, {mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -634,7 +634,7 @@ pgroup.test_select_non_unique_index = function(g)
     t.assert_equals(#customers, 10)
 
     local result, err = g.cluster.main_server.net_box:call('crud.select', {
-        space_name, {{'==', 'name', 'Ivan Bunin'}}
+        space_name, {{'==', 'name', 'Ivan Bunin'}}, {mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_not_equals(result, nil)
@@ -687,7 +687,7 @@ pgroup.test_get = function(g)
 
     -- Get a tuple.
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        'customers_name_key', {7, 'Dimitrion'},
+        'customers_name_key', {7, 'Dimitrion'}, {mode = 'write'},
     })
     t.assert_equals(err, nil)
     t.assert_equals(result.rows, {{7, 596, 'Dimitrion', 20}})
@@ -757,7 +757,7 @@ pgroup.test_get_incomplete_sharding_key = function(g)
     t.assert_equals(#result.rows, 1)
 
     local result, err = g.cluster.main_server.net_box:call('crud.get', {
-        'customers_age_key', {58, 'Viktor Pelevin'}
+        'customers_age_key', {58, 'Viktor Pelevin'}, {mode = 'write'},
     })
 
     t.assert_str_contains(err.err,
@@ -804,7 +804,8 @@ pgroup.test_get_secondary_idx = function(g)
 
     -- get
     local result, err = g.cluster.main_server.net_box:call('crud.get',
-        {'customers_secondary_idx_name_key', {4, 'Leo'}})
+        {'customers_secondary_idx_name_key', {4, 'Leo'}, {mode = 'write'},
+    })
 
     t.assert_str_contains(err.err,
         "Sharding key for space \"customers_secondary_idx_name_key\" is missed in primary index, specify bucket_id")
@@ -1107,7 +1108,7 @@ local known_bucket_id_read_cases = {
         input = {
             known_bucket_id_space,
             known_bucket_id_key,
-            {bucket_id = known_bucket_id}
+            {bucket_id = known_bucket_id, mode = 'write'},
         },
     },
     select = {
@@ -1115,7 +1116,7 @@ local known_bucket_id_read_cases = {
         input = {
             known_bucket_id_space,
             {{ '==', 'id', known_bucket_id_key}},
-            {bucket_id = known_bucket_id}
+            {bucket_id = known_bucket_id, mode = 'write'},
         },
     },
 }
@@ -1148,7 +1149,7 @@ pgroup.test_gh_278_pairs_with_explicit_bucket_id_and_ddl = function(g)
     ]], {
         known_bucket_id_space,
         {{ '==', 'id', known_bucket_id_key}},
-        {bucket_id = known_bucket_id}
+        {bucket_id = known_bucket_id, mode = 'write'},
     })
 
     t.assert_equals(err, nil)
@@ -1166,7 +1167,7 @@ pgroup.test_gh_278_count_with_explicit_bucket_id_and_ddl = function(g)
         {
             known_bucket_id_space,
             {{ '==', 'id', known_bucket_id_key}},
-            {bucket_id = known_bucket_id}
+            {bucket_id = known_bucket_id, mode = 'write'},
         })
 
     t.assert_equals(err, nil)

--- a/test/integration/migration_test.lua
+++ b/test/integration/migration_test.lua
@@ -51,7 +51,8 @@ pgroup.test_gh_308_select_after_improper_ddl_space_drop = function(g)
     end)
 
     -- Ensure that crud request for existing space is ok.
-    local _, err = g.cluster.main_server.net_box:call('crud.select',
-                                                      {'customers', nil, { first = 1 }})
+    local _, err = g.cluster.main_server.net_box:call('crud.select', {
+        'customers', nil, {first = 1, mode = 'write'},
+    })
     t.assert_equals(err, nil)
 end

--- a/test/integration/pairs_test.lua
+++ b/test/integration/pairs_test.lua
@@ -59,7 +59,7 @@ pgroup.test_pairs_no_conditions = function(g)
         local crud = require('crud')
 
         local objects = {}
-        for _, object in crud.pairs('customers') do
+        for _, object in crud.pairs('customers', nil, {mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -72,7 +72,7 @@ pgroup.test_pairs_no_conditions = function(g)
         local crud = require('crud')
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {use_tomap = false}) do
+        for _, object in crud.pairs('customers', nil, {use_tomap = false, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -85,7 +85,7 @@ pgroup.test_pairs_no_conditions = function(g)
         local crud = require('crud')
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {use_tomap = true}) do
+        for _, object in crud.pairs('customers', nil, {use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -102,7 +102,7 @@ pgroup.test_pairs_no_conditions = function(g)
         local after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {after = after, use_tomap = true}) do
+        for _, object in crud.pairs('customers', nil, {after = after, use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -120,7 +120,7 @@ pgroup.test_pairs_no_conditions = function(g)
         local after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {after = after, use_tomap = true}) do
+        for _, object in crud.pairs('customers', nil, {after = after, use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -161,7 +161,7 @@ pgroup.test_ge_condition_with_index = function(g)
         local conditions = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -179,7 +179,7 @@ pgroup.test_ge_condition_with_index = function(g)
         local conditions, after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = after, use_tomap = true}) do
+        for _, object in crud.pairs('customers', conditions, {after = after, use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -220,7 +220,7 @@ pgroup.test_le_condition_with_index = function(g)
         local conditions = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -238,7 +238,7 @@ pgroup.test_le_condition_with_index = function(g)
         local conditions, after = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = after, use_tomap = true}) do
+        for _, object in crud.pairs('customers', conditions, {after = after, use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -269,7 +269,7 @@ pgroup.test_first = function(g)
     local objects, err = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {first = 2, use_tomap = true}) do
+        for _, object in crud.pairs('customers', nil, {first = 2, use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
         return objects
@@ -321,7 +321,7 @@ pgroup.test_empty_space = function(g)
     local count = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
         local count = 0
-        for _, object in crud.pairs('customers') do
+        for _, object in crud.pairs('customers', nil, {mode = 'write'}) do
             count = count + 1
         end
         return count
@@ -344,15 +344,18 @@ pgroup.test_luafun_compatibility = function(g)
     })
     local count = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
-        local count = crud.pairs('customers'):map(function() return 1 end):sum()
+        local count = crud.pairs('customers', nil, {mode = 'write'}):map(function() return 1 end):sum()
         return count
     ]])
     t.assert_equals(count, 3)
 
     count = g.cluster.main_server.net_box:eval([[
         local crud = require('crud')
-        local count = crud.pairs('customers',
-            {use_tomap = true}):map(function() return 1 end):sum()
+        local count = crud.pairs(
+            'customers',
+            nil,
+            {use_tomap = true, mode = 'write'}
+        ):map(function() return 1 end):sum()
         return count
     ]])
     t.assert_equals(count, 3)
@@ -395,7 +398,7 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -420,7 +423,11 @@ pgroup.test_pairs_partial_result = function(g)
         end
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = tuples[1], use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs(
+            'customers',
+            conditions,
+            {after = tuples[1], use_tomap = true, fields = fields, mode = 'write'}
+        ) do
             table.insert(objects, object)
         end
 
@@ -445,7 +452,7 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -465,12 +472,16 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local tuples = {}
-        for _, tuple in crud.pairs('customers', conditions, {fields = fields}) do
+        for _, tuple in crud.pairs('customers', conditions, {fields = fields, mode = 'write'}) do
             table.insert(tuples, tuple)
         end
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = tuples[1], use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs(
+            'customers',
+            conditions,
+            {after = tuples[1], use_tomap = true, fields = fields, mode = 'write'}
+        ) do
             table.insert(objects, object)
         end
 
@@ -498,7 +509,7 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -518,12 +529,16 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local tuples = {}
-        for _, tuple in crud.pairs('customers', conditions, {fields = fields}) do
+        for _, tuple in crud.pairs('customers', conditions, {fields = fields, mode = 'write'}) do
             table.insert(tuples, tuple)
         end
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = tuples[1], use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs(
+            'customers',
+            conditions,
+            {after = tuples[1], use_tomap = true, fields = fields, mode = 'write'}
+        ) do
             table.insert(objects, object)
         end
 
@@ -548,7 +563,7 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -568,12 +583,16 @@ pgroup.test_pairs_partial_result = function(g)
         local conditions, fields = ...
 
         local tuples = {}
-        for _, tuple in crud.pairs('customers', conditions, {fields = fields}) do
+        for _, tuple in crud.pairs('customers', conditions, {fields = fields, mode = 'write'}) do
             table.insert(tuples, tuple)
         end
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {after = tuples[1], use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs(
+            'customers',
+            conditions,
+            {after = tuples[1], use_tomap = true, fields = fields, mode = 'write'}
+        ) do
             table.insert(objects, object)
         end
 
@@ -619,7 +638,7 @@ pgroup.test_pairs_cut_result = function(g)
         local conditions, fields = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, fields = fields, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -640,7 +659,7 @@ pgroup.test_pairs_cut_result = function(g)
         local conditions, fields = ...
 
         local tuples = {}
-        for _, tuple in crud.pairs('customers', conditions, {fields = fields}) do
+        for _, tuple in crud.pairs('customers', conditions, {fields = fields, mode = 'write'}) do
             table.insert(tuples, tuple)
         end
 
@@ -684,7 +703,7 @@ pgroup.test_pairs_force_map_call = function(g)
         local conditions = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true}) do
+        for _, object in crud.pairs('customers', conditions, {use_tomap = true, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -700,7 +719,11 @@ pgroup.test_pairs_force_map_call = function(g)
         local conditions = ...
 
         local objects = {}
-        for _, object in crud.pairs('customers', conditions, {use_tomap = true, force_map_call = true}) do
+        for _, object in crud.pairs(
+            'customers',
+            conditions,
+            {use_tomap = true, force_map_call = true, mode = 'write'}
+        ) do
             table.insert(objects, object)
         end
 
@@ -740,7 +763,7 @@ pgroup.test_pairs_timeout = function(g)
         local crud = require('crud')
 
         local objects = {}
-        for _, object in crud.pairs('customers', nil, {timeout = 1}) do
+        for _, object in crud.pairs('customers', nil, {timeout = 1, mode = 'write'}) do
             table.insert(objects, object)
         end
 
@@ -783,7 +806,7 @@ pgroup.test_opts_not_damaged = function(g)
     local pairs_opts = {
         timeout = 1, bucket_id = 1161,
         batch_size = 105, first = 2, after = after,
-        fields = fields, mode = 'read', prefer_replica = false,
+        fields = fields, mode = 'write', prefer_replica = false,
         balance = false, force_map_call = false, use_tomap = true,
     }
     local new_pairs_opts, objects = g.cluster.main_server:eval([[
@@ -839,7 +862,7 @@ pgroup.test_pairs_no_map_reduce = function(g)
     ]], {
         'customers',
         nil,
-        {bucket_id = 2804, timeout = 1},
+        {bucket_id = 2804, timeout = 1, mode = 'write'},
     })
     t.assert_equals(rows, {
         {3, 2804, 'David', 'Smith', 33, 'Los Angeles'},
@@ -858,7 +881,7 @@ pgroup.test_pairs_no_map_reduce = function(g)
     ]], {
         'customers',
         {{'==', 'age', 81}},
-        {bucket_id = 1161, timeout = 1},
+        {bucket_id = 1161, timeout = 1, mode = 'write'},
     })
     t.assert_equals(rows, {
         {4, 1161, 'William', 'White', 81, 'Chicago'},

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -406,7 +406,7 @@ pgroup.test_intermediate_nullable_fields_update = function(g)
     end)
 
     local result, err = g.cluster.main_server.net_box:call('crud.update',
-        {'developers', 1, {{'=', 'extra_3', { a = { b = {} } } }}})
+        {'developers', 1, {{'=', 'extra_3', { a = { b = {} } } }}, {fetch_latest_metadata = true}})
     t.assert_equals(err, nil)
     objects = crud.unflatten_rows(result.rows, result.metadata)
     t.assert_equals(objects, {

--- a/test/integration/simple_operations_test.lua
+++ b/test/integration/simple_operations_test.lua
@@ -695,8 +695,11 @@ for case_name, case in pairs(gh_236_cases) do
         else
             local object = g.cluster.main_server.net_box:eval([[
                 local objects = {}
-                for _, object in crud.pairs('countries', nil,
-                        {fetch_latest_metadata = true, use_tomap = true}) do
+                for _, object in crud.pairs(
+                    'countries',
+                    nil,
+                    {fetch_latest_metadata = true, use_tomap = true, mode = 'write'}
+                ) do
                     table.insert(objects, object)
                 end
                 return objects[1]

--- a/test/integration/vshard_custom_test.lua
+++ b/test/integration/vshard_custom_test.lua
@@ -1111,41 +1111,43 @@ pgroup.test_call_replace_object_many_wrong_option = function(g)
 end
 
 pgroup.test_call_select_with_default_sharding = function(g)
-    local result, err = g:call_router_opts3(
-        'select',
+    local result, err = g:call_router_opts3('select',
         'locations',
         {{'=', 'name', 'Sky Finance'}},
-        {vshard_router = 'locations'})
+        {vshard_router = 'locations', mode = 'write'}
+    )
 
     t.assert_equals(err, nil)
     t.assert_items_equals(result.rows, {{'Sky Finance', 26826, 'Credit company', 2}})
 end
 
 pgroup.test_call_select_with_ddl_sharding = function(g)
-    local result, err = g:call_router_opts3(
-        'select',
+    local result, err = g:call_router_opts3('select',
         'customers_ddl',
         {{'=', 'id', 2}, {'=', 'name', 'Kazuma Kiryu'}},
-        {vshard_router = 'customers'})
+        {vshard_router = 'customers', mode = 'write'}
+    )
 
     t.assert_equals(err, nil)
     t.assert_items_equals(result.rows, {{2, 8768, 'Kazuma Kiryu', 41}})
 end
 
 pgroup.test_call_select_wrong_router = function(g)
-    local result, err = g:call_router_opts3(
-        'select',
+    local result, err = g:call_router_opts3('select',
         'locations',
         {{'=', 'name', 'Sky Finance'}},
-        {vshard_router = 'customers'})
+        {vshard_router = 'customers', mode = 'write'}
+    )
 
     t.assert_equals(result, nil)
     t.assert_str_contains(err.err, "Space \"locations\" doesn't exist")
 end
 
 pgroup.test_call_select_no_router = function(g)
-    local result, err = g:call_router_opts3(
-        'select', 'locations', {{'=', 'name', 'Sky Finance'}})
+    local result, err = g:call_router_opts3('select',
+        'locations',
+        {{'=', 'name', 'Sky Finance'}}
+    )
 
     t.assert_equals(result, nil)
     t.assert_str_contains(err.err,
@@ -1165,7 +1167,8 @@ pgroup.test_call_pairs_with_default_sharding = function(g)
     local result, err = g:call_router_pairs(
         'locations',
         {{'=', 'name', 'Sky Finance'}},
-        {vshard_router = 'locations'})
+        {vshard_router = 'locations', mode = 'write'}
+    )
 
     t.assert_equals(err, nil)
     t.assert_items_equals(result, {{'Sky Finance', 26826, 'Credit company', 2}})
@@ -1175,7 +1178,8 @@ pgroup.test_call_pairs_with_ddl_sharding = function(g)
     local result, err = g:call_router_pairs(
         'customers_ddl',
         {{'=', 'id', 2}, {'=', 'name', 'Kazuma Kiryu'}},
-        {vshard_router = 'customers'})
+        {vshard_router = 'customers', mode = 'write'}
+    )
 
     t.assert_equals(err, nil)
     t.assert_items_equals(result, {{2, 8768, 'Kazuma Kiryu', 41}})

--- a/test/performance/perf_test.lua
+++ b/test/performance/perf_test.lua
@@ -24,7 +24,7 @@ end
 
 local vshard_cfg_template = {
     sharding = {
-        {
+        ['s-1'] = {
             replicas = {
                 ['s1-master'] = {
                     master = true,
@@ -32,7 +32,7 @@ local vshard_cfg_template = {
                 ['s1-replica'] = {},
             },
         },
-        {
+        ['s-2'] = {
             replicas = {
                 ['s2-master'] = {
                     master = true,
@@ -40,7 +40,7 @@ local vshard_cfg_template = {
                 ['s2-replica'] = {},
             },
         },
-        {
+        ['s-3'] = {
             replicas = {
                 ['s3-master'] = {
                     master = true,

--- a/test/performance/perf_test.lua
+++ b/test/performance/perf_test.lua
@@ -693,13 +693,13 @@ local stats_cases = {
 }
 
 local integration_params = {
-    timeout = 2,
+    timeout = 0.1,
     fiber_count = 5,
     connection_count = 2,
 }
 
 local pairs_integration = {
-    timeout = 5,
+    timeout = 0.1,
     fiber_count = 1,
     connection_count = 1,
 }

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -8,7 +8,7 @@ local pgroup = t.group('call', helpers.backend_matrix())
 
 local vshard_cfg_template = {
     sharding = {
-        {
+        ['s-1'] = {
             replicas = {
                 ['s1-master'] = {
                     master = true,
@@ -16,7 +16,7 @@ local vshard_cfg_template = {
                 ['s1-replica'] = {},
             },
         },
-        {
+        ['s-2'] = {
             replicas = {
                 ['s2-master'] = {
                     master = true,

--- a/test/unit/not_initialized_test.lua
+++ b/test/unit/not_initialized_test.lua
@@ -9,7 +9,7 @@ local pgroup = t.group('not-initialized', helpers.backend_matrix({
 
 local vshard_cfg_template = {
     sharding = {
-        {
+        storages = {
             replicas = {
                 storage = {
                     master = true,

--- a/test/unit/stats_test.lua
+++ b/test/unit/stats_test.lua
@@ -45,6 +45,7 @@ local function enable_stats(g, params)
     if params ~= nil then
         params = table.deepcopy(params)
         params.backend = nil
+        params.backend_cfg = nil
     end
     g.router:eval("stats_module.enable(...)", { params })
 end

--- a/test/vshard_helpers/server.lua
+++ b/test/vshard_helpers/server.lua
@@ -204,6 +204,23 @@ function Server:replicaset_uuid()
     return uuid
 end
 
+function Server:replicaset_name()
+    -- Cache the value when found it first time.
+    if self.replicaset_name_value then
+        return self.replicaset_name_value
+    end
+    local name = self:exec(function()
+        local info = box.info
+        if info.replicaset then
+            return info.replicaset.name
+        end
+        return nil
+    end)
+
+    self.replicaset_uuid_value = name
+    return name
+end
+
 function Server:election_term()
     return self:exec(function() return box.info.election.term end)
 end


### PR DESCRIPTION
In vshard 0.1.25, new feature related to vshard configuration and storage info was introduced [1]. If the new mode is used, crud module fails to bootstrap and work in several places. This feature is enabled by Tarantool 3.0 if vshard cluster was configured with 3.0 config.

After this patch, it is possible to bootstrap a vshard cluster with new configuration mode. We run all existing vshard tests with new modes after this patch. Module code was updated to support both possible mods.

This PR also introduces several minor fixes inspired by flaky tests. (They mostly have failed locally on my PC with vinyl engine, but it is possible to get the same result on Github Actions.)

I didn't forget about

- [x] Tests
- [x] Changelog

Closes #403
