### PR TITLE
release 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.2] - 25-12-23
 
 ### Added
 * `mode` option for `crud.min` and `crud.max` (#404).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * Compatibility with vshard 0.1.25 `name_as_key` identification mode
   for Tarantool 3.0 (#403).
+* Propagating `noreturn` and `fetch_latest_metadata` options in case
+  of intermediate nullable fields update for Tarantool 2.7 and older (#404).
 
 ## [1.4.1] - 23-10-23
 

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.4.1'
+return '1.4.2'


### PR DESCRIPTION
## Overview

This release introduces compatibility with vshard 0.1.25 `name_as_key` identification mode, as well as several minor fixes and tests stabilization.

## Added
* `mode` option for `crud.min` and `crud.max` (#404).

## Fixed
* Compatibility with vshard 0.1.25 `name_as_key` identification mode for Tarantool 3.0 (#403).
* Propagating `noreturn` and `fetch_latest_metadata` options in case of intermediate nullable fields update for Tarantool 2.7 and older (#404).

## Infrastructure
* Fix flaky update unflatten test case (#404).
* Do not rely on replication in read test cases (#404).
