### PR TITLE
crud: support vshard with no UUIDs in config

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -41,8 +41,7 @@ jobs:
           - tarantool-version: "2.11"
             external-merger-version: "0.0.5"
             external-keydef-version: "0.0.4"
-          - tarantool-version: "master"
-            metrics-version: "1.0.0"
+          - tarantool-version: "3.0.0"
             vshard-version: "0.1.25"
       fail-fast: false
     # Can't install older versions on 22.04,
@@ -51,8 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Setup Tarantool CE
-        if: matrix.tarantool-version != 'master'
+      - name: Setup Tarantool CE (1.x, 2.x)
+        if: ${{ startsWith( matrix.tarantool-version, '1.' ) || startsWith( matrix.tarantool-version, '2.' ) }}
         uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool-version }}
@@ -62,6 +61,20 @@ jobs:
           curl -L https://tarantool.io/release/2/installer.sh | sudo bash
           sudo apt install -y tt
           tt version
+
+      - name: Cache Tarantool 3.x
+        if: ${{ startsWith( matrix.tarantool-version, '3.' ) }}
+        id: cache-v3
+        uses: actions/cache@v3
+        with:
+          path: "${GITHUB_WORKSPACE}/bin"
+          key: cache-${{ matrix.tarantool-version }}
+
+      - name: Setup Tarantool CE (3.x)
+        if: ${{ startsWith( matrix.tarantool-version, '3.' ) && steps.cache-latest.outputs.cache-hit != 'true' }}
+        run: |
+          tt init
+          tt install tarantool ${{ matrix.tarantool-version }}
 
       - name: Get Tarantool master latest commit
         if: matrix.tarantool-version == 'master'
@@ -78,14 +91,14 @@ jobs:
           path: "${GITHUB_WORKSPACE}/bin"
           key: cache-latest-${{ env.LATEST_COMMIT }}
 
-      - name: Setup Tarantool master
+      - name: Setup Tarantool CE (master)
         if: matrix.tarantool-version == 'master' && steps.cache-latest.outputs.cache-hit != 'true'
         run: |
           tt init
           tt install tarantool master
 
-      - name: Add Tarantool master to PATH
-        if: matrix.tarantool-version == 'master'
+      - name: Add tt Tarantool to PATH
+        if: ${{ startsWith( matrix.tarantool-version, '3.' ) || matrix.tarantool-version == 'master' }}
         run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
       - name: Fix luarocks in Tarantool CE 1.10.6
@@ -139,16 +152,15 @@ jobs:
         metrics-version: ["1.0.0"]
         cartridge-version: ["2.8.0"]
         include:
-          - tarantool-version: "master"
-            metrics-version: "1.0.0"
+          - tarantool-version: "3.0.0"
             vshard-version: "0.1.25"
       fail-fast: false
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
 
-      - name: Setup Tarantool CE
-        if: matrix.tarantool-version != 'master'
+      - name: Setup Tarantool CE (1.x, 2.x)
+        if: ${{ startsWith( matrix.tarantool-version, '1.' ) || startsWith( matrix.tarantool-version, '2.' ) }}
         uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool-version }}
@@ -158,6 +170,20 @@ jobs:
           curl -L https://tarantool.io/release/2/installer.sh | sudo bash
           sudo apt install -y tt
           tt version
+
+      - name: Cache Tarantool 3.x
+        if: ${{ startsWith( matrix.tarantool-version, '3.' ) }}
+        id: cache-v3
+        uses: actions/cache@v3
+        with:
+          path: "${GITHUB_WORKSPACE}/bin"
+          key: cache-${{ matrix.tarantool-version }}
+
+      - name: Setup Tarantool CE (3.x)
+        if: ${{ startsWith( matrix.tarantool-version, '3.' ) && steps.cache-latest.outputs.cache-hit != 'true' }}
+        run: |
+          tt init
+          tt install tarantool ${{ matrix.tarantool-version }}
 
       - name: Get Tarantool master latest commit
         if: matrix.tarantool-version == 'master'
@@ -174,14 +200,14 @@ jobs:
           path: "${GITHUB_WORKSPACE}/bin"
           key: cache-latest-${{ env.LATEST_COMMIT }}
 
-      - name: Setup Tarantool master
+      - name: Setup Tarantool CE (master)
         if: matrix.tarantool-version == 'master' && steps.cache-latest.outputs.cache-hit != 'true'
         run: |
           tt init
           tt install tarantool master
 
-      - name: Add Tarantool master to PATH
-        if: matrix.tarantool-version == 'master'
+      - name: Add tt Tarantool to PATH
+        if: ${{ startsWith( matrix.tarantool-version, '3.' ) || matrix.tarantool-version == 'master' }}
         run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
       - name: Install requirements for community
@@ -216,6 +242,12 @@ jobs:
             bundle: "tarantool-enterprise-sdk-nogc64-2.11.0-0-r563.linux.x86_64"
         metrics-version: ["", "1.0.0"]
         cartridge-version: ["2.8.0"]
+        include:
+          - tarantool-version:
+              folder: "3.0"
+              bundle: "tarantool-enterprise-sdk-gc64-3.0.0-0-gf58f7d82a-r23.linux.x86_64"
+            vshard-version: "0.1.25"
+
       fail-fast: false
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+* Compatibility with vshard configuration if UUIDs are omitted (#407).
+
 ## [1.4.2] - 25-12-23
 
 ### Added

--- a/crud.lua
+++ b/crud.lua
@@ -173,12 +173,13 @@ function crud.init_storage()
 
     local user = nil
     if not box.info.ro then
-        local replicaset_uuid, replicaset = utils.get_self_vshard_replicaset()
+        local replicaset_key, replicaset = utils.get_self_vshard_replicaset()
 
         if replicaset == nil or replicaset.master == nil then
-            error(string.format('Failed to find a vshard configuration for ' ..
-                ' replicaset with replicaset_uuid %s.',
-                replicaset_uuid))
+            error(string.format(
+                'Failed to find a vshard configuration ' ..
+                'for storage replicaset with key %q.',
+                replicaset_key))
         end
         user = luri.parse(replicaset.master.uri).login or 'guest'
     end

--- a/crud/common/map_call_cases/base_iter.lua
+++ b/crud/common/map_call_cases/base_iter.lua
@@ -66,11 +66,13 @@ end
 --
 -- @return[1] table func_args
 -- @return[2] table replicaset
+-- @return[3] string replicaset_id
 function BaseIterator:get()
+    local replicaset_id = self.next_index
     local replicaset = self.next_replicaset
     self.next_index, self.next_replicaset = next(self.replicasets, self.next_index)
 
-    return self.func_args, replicaset
+    return self.func_args, replicaset, replicaset_id
 end
 
 return BaseIterator

--- a/crud/common/map_call_cases/batch_insert_iter.lua
+++ b/crud/common/map_call_cases/batch_insert_iter.lua
@@ -40,7 +40,7 @@ function BatchInsertIterator:new(opts)
         return nil, SplitTuplesError:new("Failed to split tuples by replicaset: %s", err.err)
     end
 
-    local next_replicaset, next_batch = next(sharding_data.batches)
+    local next_index, next_batch = next(sharding_data.batches)
 
     local execute_on_storage_opts = opts.execute_on_storage_opts
     execute_on_storage_opts.sharding_func_hash = sharding_data.sharding_func_hash
@@ -51,7 +51,7 @@ function BatchInsertIterator:new(opts)
         space_name = opts.space.name,
         opts = execute_on_storage_opts,
         batches_by_replicasets = sharding_data.batches,
-        next_index = next_replicaset,
+        next_index = next_index,
         next_batch = next_batch,
     }
 
@@ -67,8 +67,10 @@ end
 --
 -- @return[1] table func_args
 -- @return[2] table replicaset
+-- @return[3] string replicaset_id
 function BatchInsertIterator:get()
-    local replicaset = self.next_index
+    local replicaset_id = self.next_index
+    local replicaset = self.next_batch.replicaset
     local func_args = {
         self.space_name,
         self.next_batch.tuples,
@@ -77,7 +79,7 @@ function BatchInsertIterator:get()
 
     self.next_index, self.next_batch = next(self.batches_by_replicasets, self.next_index)
 
-    return func_args, replicaset
+    return func_args, replicaset, replicaset_id
 end
 
 return BatchInsertIterator

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -8,6 +8,7 @@ local ReloadSchemaError = errors.new_class('ReloadSchemaError', {capture_stack =
 
 local const = require('crud.common.const')
 local dev_checks = require('crud.common.dev_checks')
+local utils = require('crud.common.vshard_utils')
 
 local schema = {}
 
@@ -234,7 +235,8 @@ function schema.wrap_func_result(space, func, args, opts)
             replica_schema_version = box.internal.schema_version()
         end
         result.storage_info = {
-            replica_uuid = box.info().uuid,
+            replica_uuid = box.info().uuid, -- Backward compatibility.
+            replica_id = utils.get_self_vshard_replica_id(), -- Replacement for replica_uuid.
             replica_schema_version = replica_schema_version,
         }
     end

--- a/crud/common/vshard_utils.lua
+++ b/crud/common/vshard_utils.lua
@@ -1,0 +1,56 @@
+local vshard = require('vshard')
+
+local vshard_utils = {}
+
+function vshard_utils.get_self_vshard_replicaset()
+    local box_info = box.info()
+
+    local ok, storage_info = pcall(vshard.storage.info)
+    assert(ok, 'vshard.storage.cfg() must be called first')
+
+    if vshard_utils.get_vshard_identification_mode() == 'name_as_key' then
+        local replicaset_name = box_info.replicaset.name
+
+        return replicaset_name, storage_info.replicasets[replicaset_name]
+    else
+        local replicaset_uuid
+        if box_info.replicaset ~= nil then
+            replicaset_uuid = box_info.replicaset.uuid
+        else
+            replicaset_uuid = box_info.cluster.uuid
+        end
+
+        return replicaset_uuid, storage_info.replicasets[replicaset_uuid]
+    end
+end
+
+function vshard_utils.get_self_vshard_replica_id()
+    local box_info = box.info()
+
+    if vshard_utils.get_vshard_identification_mode() == 'name_as_key' then
+        return box_info.name
+    else
+        return box_info.uuid
+    end
+end
+
+function vshard_utils.get_replicaset_id(vshard_router, replicaset)
+    -- https://github.com/tarantool/vshard/issues/460.
+    local known_replicasets = vshard_router:routeall()
+
+    for known_replicaset_id, known_replicaset in pairs(known_replicasets) do
+        if known_replicaset == replicaset then
+            return known_replicaset_id
+        end
+    end
+
+    return nil
+end
+
+function vshard_utils.get_vshard_identification_mode()
+    -- https://github.com/tarantool/vshard/issues/460.
+    assert(vshard.storage.internal.current_cfg ~= nil, 'available only on vshard storage')
+    return vshard.storage.internal.current_cfg.identification_mode
+end
+
+return vshard_utils

--- a/crud/count.lua
+++ b/crud/count.lua
@@ -24,7 +24,7 @@ local count = {}
 
 local function count_on_storage(space_name, index_id, conditions, opts)
     dev_checks('string', 'number', '?table', {
-        scan_value = 'table',
+        scan_value = 'table|cdata',
         tarantool_iter = 'number',
         yield_every = '?number',
         scan_condition_num = '?number',

--- a/crud/readview.lua
+++ b/crud/readview.lua
@@ -94,8 +94,8 @@ end
 
 local function select_readview_on_storage(space_name, index_id, conditions, opts)
     dev_checks('string', 'number', '?table', {
-        scan_value = 'table',
-        after_tuple = '?table',
+        scan_value = 'table|cdata',
+        after_tuple = '?table|cdata',
         tarantool_iter = 'number',
         limit = 'number',
         scan_condition_num = '?number',

--- a/crud/select.lua
+++ b/crud/select.lua
@@ -53,7 +53,8 @@ local function select_on_storage(space_name, index_id, conditions, opts)
             replica_schema_version = box.internal.schema_version()
         end
         cursor.storage_info = {
-            replica_uuid = box.info().uuid,
+            replica_uuid = box.info().uuid, -- Backward compatibility.
+            replica_id = utils.get_self_vshard_replica_id(), -- Replacement for replica_uuid.
             replica_schema_version = replica_schema_version,
         }
     end

--- a/crud/select/compat/select.lua
+++ b/crud/select/compat/select.lua
@@ -31,7 +31,7 @@ local function build_select_iterator(vshard_router, space_name, user_conditions,
         yield_every = '?number',
         call_opts = 'table',
         readview = '?boolean',
-        readview_uuid = '?table',
+        readview_info = '?table',
     })
 
     opts = opts or {}
@@ -178,7 +178,7 @@ local function build_select_iterator(vshard_router, space_name, user_conditions,
     local merger
 
     if opts.readview then
-        merger = Merger.new_readview(vshard_router, replicasets_to_select, opts.readview_uuid,
+        merger = Merger.new_readview(vshard_router, replicasets_to_select, opts.readview_info,
         space, plan.index_id, common.READVIEW_SELECT_FUNC_NAME,
         {space_name, plan.index_id, plan.conditions, select_opts},
         {tarantool_iter = plan.tarantool_iter, field_names = plan.field_names, call_opts = opts.call_opts}
@@ -215,7 +215,7 @@ function select_module.pairs(space_name, user_conditions, opts)
         balance = '?boolean',
         timeout = '?number',
         readview = '?boolean',
-        readview_uuid = '?table',
+        readview_info = '?table',
 
         vshard_router = '?string|table',
 
@@ -267,7 +267,7 @@ function select_module.pairs(space_name, user_conditions, opts)
             fetch_latest_metadata = opts.fetch_latest_metadata,
         },
         readview = opts.readview,
-        readview_uuid = opts.readview_uuid,
+        readview_info = opts.readview_info,
     }
 
     local iter, err = schema.wrap_func_reload(
@@ -332,7 +332,7 @@ local function select_module_call_xc(vshard_router, space_name, user_conditions,
         balance = '?boolean',
         timeout = '?number',
         readview = '?boolean',
-        readview_uuid = '?table',
+        readview_info = '?table',
 
         vshard_router = '?string|table',
 
@@ -379,7 +379,7 @@ local function select_module_call_xc(vshard_router, space_name, user_conditions,
             fetch_latest_metadata = opts.fetch_latest_metadata,
         },
         readview = opts.readview,
-        readview_uuid = opts.readview_uuid,
+        readview_info = opts.readview_info,
     }
 
     local iter, err = schema.wrap_func_reload(

--- a/crud/select/compat/select_old.lua
+++ b/crud/select/compat/select_old.lua
@@ -67,6 +67,7 @@ local function select_iteration(space_name, plan, opts)
     end
 
     local tuples = {}
+    -- Old select works with vshard without `name_as_key` support.
     for replicaset_uuid, replicaset_results in pairs(results) do
         -- Stats extracted with callback here and not passed
         -- outside to wrapper because fetch for pairs can be

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -832,4 +832,41 @@ function helpers.schema_compatibility(schema)
     return schema
 end
 
+function helpers.string_replace(base, old_fragment, new_fragment)
+    local i, j = base:find(old_fragment)
+
+    if i == nil then
+        return base
+    end
+
+    local prefix = ''
+    if i > 1 then
+        prefix = base:sub(1, i - 1)
+    end
+
+    local suffix = ''
+    if j < base:len() then
+        suffix = base:sub(j + 1, base:len())
+    end
+
+    return prefix .. new_fragment .. suffix
+end
+
+function helpers.assert_str_contains_pattern_with_replicaset_id(str, pattern)
+    local uuid_pattern = "%w+%-0000%-0000%-0000%-00000000000%d"
+    local name_pattern = "s%-%d" -- All existing test clusters use this pattern, but it may change in the future.
+
+    local found = false
+    for _, id_pattern in pairs({uuid_pattern, name_pattern}) do
+        -- pattern is expected to be like "Failed for [replicaset_id]".
+        local full_pattern = helpers.string_replace('[replicaset_id]', id_pattern)
+        if str:find(full_pattern) ~= nil then
+            found = true
+            break
+        end
+    end
+
+    t.assert(found, ("string %q does not contain pattern %q"):format(str, pattern))
+end
+
 return helpers

--- a/test/integration/ddl_sharding_info_reload_test.lua
+++ b/test/integration/ddl_sharding_info_reload_test.lua
@@ -662,7 +662,8 @@ pgroup_key_change.test_pairs = function(g)
         pairs_eval,
         {
             'customers',
-            {{'==', 'id', 1}, {'==', 'name', 'Emma'}, {'==', 'age', 22}}
+            {{'==', 'id', 1}, {'==', 'name', 'Emma'}, {'==', 'age', 22}},
+            {mode = 'write'},
         })
 
     -- Assert operation bucket_id is computed based on updated ddl info.
@@ -671,6 +672,7 @@ pgroup_key_change.test_pairs = function(g)
         {
             'customers',
             {{'==', 'id', 1}, {'==', 'name', 'Emma'}, {'==', 'age', 22}},
+            {mode = 'write'},
         })
     t.assert_equals(err, nil)
     t.assert_equals(obj, {test_customers_age_tuple})
@@ -881,12 +883,12 @@ pgroup_func_change.test_pairs = function(g)
         g.cluster.main_server.net_box.eval,
         g.cluster.main_server.net_box,
         pairs_eval,
-        {'customers_pk', {{'==', 'id', 1}}})
+        {'customers_pk', {{'==', 'id', 1}}, {mode = 'write'}})
 
     -- Assert operation bucket_id is computed based on updated ddl info.
     local obj, err = g.cluster.main_server.net_box:eval(
         pairs_eval,
-        {'customers_pk', {{'==', 'id', 1}}})
+        {'customers_pk', {{'==', 'id', 1}}, {mode = 'write'}})
     t.assert_equals(err, nil)
     t.assert_equals(obj, {test_customers_pk_func_tuple})
 end

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -93,7 +93,7 @@ pgroup.test_map_non_existent_func = function(g)
     ]])
 
     t.assert_equals(results, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-00000000000%d", true)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
     t.assert_str_contains(err.err, "Function non_existent_func is not registered")
 end
 
@@ -106,7 +106,7 @@ pgroup.test_single_non_existent_func = function(g)
     ]])
 
     t.assert_equals(results, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-00000000000%d", true)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
     t.assert_str_contains(err.err, "Function non_existent_func is not registered")
 end
 
@@ -178,7 +178,7 @@ pgroup.test_timeout = function(g)
     ]], {timeout + 0.1, timeout})
 
     t.assert_equals(results, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-00000000000%d", true)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
     helpers.assert_timeout_error(err.err)
 end
 
@@ -316,6 +316,6 @@ pgroup.test_any_vshard_call_timeout = function(g)
     ]], {timeout + 0.1, timeout})
 
     t.assert_equals(results, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-00000000000%d", true)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
     helpers.assert_timeout_error(err.err)
 end

--- a/test/unit/not_initialized_test.lua
+++ b/test/unit/not_initialized_test.lua
@@ -60,7 +60,7 @@ pgroup.test_insert = function(g)
     ]])
 
     t.assert_equals(results, nil)
-    t.assert_str_contains(err.err, "Failed for %w+%-0000%-0000%-0000%-00000000000%d", true)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
     t.assert_str_contains(err.err, "crud isn't initialized on replicaset")
 end
 

--- a/test/vshard_helpers/server.lua
+++ b/test/vshard_helpers/server.lua
@@ -217,7 +217,7 @@ function Server:replicaset_name()
         return nil
     end)
 
-    self.replicaset_uuid_value = name
+    self.replicaset_name_value = name
     return name
 end
 


### PR DESCRIPTION
PR #404 has introduced vshard 0.1.25 + Tarantool 3.0 "name as key" identification mode based on UUIDs extraction. If works fine if vshard configuration (or Tarantool 3.0 configuration which builds vshard one) provides UUIDs, but fails if it isn't. Since UUIDs are optional and won't be provided in most cases, it makes crud fails to work on most Tarantool 3.0 vshard clusters. This patch fixes the issue.

Now the code uses name as key, if corresponding mode is enabled, and uuid otherwise. Patch doesn't cover `select_old` since it runs only on pre-3.0 Tarantool. Unfortunately, code relies on vshard internals since now there is no other way [1].

This patch covers new mode support for readview code as well. It likely was broken before this patch even if UUIDs were provided.

1. https://github.com/tarantool/vshard/issues/460

Follows #404
Closes #407