### PR TITLE
crud: support vshard with master discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * Compatibility with vshard configuration if UUIDs are omitted (#407).
+* Compatibility with automatic master discovery in vshard (#409).
 
 ## [1.4.2] - 25-12-23
 

--- a/crud.lua
+++ b/crud.lua
@@ -23,8 +23,6 @@ local stats = require('crud.stats')
 local readview = require('crud.readview')
 local schema = require('crud.schema')
 
-local luri = require('uri')
-
 local crud = {}
 
 -- @refer crud.version
@@ -173,15 +171,7 @@ function crud.init_storage()
 
     local user = nil
     if not box.info.ro then
-        local replicaset_key, replicaset = utils.get_self_vshard_replicaset()
-
-        if replicaset == nil or replicaset.master == nil then
-            error(string.format(
-                'Failed to find a vshard configuration ' ..
-                'for storage replicaset with key %q.',
-                replicaset_key))
-        end
-        user = luri.parse(replicaset.master.uri).login or 'guest'
+        user = utils.get_this_replica_user() or 'guest'
     end
 
     if rawget(_G, '_crud') == nil then

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -21,7 +21,8 @@ local function table_len(t)
 end
 
 local function call_reload_schema_on_replicaset(replicaset, channel)
-    replicaset.master.conn:reload_schema()
+    local master = utils.get_replicaset_master(replicaset, {cached = false})
+    master.conn:reload_schema()
     channel:put(true)
 end
 

--- a/crud/common/vshard_utils.lua
+++ b/crud/common/vshard_utils.lua
@@ -1,3 +1,5 @@
+local luri = require('uri')
+
 local vshard = require('vshard')
 
 local vshard_utils = {}
@@ -51,6 +53,38 @@ function vshard_utils.get_vshard_identification_mode()
     -- https://github.com/tarantool/vshard/issues/460.
     assert(vshard.storage.internal.current_cfg ~= nil, 'available only on vshard storage')
     return vshard.storage.internal.current_cfg.identification_mode
+end
+
+function vshard_utils.get_this_replica_user()
+    local replicaset_key, replicaset = vshard_utils.get_self_vshard_replicaset()
+
+    if replicaset == nil or replicaset.master == nil then
+        error(string.format(
+            'Failed to find a vshard configuration ' ..
+            'for storage replicaset with key %q.',
+            replicaset_key))
+    end
+
+    local uri
+    if replicaset.master == 'auto' then
+        -- https://github.com/tarantool/vshard/issues/467.
+        uri = vshard.storage.internal.this_replica.uri
+    else
+        uri = replicaset.master.uri
+    end
+
+    return luri.parse(uri).login
+end
+
+function vshard_utils.get_replicaset_master(replicaset, opts)
+    opts = opts or {}
+    local cached = opts.cached or false
+
+    if (not cached) and replicaset.locate_master ~= nil then
+        replicaset:locate_master()
+    end
+
+    return replicaset.master
 end
 
 return vshard_utils

--- a/crud/truncate.lua
+++ b/crud/truncate.lua
@@ -59,7 +59,11 @@ function truncate.call(space_name, opts)
         return nil, TruncateError:new(err)
     end
 
-    local replicasets = vshard_router:routeall()
+    local replicasets, err = vshard_router:routeall()
+    if err ~= nil then
+        return nil, TruncateError:new("Failed to get router replicasets: %s", err)
+    end
+
     local _, err = call.map(vshard_router, CRUD_TRUNCATE_FUNC_NAME, {space_name}, {
         mode = 'write',
         replicasets = replicasets,

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -826,18 +826,32 @@ function helpers.extend_vshard_matrix(backend_params, backend_cfg_key, backend_c
     return backend_params
 end
 
+function helpers.is_cartridge_suite_supported()
+    local is_module_provided = pcall(require, 'cartridge')
+
+    local tarantool_version = luatest_utils.get_tarantool_version()
+    local is_tarantool_supports = not luatest_utils.version_ge(tarantool_version,
+        luatest_utils.version(3, 0, 0))
+    return is_module_provided and is_tarantool_supports
+end
+
 function helpers.backend_matrix(base_matrix)
     base_matrix = base_matrix or {{}}
     local backend_params = {
-        {
-            backend = helpers.backend.CARTRIDGE,
-            backend_cfg = nil,
-        },
         {
             backend = helpers.backend.VSHARD,
             backend_cfg = nil,
         },
     }
+
+    if helpers.is_cartridge_suite_supported() then
+        table.insert(backend_params,
+            {
+                backend = helpers.backend.CARTRIDGE,
+                backend_cfg = nil,
+            }
+        )
+    end
 
     if helpers.is_name_supported_as_vshard_id() then
         backend_params = helpers.extend_vshard_matrix(

--- a/test/integration/updated_schema_test.lua
+++ b/test/integration/updated_schema_test.lua
@@ -25,6 +25,10 @@ pgroup.before_each(function(g)
     g.cluster.main_server.net_box:eval([[
         local vshard = require('vshard')
         for _, replicaset in pairs(vshard.router.routeall()) do
+            if replicaset.locate_master ~= nil then
+                replicaset:locate_master()
+            end
+
             local master = replicaset.master
 
             if not master.conn:ping({timeout = 3}) then

--- a/test/performance/perf_test.lua
+++ b/test/performance/perf_test.lua
@@ -10,7 +10,7 @@ local t = require('luatest')
 
 local helpers = require('test.helper')
 
-local g = t.group('perf', helpers.backend_matrix())
+local g = t.group('perf', {{backend = helpers.backend.VSHARD}})
 
 local id = 0
 local function gen()


### PR DESCRIPTION
In vshard 0.1.25 and Tarantool 3.0 new feature has been implemented. The feature is related to automatic master discovery. If it has been enabled, crud fails to bootstrap and work in several places. This feature is enabled by Tarantool 3.0 if vshard cluster was configured with specific 3.0 config flags.

Unfortunately, it is impossible to rework the code using only vshard public API now [2].

1. https://github.com/tarantool/vshard/issues/429
2. https://github.com/tarantool/vshard/issues/467

Closes #409