### PR TITLE
release 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.3] - 05-02-24
 
 ### Fixed
 * Compatibility with vshard configuration if UUIDs are omitted (#407).

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.4.2'
+return '1.4.3'


### PR DESCRIPTION
### Overview

This release introduces compatibility with several Tarantool 3 + vshard 0.1.25 features, as well as critical scan fix.

### Fixed
* Compatibility with vshard configuration if UUIDs are omitted (#407).
* Compatibility with automatic master discovery in vshard (#409).
* Secondary conditions for index operands with operations `>=`, `<=`, `>`, `<` no longer cause missing part of the actual result for scan operations (`crud.select`, `crud.pairs`, `crud.count`, `readview:select`, `readview:pairs`) (#418).
