### PR TITLE
ci: bump actions to v4 in reusable_test.yml

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Clone the crud module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/crud
 
       - name: Download the Tarantool build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
Bump version of the `actions/checkout` and `actions/download-artifact` actions to v4 for fixing the following GitHub warning:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20
