### PR TITLE
scan: fix nil filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   non-iterating indexes (#373).
 * Passing errors from storages for merger operations (`crud.select`,
   `crud.pairs`, `readview:select`, `readview:pairs`) (#423).
+* Working with `nil` operand conditions in case of non-indexed fields or
+  non-iterating indexes (#422).
 
 ## [1.4.3] - 05-02-24
 

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -664,51 +664,29 @@ local function determine_enabled_features()
                                                                          2, 2, 0, nil)
 end
 
-function utils.tarantool_supports_fieldpaths()
-    if enabled_tarantool_features.fieldpaths == nil then
-        determine_enabled_features()
-    end
+determine_enabled_features()
 
+function utils.tarantool_supports_fieldpaths()
     return enabled_tarantool_features.fieldpaths
 end
 
 function utils.tarantool_supports_uuids()
-    if enabled_tarantool_features.uuids == nil then
-        determine_enabled_features()
-    end
-
     return enabled_tarantool_features.uuids
 end
 
 function utils.tarantool_supports_jsonpath_indexes()
-    if enabled_tarantool_features.jsonpath_indexes == nil then
-        determine_enabled_features()
-    end
-
     return enabled_tarantool_features.jsonpath_indexes
 end
 
 function utils.tarantool_has_builtin_merger()
-    if enabled_tarantool_features.builtin_merger == nil then
-        determine_enabled_features()
-    end
-
     return enabled_tarantool_features.builtin_merger
 end
 
 function utils.tarantool_supports_external_merger()
-    if enabled_tarantool_features.external_merger == nil then
-        determine_enabled_features()
-    end
-
     return enabled_tarantool_features.external_merger
 end
 
 function utils.tarantool_supports_netbox_skip_header_option()
-    if enabled_tarantool_features.netbox_skip_header_option == nil then
-        determine_enabled_features()
-    end
-
     return enabled_tarantool_features.netbox_skip_header_option
 end
 

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -666,28 +666,17 @@ end
 
 determine_enabled_features()
 
-function utils.tarantool_supports_fieldpaths()
-    return enabled_tarantool_features.fieldpaths
-end
+for feature_name, feature_enabled in pairs(enabled_tarantool_features) do
+    local util_name
+    if feature_name == 'builtin_merger' then
+        util_name = ('tarantool_has_%s'):format(feature_name)
+    else
+        util_name = ('tarantool_supports_%s'):format(feature_name)
+    end
 
-function utils.tarantool_supports_uuids()
-    return enabled_tarantool_features.uuids
-end
+    local util_func = function() return feature_enabled end
 
-function utils.tarantool_supports_jsonpath_indexes()
-    return enabled_tarantool_features.jsonpath_indexes
-end
-
-function utils.tarantool_has_builtin_merger()
-    return enabled_tarantool_features.builtin_merger
-end
-
-function utils.tarantool_supports_external_merger()
-    return enabled_tarantool_features.external_merger
-end
-
-function utils.tarantool_supports_netbox_skip_header_option()
-    return enabled_tarantool_features.netbox_skip_header_option
+    utils[util_name] = util_func
 end
 
 local function add_nullable_fields_recursive(operations, operations_map, space_format, tuple, id)

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -6,8 +6,6 @@ local fun = require('fun')
 local vshard = require('vshard')
 local log = require('log')
 
-local datetime_supported, datetime = pcall(require, 'datetime')
-
 local is_cartridge, cartridge = pcall(require, 'cartridge')
 local is_cartridge_hotreload, cartridge_hotreload = pcall(require, 'cartridge.hotreload')
 
@@ -605,9 +603,33 @@ local function determine_enabled_features()
     enabled_tarantool_features.fieldpaths = is_version_ge(major, minor, patch, suffix,
                                                           2, 3, 1, nil)
 
-    -- since Tarantool 2.4.1
+    -- Full support (Lua type, space format type and indexes) for decimal type
+    -- is since Tarantool 2.3.1 [1]
+    --
+    -- [1] https://github.com/tarantool/tarantool/commit/485439e33196e26d120e622175f88b4edc7a5aa1
+    enabled_tarantool_features.decimals = is_version_ge(major, minor, patch, suffix,
+                                                        2, 3, 1, nil)
+
+    -- Full support (Lua type, space format type and indexes) for uuid type
+    -- is since Tarantool 2.4.1 [1]
+    --
+    -- [1] https://github.com/tarantool/tarantool/commit/b238def8065d20070dcdc50b54c2536f1de4c7c7
     enabled_tarantool_features.uuids = is_version_ge(major, minor, patch, suffix,
                                                      2, 4, 1, nil)
+
+    -- Full support (Lua type, space format type and indexes) for datetime type
+    -- is since Tarantool 2.10.0-beta2 [1]
+    --
+    -- [1] https://github.com/tarantool/tarantool/commit/3bd870261c462416c29226414fe0a2d79aba0c74
+    enabled_tarantool_features.datetimes = is_version_ge(major, minor, patch, suffix,
+                                                         2, 10, 0, 'beta2')
+
+    -- Full support (Lua type, space format type and indexes) for datetime type
+    -- is since Tarantool 2.10.0-rc1 [1]
+    --
+    -- [1] https://github.com/tarantool/tarantool/commit/38f0c904af4882756c6dc802f1895117d3deae6a
+    enabled_tarantool_features.intervals = is_version_ge(major, minor, patch, suffix,
+                                                         2, 10, 0, 'rc1')
 
     -- since Tarantool 2.6.3 / 2.7.2 / 2.8.1
     enabled_tarantool_features.jsonpath_indexes = is_version_ge(major, minor, patch, suffix,
@@ -1304,9 +1326,7 @@ function utils.is_cartridge_hotreload_supported()
     return true, cartridge_hotreload
 end
 
-local interval_supported = datetime_supported and (datetime.interval ~= nil)
-
-if interval_supported then
+if utils.tarantool_supports_intervals() then
     -- https://github.com/tarantool/tarantool/blob/0510ffa07afd84a70c9c6f1a4c28aacd73a393d6/src/lua/datetime.lua#L175-179
     local interval_t = ffi.typeof('struct interval')
 

--- a/crud/compare/filters.lua
+++ b/crud/compare/filters.lua
@@ -1,7 +1,7 @@
-local datetime_supported, datetime = pcall(require, 'datetime')
-local decimal_supported, decimal = pcall(require, 'decimal')
-
 local errors = require('errors')
+
+local _, datetime = pcall(require, 'datetime')
+local _, decimal = pcall(require, 'decimal')
 
 local utils = require('crud.common.utils')
 local dev_checks = require('crud.common.dev_checks')
@@ -160,12 +160,12 @@ local function format_value(value)
         return tostring(value)
     elseif type(value) == 'boolean' then
         return tostring(value)
-    elseif decimal_supported and decimal.is_decimal(value) then
+    elseif utils.tarantool_supports_decimals() and decimal.is_decimal(value) then
         -- decimal supports comparison with string.
         return ("%q"):format(tostring(value))
     elseif utils.is_uuid(value) then
         return ("%q"):format(value)
-    elseif datetime_supported and datetime.is_datetime(value) then
+    elseif utils.tarantool_supports_datetimes() and datetime.is_datetime(value) then
         return ("%q"):format(value:format())
     elseif utils.is_interval(value) then
         -- As for Tarantool 3.0 and older, datetime intervals

--- a/test/entrypoint/srv_select/storage_init.lua
+++ b/test/entrypoint/srv_select/storage_init.lua
@@ -1,6 +1,3 @@
-local datetime_supported, datetime = pcall(require, 'datetime')
-local decimal_supported, _ = pcall(require, 'decimal')
-
 local crud_utils = require('crud.common.utils')
 
 return function()
@@ -231,7 +228,7 @@ return function()
         if_not_exists = true,
     })
 
-    if decimal_supported then
+    if crud_utils.tarantool_supports_decimals() then
         local decimal_format = {
             {name = 'id', type = 'unsigned'},
             {name = 'bucket_id', type = 'unsigned'},
@@ -327,7 +324,7 @@ return function()
         })
     end
 
-    if datetime_supported then
+    if crud_utils.tarantool_supports_datetimes() then
         local datetime_format = {
             {name = 'id', type = 'unsigned'},
             {name = 'bucket_id', type = 'unsigned'},
@@ -423,8 +420,7 @@ return function()
         })
     end
 
-    local interval_supported = datetime_supported and (datetime.interval ~= nil)
-    if interval_supported then
+    if crud_utils.tarantool_supports_intervals() then
         -- Interval is non-indexable.
         local interval_space = box.schema.space.create('interval', {
             if_not_exists = true,

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -962,6 +962,10 @@ function helpers.is_decimal_supported()
     return crud_utils.tarantool_supports_decimals()
 end
 
+function helpers.is_uuid_supported()
+    return crud_utils.tarantool_supports_uuids()
+end
+
 function helpers.is_datetime_supported()
     return crud_utils.tarantool_supports_datetimes()
 end

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -958,20 +958,28 @@ function helpers.prepare_ordered_data(g, space, expected_objects, bucket_id, ord
     t.assert_equals(objects, expected_objects)
 end
 
+function helpers.is_decimal_supported()
+    return crud_utils.tarantool_supports_decimals()
+end
+
+function helpers.is_datetime_supported()
+    return crud_utils.tarantool_supports_datetimes()
+end
+
+function helpers.is_interval_supported()
+    return crud_utils.tarantool_supports_intervals()
+end
+
 function helpers.skip_decimal_unsupported()
-    local module_available, _ = pcall(require, 'decimal')
-    t.skip_if(not module_available, 'decimal is not supported')
+    t.skip_if(not helpers.is_decimal_supported(), 'decimal is not supported')
 end
 
 function helpers.skip_datetime_unsupported()
-    local module_available, _ = pcall(require, 'datetime')
-    t.skip_if(not module_available, 'datetime is not supported')
+    t.skip_if(not helpers.is_datetime_supported(), 'datetime is not supported')
 end
 
 function helpers.skip_interval_unsupported()
-    local datetime_supported, datetime = pcall(require, 'datetime')
-    local interval_supported = datetime_supported and (datetime.interval ~= nil)
-    t.skip_if(not interval_supported, 'interval is not supported')
+    t.skip_if(not helpers.is_interval_supported(), 'interval is not supported')
 end
 
 function helpers.merge_tables(t1, t2, ...)

--- a/test/integration/count_test.lua
+++ b/test/integration/count_test.lua
@@ -893,3 +893,11 @@ for case_name_template, case in pairs(gh_373_types_cases) do
         case(g, read_impl)
     end
 end
+
+for case_name_template, case in pairs(read_scenario.gh_422_nullability_cases) do
+    local case_name = 'test_' .. case_name_template:format('count')
+
+    pgroup[case_name] = function(g)
+        case(g, read_impl)
+    end
+end

--- a/test/integration/pairs_readview_test.lua
+++ b/test/integration/pairs_readview_test.lua
@@ -936,3 +936,11 @@ pgroup.after_test(
     'test_pairs_merger_process_storage_error',
     read_scenario.after_merger_process_storage_error
 )
+
+for case_name_template, case in pairs(read_scenario.gh_422_nullability_cases) do
+    local case_name = 'test_' .. case_name_template:format('pairs')
+
+    pgroup[case_name] = function(g)
+        case(g, read_impl)
+    end
+end

--- a/test/integration/pairs_test.lua
+++ b/test/integration/pairs_test.lua
@@ -944,3 +944,11 @@ pgroup.after_test(
     'test_pairs_merger_process_storage_error',
     read_scenario.after_merger_process_storage_error
 )
+
+for case_name_template, case in pairs(read_scenario.gh_422_nullability_cases) do
+    local case_name = 'test_' .. case_name_template:format('pairs')
+
+    pgroup[case_name] = function(g)
+        case(g, read_impl)
+    end
+end

--- a/test/integration/read_scenario.lua
+++ b/test/integration/read_scenario.lua
@@ -5,8 +5,9 @@
 -- Scenarios here are for `srv_select` entrypoint.
 
 local t = require('luatest')
-local datetime_supported, datetime = pcall(require, 'datetime')
-local decimal_supported, decimal = pcall(require, 'decimal')
+
+local _, datetime = pcall(require, 'datetime')
+local _, decimal = pcall(require, 'decimal')
 
 local helpers = require('test.helper')
 
@@ -98,7 +99,7 @@ end
 
 local decimal_vals = {}
 
-if decimal_supported then
+if helpers.is_decimal_supported() then
     decimal_vals = {
         smallest_negative = decimal.new('-123456789012345678.987431234678392'),
         bigger_negative = decimal.new('-123456789012345678.987431234678391'),
@@ -318,7 +319,7 @@ end
 
 local datetime_vals = {}
 
-if datetime_supported then
+if helpers.is_datetime_supported() then
     datetime_vals = {
         yesterday = datetime.new{
             year = 2024,

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2496,6 +2496,9 @@ end
 
 local function read_impl(cg, space, conditions, opts)
     return cg.cluster.main_server:exec(function(space, conditions, opts)
+        opts = table.deepcopy(opts) or {}
+        opts.fullscan = true
+
         local crud = require('crud')
         local rv, err = crud.readview()
         t.assert_equals(err, nil)

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2392,6 +2392,11 @@ pgroup.test_select_switch_master = function(g)
 
 end
 
+pgroup.after_test('test_select_switch_master', function(g)
+    local replicasets = helpers.get_test_cartridge_replicasets()
+    set_master(g.cluster, replicasets[2].uuid, replicasets[2].servers[1].instance_uuid)
+end)
+
 -- TODO: https://github.com/tarantool/crud/issues/383
 pgroup.test_select_switch_master_first = function(g)
     helpers.skip_not_cartridge_backend(g.params.backend)
@@ -2447,6 +2452,11 @@ pgroup.test_select_switch_master_first = function(g)
     })
 
 end
+
+pgroup.after_test('test_select_switch_master', function(g)
+    local replicasets = helpers.get_test_cartridge_replicasets()
+    set_master(g.cluster, replicasets[2].uuid, replicasets[2].servers[1].instance_uuid)
+end)
 
 -- TODO: https://github.com/tarantool/crud/issues/383
 pgroup.test_select_closed_readview = function(g)

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2335,11 +2335,9 @@ end
 pgroup.after_test('test_stop_select', function(g)
     -- It seems more easy to restart the cluster rather then restore it
     -- original state.
-    if g.params.backend == helpers.backend.VSHARD then
-        helpers.stop_cluster(g.cluster, g.params.backend)
-        g.cluster = nil
-        init_cluster(g)
-    end
+    helpers.stop_cluster(g.cluster, g.params.backend)
+    g.cluster = nil
+    init_cluster(g)
 end)
 
 pgroup.test_select_switch_master = function(g)

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2545,3 +2545,11 @@ pgroup.after_test(
     'test_select_merger_process_storage_error',
     read_scenario.after_merger_process_storage_error
 )
+
+for case_name_template, case in pairs(read_scenario.gh_422_nullability_cases) do
+    local case_name = 'test_' .. case_name_template:format('select')
+
+    pgroup[case_name] = function(g)
+        case(g, read_impl)
+    end
+end

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -2271,6 +2271,7 @@ end
 local function read_impl(cg, space, conditions, opts)
     opts = table.deepcopy(opts) or {}
     opts.mode = 'write'
+    opts.fullscan = true
 
     local resp, err = cg.cluster.main_server:call('crud.select', {space, conditions, opts})
 

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -2313,3 +2313,11 @@ pgroup.after_test(
     'test_select_merger_process_storage_error',
     read_scenario.after_merger_process_storage_error
 )
+
+for case_name_template, case in pairs(read_scenario.gh_422_nullability_cases) do
+    local case_name = 'test_' .. case_name_template:format('select')
+
+    pgroup[case_name] = function(g)
+        case(g, read_impl)
+    end
+end


### PR DESCRIPTION
Before this patch, some nil conditions failed with internal filter library build error. This patch fixes this internal error, as well as normalize filters to behave similar to core indexes.

The logic in core Tarantool select is as follows. `nil` condition in index select is an absence of condition, thus all data is returned disregarding the condition (condition may affect the order). `box.NULL` condition is a condition for the null value -- in case of EQ, only records with null index value are returned, in case of GT, all non-null values are returned since nulls are in the beginning of an index and so on. `nil`s and `box.NULL`s in tuple are both satisfy `box.NULL` equity.

After this patch, `nil` filter condition is treated as no condition. This is a breaking change since conditions for `'>'` and `'<'` operator with `nil` operand had resulted with empty response before this patch. But since it was inconsistent with scanning index conditions and wasn't intentional, we change it here.

Closes #422
