### PR TITLE
crud: introduce tarantool 3 roles

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -43,6 +43,8 @@ jobs:
             external-keydef-version: "0.0.4"
           - tarantool-version: "3.0.0"
             vshard-version: "0.1.25"
+          - tarantool-version: "master"
+            vshard-version: "0.1.26"
       fail-fast: false
     # Can't install older versions on 22.04,
     # see https://github.com/tarantool/setup-tarantool/issues/36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Asynchronous bootstrap support for storages (#412).
 * Tarantool 3 roles for setting up crud routers and storages (#415).
+* Ability to configure crud through Tarantool 3 roles configuration (#415).
 
 ### Changed
 * Explicitly forbid datetime interval conditions (#373).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * Explicitly forbid datetime interval conditions (#373).
 * Storage initialization is now asynchronous by default for Tarantool 3.0+ (#412).
+* Additionally check backoff error on storage info fetch (#427).
 
 ### Fixed
 * Working with datetime conditions in case of non-indexed fields or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * Asynchronous bootstrap support for storages (#412).
+* Tarantool 3 roles for setting up crud routers and storages (#415).
 
 ### Changed
 * Explicitly forbid datetime interval conditions (#373).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ file(GLOB_RECURSE LUA_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/crud.lua"
   "${CMAKE_CURRENT_SOURCE_DIR}/crud/*.lua"
   "${CMAKE_CURRENT_SOURCE_DIR}/cartridge/roles/*.lua"
+  "${CMAKE_CURRENT_SOURCE_DIR}/roles/*.lua"
 )
 
 ## Testing ####################################################################
@@ -93,5 +94,10 @@ install(
 
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cartridge
+  DESTINATION ${TARANTOOL_INSTALL_LUADIR}
+)
+
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/roles
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}
 )

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It also provides the `crud-storage` and `crud-router` roles for
     - [Read view select](#read-view-select)
       - [Read view select conditions](#read-view-select-conditions)
     - [Read view pairs](#read-view-pairs)
+  - [Schema](#schema)
 - [Cartridge roles](#cartridge-roles)
   - [Usage](#usage)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -2102,6 +2102,21 @@ issues.
 5.  Start the application cluster. You can check whether asynchronous bootstrap
     had finished through `crud.storage_info()` calls on router.
 
+6.  Configure the statistics with roles configuration
+    (see `crud.cfg` options in [statistics](#statistics) section):
+    ```yaml
+    roles:
+      - roles.crud-router
+    roles_cfg:
+      roles.crud-router:
+        stats: true
+        stats_driver: metrics
+        stats_quantiles: false
+        stats_quantile_tolerated_error: 0.001
+        stats_quantile_age_buckets_count: 5
+        stats_quantile_max_age_time: 180
+    ```
+
 Now your cluster contains storages that are configured to be used for
 CRUD-operations.
 You can simply call CRUD functions on the router to insert, select, and update

--- a/README.md
+++ b/README.md
@@ -1848,79 +1848,79 @@ scope, so that you can call them via `net.box`.
 
 1. Add `crud` to dependencies in the project rockspec.
 
-**Note**: it's better to use tagged version than `scm-1`.
-Check the latest available [release](https://github.com/tarantool/crud/releases) tag and use it.
+    **Note**: it's better to use tagged version than `scm-1`.
+    Check the latest available [release](https://github.com/tarantool/crud/releases) tag and use it.
 
-```lua
--- <project-name>-scm-1.rockspec
-dependencies = {
-    ...
-    'crud == <the-latest-tag>-1',
-    ...
-}
-```
+    ```lua
+    -- <project-name>-scm-1.rockspec
+    dependencies = {
+        ...
+        'crud == <the-latest-tag>-1',
+        ...
+    }
+    ```
 
 2. Create the role that stores your data and depends on `crud-storage`.
 
-```lua
--- app.roles.customers-storage.lua
-local cartridge = require('cartridge')
+    ```lua
+    -- app.roles.customers-storage.lua
+    local cartridge = require('cartridge')
 
-return {
-        role_name = 'customers-storage',
-        init = function()
-            local customers_space = box.schema.space.create('customers', {
-                format = {
-                    {name = 'id', type = 'unsigned'},
-                    {name = 'bucket_id', type = 'unsigned'},
-                    {name = 'name', type = 'string'},
-                    {name = 'age', type = 'number'},
-                },
-                if_not_exists = true,
-            })
-            customers_space:create_index('id', {
-                parts = { {field ='id', is_nullable = false} },
-                if_not_exists = true,
-            })
-            customers_space:create_index('bucket_id', {
-                parts = { {field ='bucket_id', is_nullable = false} },
-                if_not_exists = true,
-            })
-            customers_space:create_index('age', {
-                parts = { {field ='age'} },
-                unique = false,
-                if_not_exists = true,
-            })
-        end,
-        dependencies = {'cartridge.roles.crud-storage'},
-    }
-```
+    return {
+            role_name = 'customers-storage',
+            init = function()
+                local customers_space = box.schema.space.create('customers', {
+                    format = {
+                        {name = 'id', type = 'unsigned'},
+                        {name = 'bucket_id', type = 'unsigned'},
+                        {name = 'name', type = 'string'},
+                        {name = 'age', type = 'number'},
+                    },
+                    if_not_exists = true,
+                })
+                customers_space:create_index('id', {
+                    parts = { {field ='id', is_nullable = false} },
+                    if_not_exists = true,
+                })
+                customers_space:create_index('bucket_id', {
+                    parts = { {field ='bucket_id', is_nullable = false} },
+                    if_not_exists = true,
+                })
+                customers_space:create_index('age', {
+                    parts = { {field ='age'} },
+                    unique = false,
+                    if_not_exists = true,
+                })
+            end,
+            dependencies = {'cartridge.roles.crud-storage'},
+        }
+    ```
 
-```lua
--- app.roles.customers-router.lua
-local cartridge = require('cartridge')
-return {
-        role_name = 'customers-router',
-        dependencies = {'cartridge.roles.crud-router'},
-    }
-```
+    ```lua
+    -- app.roles.customers-router.lua
+    local cartridge = require('cartridge')
+    return {
+            role_name = 'customers-router',
+            dependencies = {'cartridge.roles.crud-router'},
+        }
+    ```
 
-3. Start the application and create `customers-storage` and
-   `customers-router` replica sets.
+3.  Start the application and create `customers-storage` and
+    `customers-router` replica sets.
 
-4. Don't forget to bootstrap vshard.
+4.  Don't forget to bootstrap vshard.
 
-5. Configure the statistics with clusterwide configuration
-   (see `crud.cfg` options in [statistics](#statistics) section):
-```yaml
-crud:
-  stats: true
-  stats_driver: metrics
-  stats_quantiles: false
-  stats_quantile_tolerated_error: 0.001
-  stats_quantile_age_buckets_count: 5
-  stats_quantile_max_age_time: 180
-```
+5.  Configure the statistics with clusterwide configuration
+    (see `crud.cfg` options in [statistics](#statistics) section):
+    ```yaml
+    crud:
+      stats: true
+      stats_driver: metrics
+      stats_quantiles: false
+      stats_quantile_tolerated_error: 0.001
+      stats_quantile_age_buckets_count: 5
+      stats_quantile_max_age_time: 180
+    ```
 
 Now your cluster contains storages that are configured to be used for
 CRUD-operations.

--- a/crud/common/roles.lua
+++ b/crud/common/roles.lua
@@ -1,0 +1,25 @@
+local config = require('config')
+
+local function is_sharding_role_enabled(expected_sharding_role)
+    -- Works only for versions newer than 3.0.1-10 (3.0.2 and following)
+    -- https://github.com/tarantool/tarantool/commit/e0e1358cb60d6749c34daf508e05586e0959bf89
+    -- and newer than 3.1.0-entrypoint-77 (3.1.0 and following).
+    -- https://github.com/tarantool/tarantool/commit/ebb170cb8cf2b9c4634bcf0178665909f578c335
+    -- Corresponding EE releases: 3.0.1-10 (works with 3.0.2 and following)
+    -- https://github.com/tarantool/tarantool-ee/commit/1dea81bed4cbe4856a0fc77dcc548849a2dabf45
+    -- and 3.1.0-entrypoint-44 (works with 3.1.0 and following)
+    -- https://github.com/tarantool/tarantool-ee/commit/368cc4007727af30ae3ca3a3cdfc7065f34e02aa
+    local actual_sharding_roles = config:get('sharding.roles')
+
+    for _, actual_sharding_role in ipairs(actual_sharding_roles or {}) do
+        if actual_sharding_role == expected_sharding_role then
+            return true
+        end
+    end
+
+    return false
+end
+
+return {
+    is_sharding_role_enabled = is_sharding_role_enabled,
+}

--- a/crud/readview.lua
+++ b/crud/readview.lua
@@ -1,7 +1,6 @@
 local fiber = require('fiber')
 local checks = require('checks')
 local errors = require('errors')
-local tarantool = require('tarantool')
 
 local const = require('crud.common.const')
 local stash = require('crud.common.stash')
@@ -25,7 +24,7 @@ local CLOSE_FUNC_NAME = 'readview_close_on_storage'
 local CRUD_CLOSE_FUNC_NAME = utils.get_storage_call(CLOSE_FUNC_NAME)
 
 if (not utils.tarantool_version_at_least(2, 11, 0))
-or (tarantool.package ~= 'Tarantool Enterprise') or (not has_merger) then
+or (not utils.is_enterprise_package()) or (not has_merger) then
     return {
         new = function()
             return nil, ReadviewError:new("Tarantool does not support readview")
@@ -40,7 +39,7 @@ local readview = {}
 
 local function readview_open_on_storage(readview_name)
     if not utils.tarantool_version_at_least(2, 11, 0) or
-    tarantool.package ~= 'Tarantool Enterprise' then
+    not utils.is_enterprise_package() then
         ReadviewError:assert(false, ("Tarantool does not support readview"))
     end
     -- We store readview in stash because otherwise gc will delete it.

--- a/roles/crud-router.lua
+++ b/roles/crud-router.lua
@@ -3,6 +3,7 @@ local errors = require('errors')
 local crud = require('crud')
 local common_role_utils = require('crud.common.roles')
 local common_utils = require('crud.common.utils')
+local stats = require('crud.stats')
 
 local TarantoolRoleConfigurationError = errors.new_class('TarantoolRoleConfigurationError')
 
@@ -12,15 +13,71 @@ TarantoolRoleConfigurationError:assert(
     ('Tarantool 3 role is not supported for Tarantool %s, use 3.0.2 or newer'):format(tarantool_version)
 )
 
-local function validate()
+
+local function validate_enabled_on_sharding_router()
     TarantoolRoleConfigurationError:assert(
         common_role_utils.is_sharding_role_enabled('router'),
         'Instance must be a sharding router to enable roles.crud-router'
     )
 end
 
-local function apply()
+local cfg_types = {
+    stats = 'boolean',
+    stats_driver = 'string',
+    stats_quantiles = 'boolean',
+    stats_quantile_tolerated_error = 'number',
+    stats_quantile_age_buckets_count = 'number',
+    stats_quantile_max_age_time = 'number',
+}
+
+local cfg_values = {
+    stats_driver = function(value)
+        TarantoolRoleConfigurationError:assert(
+            stats.is_driver_supported(value),
+            'Invalid "stats_driver" field value: %q is not supported',
+            value
+        )
+    end,
+}
+
+local function validate_roles_cfg(roles_cfg)
+    if roles_cfg == nil then
+        return
+    end
+
+    TarantoolRoleConfigurationError:assert(
+        type(roles_cfg) == 'table',
+        'roles_cfg must be a table'
+    )
+
+    for name, value in pairs(roles_cfg) do
+        TarantoolRoleConfigurationError:assert(
+            cfg_types[name] ~= nil,
+            'Unknown field %q', name
+        )
+
+        TarantoolRoleConfigurationError:assert(
+            type(value) == cfg_types[name],
+            'Invalid %q field type: expected %s, got %s',
+            name, cfg_types[name], type(value)
+        )
+
+        if cfg_values[name] ~= nil then
+            cfg_values[name](value)
+        end
+    end
+end
+
+local function validate(roles_cfg)
+    validate_enabled_on_sharding_router()
+
+    validate_roles_cfg(roles_cfg)
+end
+
+local function apply(roles_cfg)
     crud.init_router()
+
+    crud.cfg(roles_cfg)
 end
 
 local function stop()

--- a/roles/crud-router.lua
+++ b/roles/crud-router.lua
@@ -1,0 +1,34 @@
+local errors = require('errors')
+
+local crud = require('crud')
+local common_role_utils = require('crud.common.roles')
+local common_utils = require('crud.common.utils')
+
+local TarantoolRoleConfigurationError = errors.new_class('TarantoolRoleConfigurationError')
+
+local tarantool_version = rawget(_G, '_TARANTOOL')
+TarantoolRoleConfigurationError:assert(
+    common_utils.tarantool_supports_config_get_inside_roles(),
+    ('Tarantool 3 role is not supported for Tarantool %s, use 3.0.2 or newer'):format(tarantool_version)
+)
+
+local function validate()
+    TarantoolRoleConfigurationError:assert(
+        common_role_utils.is_sharding_role_enabled('router'),
+        'Instance must be a sharding router to enable roles.crud-router'
+    )
+end
+
+local function apply()
+    crud.init_router()
+end
+
+local function stop()
+    crud.stop_router()
+end
+
+return {
+    validate = validate,
+    apply = apply,
+    stop = stop,
+}

--- a/roles/crud-storage.lua
+++ b/roles/crud-storage.lua
@@ -1,0 +1,35 @@
+local errors = require('errors')
+
+local crud = require('crud')
+local common_role_utils = require('crud.common.roles')
+local common_utils = require('crud.common.utils')
+
+local TarantoolRoleConfigurationError = errors.new_class('TarantoolRoleConfigurationError', {capture_stack = false})
+
+local tarantool_version = rawget(_G, '_TARANTOOL')
+TarantoolRoleConfigurationError:assert(
+    common_utils.tarantool_supports_config_get_inside_roles()
+    and common_utils.tarantool_role_privileges_not_revoked(),
+    ('Tarantool 3 role is not supported for Tarantool %s, use 3.0.2 or newer'):format(tarantool_version)
+)
+
+local function validate()
+    TarantoolRoleConfigurationError:assert(
+        common_role_utils.is_sharding_role_enabled('storage'),
+        'instance must be a sharding storage to enable roles.crud-storage'
+    )
+end
+
+local function apply()
+    crud.init_storage{async = true}
+end
+
+local function stop()
+    crud.stop_storage()
+end
+
+return {
+    validate = validate,
+    apply = apply,
+    stop = stop,
+}

--- a/test/entrypoint/srv_say_hi/cartridge_init.lua
+++ b/test/entrypoint/srv_say_hi/cartridge_init.lua
@@ -17,15 +17,20 @@ end
 local root = fio.dirname(fio.dirname(fio.dirname(debug.sourcedir())))
 package.path = package.path .. root .. "/?.lua;"
 
-local ok, err
+package.preload['customers-storage'] = function()
+    return {
+        role_name = 'customers-storage',
+    }
+end
 
-ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
     advertise_uri = 'localhost:3301',
     http_port = 8081,
     bucket_count = 3000,
     roles = {
         'cartridge.roles.crud-storage',
         'cartridge.roles.crud-router',
+        'customers-storage',
     },
 })
 

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -743,16 +743,8 @@ local Capture = {
 assert_class_implements_interface(FileCapture, Capture)
 assert_class_implements_interface(LuatestCapture, Capture)
 
-function helpers.get_command_log(router, backend, call, args)
-    local capture
-
-    local use_builtin_capture = (backend == helpers.backend.CARTRIDGE)
-                                or (backend == helpers.backend.CONFIG)
-    if use_builtin_capture then
-        capture = LuatestCapture:new()
-    else
-        capture = FileCapture:new({server = router})
-    end
+function helpers.get_command_log(router, call, args)
+    local capture = LuatestCapture:new()
 
     local _, err = router.net_box:call(call, args)
     if err ~= nil then

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -144,7 +144,7 @@ function helpers.box_cfg(opts)
 
     if opts.wait_rw then
         t.helpers.retrying(
-            {timeout = 3, delay = 0.1},
+            {timeout = 60, delay = 0.1},
             t.assert_equals, box.info.ro, false
         )
     end
@@ -1021,7 +1021,7 @@ function helpers.wait_crud_is_ready_on_cluster(g, opts)
             opts.storage_roles
         )
 
-        local WAIT_TIMEOUT = 5
+        local WAIT_TIMEOUT = 60
         local DELAY = 0.1
         t.helpers.retrying(
             {timeout = WAIT_TIMEOUT, delay = DELAY},
@@ -1368,7 +1368,7 @@ function helpers.is_func_flag(flag)
 end
 
 function helpers.wait_func_flag(flag)
-    local TIMEOUT = 5
+    local TIMEOUT = 60
     local start = clock.monotonic()
 
     while clock.monotonic() - start < TIMEOUT do

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1468,4 +1468,8 @@ function helpers.skip_if_tarantool3_crud_roles_unsupported()
               ("Tarantool %s does not support crud roles"):format(version))
 end
 
+function helpers.skip_if_not_config_backend(backend)
+    t.skip_if(backend ~= helpers.backend.CONFIG, "The test is for Tarantool 3 with config only")
+end
+
 return helpers

--- a/test/integration/count_test.lua
+++ b/test/integration/count_test.lua
@@ -153,7 +153,7 @@ for name, case in pairs(count_safety_cases) do
         local uc = case.user_conditions
         local opts = case.opts
         local captured, err = helpers.get_command_log(g.router,
-            g.params.backend, 'crud.count', {space, uc, opts})
+            'crud.count', {space, uc, opts})
 
         t.assert_equals(err, nil)
         if case.has_crit then

--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -1,0 +1,99 @@
+local t = require('luatest')
+
+local helpers = require('test.helper')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    helpers.skip_if_tarantool3_crud_roles_unsupported()
+
+    cg.template_cfg = helpers.build_default_tarantool3_cluster_cfg('srv_select')
+end)
+
+g.before_each(function(cg)
+    -- Tests are rather dangerous and may break the cluster,
+    -- so it's safer to restart for each case.
+    helpers.start_tarantool3_cluster(cg, cg.template_cfg)
+    cg.router = cg.cluster:server('router')
+
+    helpers.wait_crud_is_ready_on_cluster(cg, {backend = helpers.backend.CONFIG})
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+-- Use autoincrement id so one test would be able to call the helper multiple times.
+local last_id = 0
+local function basic_insert_get_object(cluster)
+    last_id = last_id + 1
+
+    cluster:server('router'):exec(function(id)
+        local crud = require('crud')
+
+        local _, err = crud.insert_object('customers',
+            {
+                id = id,
+                name = 'Vincent',
+                last_name = 'Brooks',
+                age = 32,
+                city = 'Babel',
+            },
+            {noreturn = true}
+        )
+        t.assert_equals(err, nil)
+
+        local result, err = crud.get('customers', id, {mode = 'write'})
+        t.assert_equals(err, nil)
+        t.assert_equals(#result.rows, 1, 'Tuple found')
+
+        local objects, err = crud.unflatten_rows(result.rows, result.metadata)
+        t.assert_equals(err, nil)
+        t.assert_equals(objects[1].id, id)
+        t.assert_equals(objects[1].name, 'Vincent')
+        t.assert_equals(objects[1].last_name, 'Brooks')
+        t.assert_equals(objects[1].age, 32)
+        t.assert_equals(objects[1].city, 'Babel')
+    end, {last_id})
+end
+
+g.test_cluster_works_if_roles_enabled = function(cg)
+    basic_insert_get_object(cg.cluster)
+end
+
+g.test_cluster_works_after_vshard_user_password_alter = function(cg)
+    -- Alter the cluster.
+    local cfg = cg.cluster:cfg()
+
+    local old_password = cfg.credentials.users['storage'].password
+    cfg.credentials.users['storage'].password = old_password .. '_new_suffix'
+
+    cg.cluster:reload_config(cfg)
+
+    -- Wait until ready.
+    helpers.wait_crud_is_ready_on_cluster(cg, {backend = helpers.backend.CONFIG})
+
+    -- Check everything is fine.
+    basic_insert_get_object(cg.cluster)
+end
+
+g.test_cluster_works_after_vshard_user_alter = function(cg)
+    -- Alter the cluster.
+    local cfg = cg.cluster:cfg()
+
+    cfg.credentials.users['storage'] = nil
+    cfg.credentials.users['new_storage'] = {
+        password = 'storing-buckets-instead-of-storage',
+        roles = {'sharding'},
+    }
+
+    cfg.iproto.advertise.sharding.login = 'new_storage'
+
+    cg.cluster:reload_config(cfg)
+
+    -- Wait until ready.
+    helpers.wait_crud_is_ready_on_cluster(cg, {backend = helpers.backend.CONFIG})
+
+    -- Check everything is fine.
+    basic_insert_get_object(cg.cluster)
+end

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2322,6 +2322,12 @@ pgroup.test_stop_select = function(g)
             require('vshard.storage').cfg(cfg, box.info[bootstrap_key])
             require('crud').init_storage()
         end, {g.cfg, bootstrap_key})
+    elseif g.params.backend == helpers.backend.CONFIG then
+        g.cluster:server('s2-master'):wait_for_rw()
+
+        g.cluster:server('s2-master'):exec(function()
+            require('crud').init_storage()
+        end)
     end
 
     helpers.wait_crud_is_ready_on_cluster(g)

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -164,7 +164,7 @@ for name, case in pairs(select_safety_cases) do
         end
 
         local captured, err = helpers.get_command_log(g.router,
-            g.params.backend, 'crud.select', {space, uc, opts})
+            'crud.select', {space, uc, opts})
         t.assert_equals(err, nil)
 
         if case.has_crit then

--- a/test/integration/storages_state_test.lua
+++ b/test/integration/storages_state_test.lua
@@ -51,10 +51,12 @@ end)
 
 local function build_storage_info(g, array_info)
     local is_vshard = g.params.backend == 'vshard'
+    local is_config = g.params.backend == 'config'
+
     local name_as_key = is_vshard and (
         type(g.params.backend_cfg) == 'table'
         and g.params.backend_cfg.identification_mode == 'name_as_key'
-    )
+    ) or is_config
 
     local keys
     if name_as_key then

--- a/test/path.lua
+++ b/test/path.lua
@@ -1,0 +1,13 @@
+local fio = require('fio')
+
+local ROOT = fio.dirname(fio.dirname(fio.abspath(package.search('test.path'))))
+
+local LUA_PATH = ROOT .. '/?.lua;' ..
+    ROOT .. '/?/init.lua;' ..
+    ROOT .. '/.rocks/share/tarantool/?.lua;' ..
+    ROOT .. '/.rocks/share/tarantool/?/init.lua'
+
+return {
+    ROOT = ROOT,
+    LUA_PATH = LUA_PATH,
+}

--- a/test/performance/perf_test.lua
+++ b/test/performance/perf_test.lua
@@ -114,6 +114,7 @@ local tarantool3_cluster_cfg_template = {
             sharding = {
                 roles = {'router'},
             },
+            roles = {'roles.crud-router'},
             replicasets = {
                 ['router'] = {
                     leader = 'router',
@@ -127,6 +128,7 @@ local tarantool3_cluster_cfg_template = {
             sharding = {
                 roles = {'storage'},
             },
+            roles = {'roles.crud-storage'},
             replicasets = {
                 ['s-1'] = {
                     leader = 's1-master',
@@ -155,7 +157,6 @@ local tarantool3_cluster_cfg_template = {
     bucket_count = 3000,
     router_entrypoint = helpers.entrypoint_vshard_storage('srv_ddl'),
     storage_entrypoint = helpers.entrypoint_vshard_storage('srv_ddl'),
-    crud_init = true,
 }
 
 g.before_all(function(g)

--- a/test/tarantool3_helpers/cluster.lua
+++ b/test/tarantool3_helpers/cluster.lua
@@ -262,7 +262,7 @@ function Cluster:wait_crud_is_ready_on_cluster()
     local router = self:get_router()
     local storages_in_topology = self:count_storages()
 
-    local WAIT_TIMEOUT = 5
+    local WAIT_TIMEOUT = 60
     local DELAY = 0.1
     t.helpers.retrying(
         {timeout = WAIT_TIMEOUT, delay = DELAY},

--- a/test/tarantool3_helpers/cluster.lua
+++ b/test/tarantool3_helpers/cluster.lua
@@ -297,8 +297,33 @@ function Cluster:cfg(new_config)
     return table.deepcopy(self.config)
 end
 
+local function strip_all_entries(t, name)
+    if type(t) ~= 'table' then
+        return t
+    end
+
+    t[name] = nil
+
+    for k, v in pairs(t) do
+        t[k] = strip_all_entries(v, name)
+    end
+
+    return t
+end
+
+local function check_only_roles_cfg_changed_in_groups(old_groups, new_groups)
+    old_groups = table.deepcopy(old_groups)
+    new_groups = table.deepcopy(new_groups)
+
+    local old_groups_no_roles_cfg = strip_all_entries(old_groups, 'roles_cfg')
+    local new_groups_no_roles_cfg = strip_all_entries(new_groups, 'roles_cfg')
+
+    t.assert_equals(new_groups_no_roles_cfg, old_groups_no_roles_cfg,
+                    'groups reload supports only roles_cfg reload')
+end
+
 function Cluster:reload_config(new_config)
-    t.assert_equals(new_config.groups, self.config.groups, 'groups reload is not supported yet')
+    check_only_roles_cfg_changed_in_groups(self.config.groups, new_config.groups)
 
     for _, server in ipairs(self.servers) do
         write_config(self.dirs[server], new_config)

--- a/test/tarantool3_helpers/cluster.lua
+++ b/test/tarantool3_helpers/cluster.lua
@@ -1,0 +1,363 @@
+local checks = require('checks')
+local json = require('json')
+local fun = require('fun')
+local yaml = require('yaml')
+
+local t = require('luatest')
+
+local vtest = require('test.vshard_helpers.vtest')
+local treegen = require('test.tarantool3_helpers.treegen')
+local server_helper = require('test.tarantool3_helpers.server')
+local utils = require('test.tarantool3_helpers.utils')
+
+local Cluster = {}
+
+-- Inspired by
+-- https://github.com/tarantool/cartridge/blob/b9dc61e61bb85e75b7da7dc8f369867c0d3786c4/cartridge/test-helpers/cluster.lua
+-- together with
+-- https://github.com/tarantool/tarantool/blob/1a5e3bf3c3badd14ffc37b2b31e47554e4778cde/test/config-luatest/basic_test.lua#L39-L67
+
+function Cluster:inherit(object)
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+function Cluster:new(object)
+    checks('table', {
+        config = 'table',
+        modules = '?table',
+        env = '?table',
+        crud_init = '?boolean',
+        router_wait_until_ready = '?string',
+        storage_wait_until_ready = '?string',
+    })
+
+    self:inherit(object)
+    object:initialize()
+    return object
+end
+
+local function write_config(dir, config)
+    return treegen.write_script(dir, 'config.yaml', yaml.encode(config))
+end
+
+function Cluster:initialize()
+    self.servers = {}
+    self.dirs = {}
+
+    self.treegen = {}
+    treegen.init(self.treegen)
+
+    for _, group in pairs(self.config.groups) do
+        for _, replicaset in pairs(group.replicasets) do
+            local is_router = utils.is_replicaset_a_sharding_router(group, replicaset)
+            local is_storage = utils.is_replicaset_a_sharding_storage(group, replicaset)
+
+            for alias, _ in pairs(replicaset.instances) do
+                local dir = treegen.prepare_directory(self.treegen, {}, {})
+
+                local config_file = write_config(dir, self.config)
+
+                for name, content in pairs(self.modules or {}) do
+                    treegen.write_script(dir, name .. '.lua', content)
+                end
+
+                local opts = {config_file = config_file, chdir = dir}
+
+                local server = server_helper:new(fun.chain(opts, {alias = alias}):tomap())
+
+                for k, v in pairs(self.env or {}) do
+                    server.env[k] = v
+                end
+
+                server:set_router_tag(is_router)
+                server:set_storage_tag(is_storage)
+
+                table.insert(self.servers, server)
+                self.dirs[server] = dir
+            end
+        end
+    end
+
+    self.main_server = self.servers[1]
+
+    return self
+end
+
+function Cluster:set_etalon_bucket_balance()
+    local masters = {}
+    local etalon_balance = {}
+    local replicaset_count = 0
+
+    for _, group in pairs(self.config.groups) do
+        for rs_id, rs in pairs(group.replicasets) do
+            if not utils.is_replicaset_a_sharding_storage(group, rs) then
+                goto continue
+            end
+
+            local rs_uuid
+            if (rs.database or {}).replicaset_uuid ~= nil then
+                rs_uuid = rs.database.replicaset_uuid
+            else
+                rs_uuid = vtest.replicaset_name_to_uuid(rs_id)
+            end
+
+            local leader_id = rs.leader
+            assert(leader_id ~= nil, "Only explicit leader is supported now.")
+
+            masters[rs_uuid] = self:server(leader_id)
+
+            local weight = 1 -- Only equal weight is supported now.
+
+            etalon_balance[rs_uuid] = {
+                weight = weight,
+            }
+            replicaset_count = replicaset_count + 1
+
+            ::continue::
+        end
+    end
+    t.assert_not_equals(masters, {}, 'have masters')
+
+    local bucket_count = self.config.sharding.bucket_count
+    vtest.distribute_etalon_buckets(etalon_balance, masters, replicaset_count, bucket_count)
+end
+
+function Cluster:method_on_replicaset(method, config_replicaset, func, args)
+    for alias, _ in pairs(config_replicaset.instances) do
+        local server = self:server(alias)
+        server[method](server, func, args)
+    end
+end
+
+function Cluster:exec_on_replicaset(config_replicaset, func, args)
+    self:method_on_replicaset('exec', config_replicaset, func, args)
+end
+
+function Cluster:eval_on_replicaset(config_replicaset, func, args)
+    self:method_on_replicaset('eval', config_replicaset, func, args)
+end
+
+local function bootstrap_vshard_router()
+    local vshard = require('vshard')
+    vshard.router.bootstrap()
+end
+
+function Cluster:bootstrap_vshard_routers()
+    for _, group in pairs(self.config.groups) do
+        for _, rs in pairs(group.replicasets) do
+            if utils.is_replicaset_a_sharding_router(group, rs) then
+                self:exec_on_replicaset(rs, bootstrap_vshard_router)
+            end
+        end
+    end
+end
+
+local function bootstrap_crud_router()
+    local crud = require('crud')
+    crud.init_router()
+end
+
+local function bootstrap_crud_storage()
+    local crud = require('crud')
+    crud.init_storage{async = true}
+end
+
+function Cluster:bootstrap_crud()
+    for _, group in pairs(self.config.groups) do
+        for _, rs in pairs(group.replicasets) do
+            if utils.is_replicaset_a_sharding_router(group, rs) then
+                self:exec_on_replicaset(rs, bootstrap_crud_router)
+            end
+
+            if utils.is_replicaset_a_sharding_storage(group, rs) then
+                self:exec_on_replicaset(rs, bootstrap_crud_storage)
+            end
+        end
+    end
+end
+
+function Cluster:wait_for_leaders_rw()
+    for _, group in pairs(self.config.groups) do
+        for _, rs in pairs(group.replicasets) do
+            local leader_id = rs.leader
+            local leader = self:server(leader_id)
+
+            leader:wait_for_rw()
+        end
+    end
+end
+
+function Cluster:start()
+    for _, server in ipairs(self.servers) do
+        server:start({wait_until_ready = false})
+    end
+
+    return self:wait_until_ready()
+end
+
+function Cluster:wait_until_ready()
+    for _, server in ipairs(self.servers) do
+        server:wait_until_ready()
+    end
+
+    for _, server in ipairs(self.servers) do
+        t.assert_equals(server:eval('return box.info.name'), server.alias)
+    end
+
+    self:wait_for_leaders_rw()
+
+    self:bootstrap()
+    self:wait_until_bootstrap_finished()
+
+    return self
+end
+
+function Cluster:bootstrap()
+    self:set_etalon_bucket_balance()
+    self:bootstrap_vshard_routers()
+
+    if self.crud_init then
+        self:bootstrap_crud()
+    end
+
+    return self
+end
+
+function Cluster:wait_until_bootstrap_finished()
+    if self.crud_init then
+        self:wait_crud_is_ready_on_cluster()
+    end
+
+    self:wait_modules_are_ready_on_cluster()
+
+    return self
+end
+
+local function assert_expected_number_of_storages_is_running(router, expected_number)
+    local res, err = router:call('crud.storage_info')
+    assert(
+        err == nil,
+        ('crud is not bootstrapped: error on getting storage info: %s'):format(err)
+    )
+
+    local running_storages = 0
+    for _, storage in pairs(res) do
+        if storage.status == 'running' then
+            running_storages = running_storages + 1
+        end
+    end
+
+    assert(
+        running_storages == expected_number,
+        ('crud is not bootstrapped: expected %d running storages, got the following storage info: %s'):format(
+            expected_number, json.encode(res))
+    )
+
+    return true
+end
+
+function Cluster:wait_crud_is_ready_on_cluster()
+    local router = self:get_router()
+    local storages_in_topology = self:count_storages()
+
+    local WAIT_TIMEOUT = 5
+    local DELAY = 0.1
+    t.helpers.retrying(
+        {timeout = WAIT_TIMEOUT, delay = DELAY},
+        assert_expected_number_of_storages_is_running,
+        router, storages_in_topology
+    )
+
+    return self
+end
+
+function Cluster:get_router()
+    for _, server in pairs(self.servers) do
+        if server:is_router() then
+            return server
+        end
+    end
+
+    return nil
+end
+
+function Cluster:count_storages()
+    local storages_in_topology = 0
+    for _, server in pairs(self.servers) do
+        if server:is_storage() then
+            storages_in_topology = storages_in_topology + 1
+        end
+    end
+
+    return storages_in_topology
+end
+
+function Cluster:wait_modules_are_ready_on_cluster()
+    for _, group in pairs(self.config.groups) do
+        for _, rs in pairs(group.replicasets) do
+            if self.router_wait_until_ready ~= nil
+            and utils.is_replicaset_a_sharding_router(group, rs) then
+                self:eval_on_replicaset(rs, self.router_wait_until_ready)
+            end
+
+            if self.storage_wait_until_ready ~= nil
+            and utils.is_replicaset_a_sharding_storage(group, rs) then
+                self:eval_on_replicaset(rs, self.storage_wait_until_ready)
+            end
+        end
+    end
+
+    return self
+end
+
+function Cluster:cfg(new_config)
+    if new_config ~= nil then
+        self:reload_config(new_config)
+    end
+
+    return table.deepcopy(self.config)
+end
+
+function Cluster:reload_config(new_config)
+    t.assert_equals(new_config.groups, self.config.groups, 'groups reload is not supported yet')
+
+    for _, server in ipairs(self.servers) do
+        write_config(self.dirs[server], new_config)
+    end
+
+    for _, server in ipairs(self.servers) do
+        server:exec(function()
+            require('config'):reload()
+        end)
+    end
+
+    self.config = new_config
+end
+
+function Cluster:stop()
+    for _, server in ipairs(self.servers) do
+        server:stop()
+    end
+
+    return self
+end
+
+function Cluster:drop()
+    self:stop()
+    treegen.clean(self.treegen)
+
+    return self
+end
+
+function Cluster:server(alias)
+    for _, server in ipairs(self.servers) do
+        if server.alias == alias then
+            return server
+        end
+    end
+    error('Server ' .. alias .. ' not found', 2)
+end
+
+return Cluster

--- a/test/tarantool3_helpers/cluster_test.lua
+++ b/test/tarantool3_helpers/cluster_test.lua
@@ -6,7 +6,7 @@ local cluster_helpers = require('test.tarantool3_helpers.cluster')
 local g = t.group()
 
 g.before_all(function(cg)
-    helpers.skip_if_tarantool_config_unsupported()
+    helpers.skip_if_tarantool3_crud_roles_unsupported()
 
     local config = {
         credentials = {
@@ -42,6 +42,7 @@ g.before_all(function(cg)
                 sharding = {
                     roles = {'router'},
                 },
+                roles = {'roles.crud-router'},
                 replicasets = {
                     ['router'] = {
                         leader = 'router',
@@ -62,6 +63,7 @@ g.before_all(function(cg)
                 sharding = {
                     roles = {'storage'},
                 },
+                roles = {'roles.crud-storage'},
                 replicasets = {
                     ['s-1'] = {
                         leader = 's1-master',
@@ -158,7 +160,6 @@ g.before_all(function(cg)
 
             error('timeout while waiting for storage bootstrap')
         ]],
-        crud_init = true,
     })
 
     cg.cluster:start()

--- a/test/tarantool3_helpers/cluster_test.lua
+++ b/test/tarantool3_helpers/cluster_test.lua
@@ -1,0 +1,212 @@
+local t = require('luatest')
+
+local helpers = require('test.helper')
+local cluster_helpers = require('test.tarantool3_helpers.cluster')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    helpers.skip_if_tarantool_config_unsupported()
+
+    local config = {
+        credentials = {
+            users = {
+                guest = {
+                    roles = {'super'},
+                },
+                replicator = {
+                    password = 'replicating',
+                    roles = {'replication'},
+                },
+                storage = {
+                    password = 'storing-buckets',
+                    roles = {'sharding'},
+                },
+            },
+        },
+        iproto = {
+            advertise = {
+                peer = {
+                    login = 'replicator',
+                },
+                sharding = {
+                    login = 'storage',
+                },
+            },
+        },
+        sharding = {
+            bucket_count = 3000,
+        },
+        groups = {
+            routers = {
+                sharding = {
+                    roles = {'router'},
+                },
+                replicasets = {
+                    ['router'] = {
+                        leader = 'router',
+                        instances = {
+                            ['router'] = {
+                                iproto = {
+                                    listen = {{uri = 'localhost:3301'}},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            storages = {
+                app = {
+                    module = 'storage',
+                },
+                sharding = {
+                    roles = {'storage'},
+                },
+                replicasets = {
+                    ['s-1'] = {
+                        leader = 's1-master',
+                        instances = {
+                            ['s1-master'] = {
+                                iproto = {
+                                    listen = {{uri = 'localhost:3302'}},
+                                },
+                            },
+                            ['s1-replica'] = {
+                                iproto = {
+                                    listen = {{uri = 'localhost:3303'}},
+                                },
+                            },
+                        },
+                    },
+                    ['s-2'] = {
+                        leader = 's2-master',
+                        instances = {
+                            ['s2-master'] = {
+                                iproto = {
+                                    listen = {{uri = 'localhost:3304'}},
+                                },
+                            },
+                            ['s2-replica'] = {
+                                iproto = {
+                                    listen = {{uri = 'localhost:3305'}},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        replication = {
+            failover = 'manual',
+        },
+    }
+
+    cg.cluster = cluster_helpers:new({
+        config = config,
+        modules = {
+            storage = [[
+                box.watch('box.status', function()
+                    if box.info.ro then
+                        return
+                    end
+
+                    local customers_space = box.schema.space.create('customers', {
+                        format = {
+                            {name = 'id', type = 'unsigned'},
+                            {name = 'bucket_id', type = 'unsigned'},
+                            {name = 'name', type = 'string'},
+                            {name = 'age', type = 'number'},
+                        },
+                        if_not_exists = true,
+                        engine = 'memtx',
+                    })
+
+                    customers_space:create_index('id', {
+                        parts = {{field = 'id'}},
+                        if_not_exists = true,
+                    })
+
+                    customers_space:create_index('bucket_id', {
+                        parts = {{field = 'bucket_id'}},
+                        unique = false,
+                        if_not_exists = true,
+                    })
+
+                    box.schema.func.create('_is_schema_ready', {
+                        language = 'LUA',
+                        body = 'function() return true end',
+                        if_not_exists = true,
+                    })
+                end)
+            ]],
+        },
+        storage_wait_until_ready = [[
+            local clock = require('clock')
+            local fiber = require('fiber')
+
+            local TIMEOUT = 60
+            local start = clock.monotonic()
+
+            while clock.monotonic() - start < TIMEOUT do
+                local status, ready = pcall(box.schema.func.call, '_is_schema_ready')
+                if status and ready then
+                    return true
+                end
+
+                fiber.sleep(0.05)
+            end
+
+            error('timeout while waiting for storage bootstrap')
+        ]],
+        crud_init = true,
+    })
+
+    cg.cluster:start()
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_router_provides_crud_version = function(cg)
+    local result, err = cg.cluster:server('router'):exec(function()
+        local crud = require('crud')
+        return crud._VERSION
+    end)
+    t.assert_equals(err, nil)
+    t.assert_equals(result, require('crud')._VERSION)
+end
+
+g.test_router_tags = function(cg)
+    local router = cg.cluster:server('router')
+    t.assert_equals(router:is_router(), true)
+    t.assert_equals(router:is_storage(), false)
+end
+
+g.test_storage_tags = function(cg)
+    local storage = cg.cluster:server('s1-master')
+    t.assert_equals(storage:is_router(), false)
+    t.assert_equals(storage:is_storage(), true)
+end
+
+g.test_cluster_supports_basic_insert_get_object = function(cg)
+    cg.cluster:server('router'):exec(function()
+        local crud = require('crud')
+
+        local _, err = crud.insert_object('customers',
+            {id = 1, name = 'Vincent Brooks', age = 32},
+            {noreturn = true}
+        )
+        t.assert_equals(err, nil)
+
+        local result, err = crud.get('customers', 1, {mode = 'write'})
+        t.assert_equals(err, nil)
+        t.assert_equals(#result.rows, 1, 'Tuple found')
+
+        local objects, err = crud.unflatten_rows(result.rows, result.metadata)
+        t.assert_equals(err, nil)
+        t.assert_equals(objects[1].id, 1)
+        t.assert_equals(objects[1].name, 'Vincent Brooks')
+        t.assert_equals(objects[1].age, 32)
+    end)
+end

--- a/test/tarantool3_helpers/config.lua
+++ b/test/tarantool3_helpers/config.lua
@@ -1,0 +1,212 @@
+local checks = require('checks')
+
+local utils = require('test.tarantool3_helpers.utils')
+
+local function set_listen_uris_to_instances(groups)
+    local port = 3301
+
+    for _, group in pairs(groups) do
+        for _, replicaset in pairs(group.replicasets) do
+            for _, instance in pairs(replicaset.instances) do
+                instance.iproto = {listen = {{uri = ('localhost:%d'):format(port)}}}
+
+                port = port + 1
+            end
+        end
+    end
+
+    return groups
+end
+
+local Script = {
+    new = function(self)
+        local object = {_contents = ''}
+
+        setmetatable(object, self)
+        self.__index = self
+        return object
+    end,
+    append = function(self, code)
+        self._contents = self._contents .. ("%s;\n"):format(code)
+    end,
+    append_require_and_run = function(self, to_require, to_run)
+        self:append((
+            "do\n" ..
+            "    local to_require = %q\n" ..
+            "    local to_run = %q\n" ..
+
+            "    local module = require(to_require)\n" ..
+            "    local method = to_run\n" ..
+            "    if module[method] ~= nil then\n" ..
+            "        module[method]()\n" ..
+            "    end\n" ..
+            "end"
+        ):format(to_require, to_run))
+    end,
+    dump = function(self)
+        return self._contents
+    end,
+}
+
+local function generate_modules(storage_entrypoint, router_entrypoint, all_entrypoint)
+    local router = Script:new()
+    local storage = Script:new()
+    local router_and_storage = Script:new()
+
+    if storage_entrypoint ~= nil then
+        storage:append_require_and_run(storage_entrypoint, 'init')
+        router_and_storage:append_require_and_run(storage_entrypoint, 'init')
+    end
+
+    if router_entrypoint ~= nil then
+        router:append_require_and_run(router_entrypoint, 'init')
+        router_and_storage:append_require_and_run(router_entrypoint, 'init')
+    end
+
+    if all_entrypoint ~= nil then
+        router:append_require_and_run(all_entrypoint, 'init')
+        storage:append_require_and_run(all_entrypoint, 'init')
+        router_and_storage:append_require_and_run(all_entrypoint, 'init')
+    end
+
+    return {
+        ['router'] = router:dump(),
+        ['storage'] = storage:dump(),
+        ['router_and_storage'] = router_and_storage:dump(),
+    }
+end
+
+local function generate_wait_until_ready_evals(storage_entrypoint, router_entrypoint, all_entrypoint)
+    local router = Script:new()
+    local storage = Script:new()
+
+    if storage_entrypoint ~= nil then
+        storage:append_require_and_run(storage_entrypoint, 'wait_until_ready')
+    end
+
+    if router_entrypoint ~= nil then
+        router:append_require_and_run(router_entrypoint, 'wait_until_ready')
+    end
+
+    if all_entrypoint ~= nil then
+        router:append_require_and_run(all_entrypoint, 'wait_until_ready')
+        storage:append_require_and_run(all_entrypoint, 'wait_until_ready')
+    end
+
+    return {
+        ['router'] = router:dump(),
+        ['storage'] = storage:dump(),
+    }
+end
+
+local function set_app_module(app, is_router, is_storage)
+    if is_router and is_storage then
+        app.module = 'router_and_storage'
+    elseif is_router then
+        app.module = 'router'
+    elseif is_storage then
+        app.module = 'storage'
+    end
+
+    return app
+end
+
+local function set_modules_to_groups(groups)
+    for _, group in pairs(groups) do
+        group.app = group.app or {}
+
+        local is_router = utils.is_group_a_sharding_router(group)
+        local is_storage = utils.is_group_a_sharding_storage(group)
+
+        group.app = set_app_module(group.app, is_router, is_storage)
+    end
+
+    return groups
+end
+
+-- Do not deepcopy anything here.
+local function new(cfg)
+    checks({
+        groups = 'table',
+        bucket_count = 'number',
+        storage_entrypoint = '?string',
+        router_entrypoint = '?string',
+        all_entrypoint = '?string',
+        env = '?table',
+        crud_init = '?boolean',
+    })
+
+    local modules = generate_modules(
+        cfg.storage_entrypoint,
+        cfg.router_entrypoint,
+        cfg.all_entrypoint
+    )
+
+    local credentials = {
+        users = {
+            guest = {
+                roles = {'super'},
+            },
+            replicator = {
+                password = 'replicating',
+                roles = {'replication'},
+            },
+            storage = {
+                password = 'storing-buckets',
+                roles = {'sharding'},
+            },
+        },
+    }
+
+    local iproto = {
+        advertise = {
+            peer = {
+                login = 'replicator',
+            },
+            sharding = {
+                login = 'storage'
+            },
+        },
+    }
+
+    local sharding = {
+        bucket_count = cfg.bucket_count,
+    }
+
+    local groups = cfg.groups
+    groups = set_listen_uris_to_instances(groups)
+    groups = set_modules_to_groups(groups)
+
+    local replication = {
+        failover = 'manual',
+        -- https://github.com/tarantool/tarantool/blob/e01fe8f7144eebc64249ab60a83f656cb4a11dc0/test/config-luatest/cbuilder.lua#L72-L87
+        timeout = 0.1,
+    }
+
+    local config = {
+        credentials = credentials,
+        iproto = iproto,
+        sharding = sharding,
+        groups = groups,
+        replication = replication,
+    }
+
+    local wait_until_ready_evals = generate_wait_until_ready_evals(
+        cfg.storage_entrypoint,
+        cfg.router_entrypoint,
+        cfg.all_entrypoint
+    )
+
+    return {
+        config = config,
+        modules = modules,
+        crud_init = cfg.crud_init,
+        env = cfg.env,
+        router_wait_until_ready = wait_until_ready_evals.router,
+        storage_wait_until_ready = wait_until_ready_evals.storage,
+    }
+end
+
+return {
+    new = new,
+}

--- a/test/tarantool3_helpers/config.lua
+++ b/test/tarantool3_helpers/config.lua
@@ -133,7 +133,6 @@ local function new(cfg)
         router_entrypoint = '?string',
         all_entrypoint = '?string',
         env = '?table',
-        crud_init = '?boolean',
     })
 
     local modules = generate_modules(
@@ -200,7 +199,6 @@ local function new(cfg)
     return {
         config = config,
         modules = modules,
-        crud_init = cfg.crud_init,
         env = cfg.env,
         router_wait_until_ready = wait_until_ready_evals.router,
         storage_wait_until_ready = wait_until_ready_evals.storage,

--- a/test/tarantool3_helpers/server.lua
+++ b/test/tarantool3_helpers/server.lua
@@ -1,0 +1,266 @@
+-- Borrowed from https://github.com/tarantool/tarantool/blob/1a5e3bf3c3badd14ffc37b2b31e47554e4778cde/test/luatest_helpers/server.lua
+
+local fun = require('fun')
+local yaml = require('yaml')
+local urilib = require('uri')
+local fio = require('fio')
+local luatest = require('luatest')
+
+local path = require('test.path')
+local vclock_utils = require('test.vshard_helpers.vclock')
+
+local WAIT_TIMEOUT = 60
+local WAIT_DELAY = 0.1
+
+-- Join paths in an intuitive way.
+--
+-- If a component is nil, it is skipped.
+--
+-- If a component is an absolute path, it skips all the previous
+-- components.
+--
+-- The wrapper is written for two components for simplicity.
+local function pathjoin(a, b)
+    -- No first path -- skip it.
+    if a == nil then
+        return b
+    end
+    -- No second path -- skip it.
+    if b == nil then
+        return a
+    end
+    -- The absolute path is checked explicitly due to gh-8816.
+    if b:startswith('/') then
+        return b
+    end
+    return fio.pathjoin(a, b)
+end
+
+local function find_instance(groups, instance_name)
+    for _, group in pairs(groups or {}) do
+        for _, replicaset in pairs(group.replicasets or {}) do
+            local instance = (replicaset.instances or {})[instance_name]
+
+            if instance ~= nil then
+                return group, replicaset, instance
+            end
+        end
+    end
+
+    return nil, nil, nil
+end
+
+-- Determine advertise URI for given instance from a cluster
+-- configuration.
+local function find_advertise_uri(config, instance_name, dir)
+    if config == nil or next(config) == nil then
+        return nil
+    end
+
+    -- Determine listen and advertise options that are in effect
+    -- for the given instance.
+    local advertise = nil
+    local listen = nil
+
+    local group, replicaset, instance = find_instance(config.groups, instance_name)
+
+    if instance ~= nil then
+        if instance.iproto ~= nil then
+            if instance.iproto.advertise ~= nil then
+                advertise = advertise or instance.iproto.advertise.client
+            end
+            listen = listen or instance.iproto.listen
+        end
+        if replicaset.iproto ~= nil then
+            if replicaset.iproto.advertise ~= nil then
+                advertise = advertise or replicaset.iproto.advertise.client
+            end
+            listen = listen or replicaset.iproto.listen
+        end
+        if group.iproto ~= nil then
+            if group.iproto.advertise ~= nil then
+                advertise = advertise or group.iproto.advertise.client
+            end
+            listen = listen or group.iproto.listen
+        end
+    end
+
+    if config.iproto ~= nil then
+        if config.iproto.advertise ~= nil then
+            advertise = advertise or config.iproto.advertise.client
+        end
+        listen = listen or config.iproto.listen
+    end
+
+    local uris
+    if advertise ~= nil then
+        uris = {{uri = advertise}}
+    else
+        uris = listen
+    end
+
+    for _, uri in ipairs(uris or {}) do
+        uri = table.copy(uri)
+        uri.uri = uri.uri:gsub('{{ *instance_name *}}', instance_name)
+        uri.uri = uri.uri:gsub('unix/:%./', ('unix/:%s/'):format(dir))
+        local u = urilib.parse(uri)
+        if u.ipv4 ~= '0.0.0.0' and u.ipv6 ~= '::' and u.service ~= '0' then
+            return uri
+        end
+    end
+    error('No suitable URI to connect is found')
+end
+
+local Server = luatest.Server:inherit({})
+
+-- Adds the following options:
+--
+-- * config_file (string)
+--
+--   An argument of the `--config <...>` CLI option.
+--
+--   Used to deduce advertise URI to connect net.box to the
+--   instance.
+--
+--   The special value '' means running without `--config <...>`
+--   CLI option (but still pass `--name <alias>`).
+-- * remote_config (table)
+--
+--   If `config_file` is not passed, this config value is used to
+--   deduce the advertise URI to connect net.box to the instance.
+Server.constructor_checks = fun.chain(Server.constructor_checks, {
+    config_file = 'string',
+    remote_config = '?table',
+}):tomap()
+
+function Server:new(object, extra)
+    extra = extra or {}
+    extra._tags = {}
+
+    return getmetatable(self).new(self, object, extra)
+end
+
+function Server:initialize()
+    if self.config_file ~= nil then
+        self.command = arg[-1]
+
+        self.args = fun.chain(self.args or {}, {
+            '--name', self.alias
+        }):totable()
+
+        if self.config_file ~= '' then
+            table.insert(self.args, '--config')
+            table.insert(self.args, self.config_file)
+
+            -- Take into account self.chdir to calculate a config
+            -- file path.
+            local config_file_path = pathjoin(self.chdir, self.config_file)
+
+            -- Read the provided config file.
+            local fh, err = fio.open(config_file_path, {'O_RDONLY'})
+            if fh == nil then
+                error(('Unable to open file %q: %s'):format(config_file_path,
+                    err))
+            end
+            self.config = yaml.decode(fh:read())
+            fh:close()
+        end
+
+        if self.net_box_uri == nil then
+            local config = self.config or self.remote_config
+
+            -- NB: listen and advertise URIs are relative to
+            -- process.work_dir, which, in turn, is relative to
+            -- self.chdir.
+            local work_dir
+            if config.process ~= nil and config.process.work_dir ~= nil then
+                work_dir = config.process.work_dir
+            end
+            local dir = pathjoin(self.chdir, work_dir)
+            self.net_box_uri = find_advertise_uri(config, self.alias, dir)
+        end
+    end
+
+    self.env = self.env or {}
+
+    if self.env['LUA_PATH'] == nil then
+        self.env['LUA_PATH'] = path.LUA_PATH
+    end
+
+    getmetatable(getmetatable(self)).initialize(self)
+end
+
+function Server:set_tag(name, value)
+    self._tags[name] = value
+end
+
+function Server:get_tag(name)
+    return self._tags[name]
+end
+
+function Server:set_storage_tag(value)
+    self:set_tag('storage', value)
+end
+
+function Server:set_router_tag(value)
+    self:set_tag('router', value)
+end
+
+function Server:is_storage()
+    local is_storage = self:get_tag('storage')
+    assert(is_storage ~= nil, 'please, prepare server before using this handle')
+    return is_storage
+end
+
+function Server:is_router()
+    local is_router = self:get_tag('router')
+    assert(is_router ~= nil, 'please, prepare server before using this handle')
+    return is_router
+end
+
+function Server:connect_net_box()
+    getmetatable(getmetatable(self)).connect_net_box(self)
+
+    if self.config_file == nil then
+        return
+    end
+
+    if not self.net_box then
+        return
+    end
+
+    -- Replace the ready condition.
+    local saved_eval = self.net_box.eval
+    self.net_box.eval = function(self, expr, args, opts)
+        if expr == 'return _G.ready' then
+            expr = "return require('config'):info().status == 'ready' or " ..
+                          "require('config'):info().status == 'check_warnings'"
+        end
+        return saved_eval(self, expr, args, opts)
+    end
+end
+
+function Server:wait_for_rw()
+    luatest.helpers.retrying({timeout = WAIT_TIMEOUT, delay = WAIT_DELAY}, function()
+        local ro, err = self:exec(function()
+            return box.info.ro
+        end)
+
+        luatest.assert_equals(err, nil)
+        luatest.assert_equals(ro, false)
+    end)
+end
+
+-- Enable the startup waiting if the advertise URI of the instance
+-- is determined.
+function Server:start(opts)
+    opts = opts or {}
+    if self.config_file and opts.wait_until_ready == nil then
+        opts.wait_until_ready = self.net_box_uri ~= nil
+    end
+    getmetatable(getmetatable(self)).start(self, opts)
+end
+
+vclock_utils.extend_with_vclock_methods(Server)
+
+return Server

--- a/test/tarantool3_helpers/treegen.lua
+++ b/test/tarantool3_helpers/treegen.lua
@@ -1,0 +1,146 @@
+-- Borrowed from https://github.com/tarantool/tarantool/blob/b5864c40a0bfc8f26cc65189f3a5c76e441a9396/test/treegen.lua
+
+-- Working tree generator.
+--
+-- Generates a tree of Lua files using provided templates and
+-- filenames. Reworked to be used inside the Cluster.
+
+local fio = require('fio')
+local log = require('log')
+local fun = require('fun')
+
+local treegen = {}
+
+local function find_template(storage, script)
+    for _, template_def in ipairs(storage.templates) do
+        if script:match(template_def.pattern) then
+            return template_def.template
+        end
+    end
+    error(("treegen: can't find a template for script %q"):format(script))
+end
+
+-- Write provided script into the given directory.
+function treegen.write_script(dir, script, body)
+    local script_abspath = fio.pathjoin(dir, script)
+    local flags = {'O_CREAT', 'O_WRONLY', 'O_TRUNC'}
+    local mode = tonumber('644', 8)
+
+    local scriptdir_abspath = fio.dirname(script_abspath)
+    log.info(('Creating a directory: %s'):format(scriptdir_abspath))
+    fio.mktree(scriptdir_abspath)
+
+    log.info(('Writing a script: %s'):format(script_abspath))
+    local fh = fio.open(script_abspath, flags, mode)
+    fh:write(body)
+    fh:close()
+    return script_abspath
+end
+
+-- Generate a script that follows a template and write it at the
+-- given path in the given directory.
+local function gen_script(storage, dir, script, replacements)
+    local template = find_template(storage, script)
+    local replacements = fun.chain({script = script}, replacements):tomap()
+    local body = template:gsub('<(.-)>', replacements)
+    treegen.write_script(dir, script, body)
+end
+
+function treegen.init(storage)
+    storage.tempdirs = {}
+    storage.templates = {}
+end
+
+-- Remove all temporary directories created by the test
+-- unless KEEP_DATA environment variable is set to a
+-- non-empty value.
+function treegen.clean(storage)
+    local dirs = table.copy(storage.tempdirs) or {}
+    storage.tempdirs = nil
+
+    local keep_data = (os.getenv('KEEP_DATA') or '') ~= ''
+
+    for _, dir in ipairs(dirs) do
+        if keep_data then
+            log.info(('Left intact due to KEEP_DATA env var: %s'):format(dir))
+        else
+            log.info(('Recursively removing: %s'):format(dir))
+            fio.rmtree(dir)
+        end
+    end
+
+    storage.templates = nil
+end
+
+function treegen.add_template(storage, pattern, template)
+    table.insert(storage.templates, {
+        pattern = pattern,
+        template = template,
+    })
+end
+
+-- Create a temporary directory with given scripts.
+--
+-- The scripts are generated using templates added by
+-- treegen.add_template().
+--
+-- Example for {'foo/bar.lua', 'baz.lua'}:
+--
+-- /
+-- + tmp/
+--   + rfbWOJ/
+--     + foo/
+--     | + bar.lua
+--     + baz.lua
+--
+-- The return value is '/tmp/rfbWOJ' for this example.
+function treegen.prepare_directory(storage, scripts, replacements)
+    local replacements = replacements or {}
+
+    assert(type(scripts) == 'table')
+    assert(type(replacements) == 'table')
+
+    local dir = fio.tempdir()
+
+    -- fio.tempdir() follows the TMPDIR environment variable.
+    -- If it ends with a slash, the return value contains a double
+    -- slash in the middle: for example, if TMPDIR=/tmp/, the
+    -- result is like `/tmp//rfbWOJ`.
+    --
+    -- It looks harmless on the first glance, but this directory
+    -- path may be used later to form an URI for a Unix domain
+    -- socket. As result the URI looks like
+    -- `unix/:/tmp//rfbWOJ/instance-001.iproto`.
+    --
+    -- It confuses net_box.connect(): it reports EAI_NONAME error
+    -- from getaddrinfo().
+    --
+    -- It seems, the reason is a peculiar of the URI parsing:
+    --
+    -- tarantool> uri.parse('unix/:/foo/bar.iproto')
+    -- ---
+    -- - host: unix/
+    --   service: /foo/bar.iproto
+    --   unix: /foo/bar.iproto
+    -- ...
+    --
+    -- tarantool> uri.parse('unix/:/foo//bar.iproto')
+    -- ---
+    -- - host: unix
+    --   path: /foo//bar.iproto
+    -- ...
+    --
+    -- Let's normalize the path using fio.abspath(), which
+    -- eliminates the double slashes.
+    dir = fio.abspath(dir)
+
+    table.insert(storage.tempdirs, dir)
+
+    for _, script in ipairs(scripts) do
+        gen_script(storage, dir, script, replacements)
+    end
+
+    return dir
+end
+
+return treegen

--- a/test/tarantool3_helpers/utils.lua
+++ b/test/tarantool3_helpers/utils.lua
@@ -40,9 +40,34 @@ local function is_group_a_sharding_storage(group)
     return is_group_has_sharding_role(group, 'storage')
 end
 
+local function is_group_a_crud_router(group)
+    return has_role(group, 'roles.crud-router')
+end
+
+local function is_group_a_crud_storage(group)
+    return has_role(group, 'roles.crud-storage')
+end
+
+local function is_replicaset_has_role(group, replicaset, role)
+    return has_role(group, role) or has_role(replicaset, role)
+end
+
+local function is_replicaset_a_crud_router(group, replicaset)
+    return is_replicaset_has_role(group, replicaset, 'roles.crud-router')
+end
+
+local function is_replicaset_a_crud_storage(group, replicaset)
+    return is_replicaset_has_role(group, replicaset, 'roles.crud-storage')
+end
+
 return {
     is_group_a_sharding_router = is_group_a_sharding_router,
     is_group_a_sharding_storage = is_group_a_sharding_storage,
     is_replicaset_a_sharding_router = is_replicaset_a_sharding_router,
     is_replicaset_a_sharding_storage = is_replicaset_a_sharding_storage,
+
+    is_group_a_crud_router = is_group_a_crud_router,
+    is_group_a_crud_storage = is_group_a_crud_storage,
+    is_replicaset_a_crud_router = is_replicaset_a_crud_router,
+    is_replicaset_a_crud_storage = is_replicaset_a_crud_storage,
 }

--- a/test/tarantool3_helpers/utils.lua
+++ b/test/tarantool3_helpers/utils.lua
@@ -1,0 +1,48 @@
+local function has_role(object, role)
+    if object == nil then
+        return false
+    end
+
+    for _, v in ipairs(object.roles or {}) do
+        if v == role then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function is_group_has_sharding_role(group, role)
+    return has_role(group.sharding, role)
+end
+
+local function is_replicaset_has_sharding_role(group, replicaset, role)
+    if is_group_has_sharding_role(group, role) then
+        return true
+    end
+
+    return has_role(replicaset.sharding, role)
+end
+
+local function is_replicaset_a_sharding_router(group, replicaset)
+    return is_replicaset_has_sharding_role(group, replicaset, 'router')
+end
+
+local function is_replicaset_a_sharding_storage(group, replicaset)
+    return is_replicaset_has_sharding_role(group, replicaset, 'storage')
+end
+
+local function is_group_a_sharding_router(group)
+    return is_group_has_sharding_role(group, 'router')
+end
+
+local function is_group_a_sharding_storage(group)
+    return is_group_has_sharding_role(group, 'storage')
+end
+
+return {
+    is_group_a_sharding_router = is_group_a_sharding_router,
+    is_group_a_sharding_storage = is_group_a_sharding_storage,
+    is_replicaset_a_sharding_router = is_replicaset_a_sharding_router,
+    is_replicaset_a_sharding_storage = is_replicaset_a_sharding_storage,
+}

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -1,71 +1,11 @@
-local fio = require('fio')
-
 local t = require('luatest')
 
 local helpers = require('test.helper')
 
 local pgroup = t.group('call', helpers.backend_matrix())
 
-local vshard_cfg_template = {
-    sharding = {
-        ['s-1'] = {
-            replicas = {
-                ['s1-master'] = {
-                    master = true,
-                },
-                ['s1-replica'] = {},
-            },
-        },
-        ['s-2'] = {
-            replicas = {
-                ['s2-master'] = {
-                    master = true,
-                },
-                ['s2-replica'] = {},
-            },
-        },
-    },
-    bucket_count = 3000,
-    all_entrypoint = helpers.entrypoint_vshard_all('srv_say_hi'),
-    crud_init = true,
-}
-
-local cartridge_cfg_template = {
-    datadir = fio.tempdir(),
-    server_command = helpers.entrypoint_cartridge('srv_say_hi'),
-    use_vshard = true,
-    replicasets = {
-        {
-            uuid = helpers.uuid('a'),
-            alias = 'router',
-            roles = { 'crud-router' },
-            servers = {
-                { instance_uuid = helpers.uuid('a', 1), alias = 'router' },
-            },
-        },
-        {
-            uuid = helpers.uuid('b'),
-            alias = 's-1',
-            roles = { 'crud-storage' },
-            servers = {
-                { instance_uuid = helpers.uuid('b', 1), alias = 's1-master' },
-                { instance_uuid = helpers.uuid('b', 2), alias = 's1-replica' },
-            },
-        },
-        {
-            uuid = helpers.uuid('c'),
-            alias = 's-2',
-            roles = { 'crud-storage' },
-            servers = {
-                { instance_uuid = helpers.uuid('c', 1), alias = 's2-master' },
-                { instance_uuid = helpers.uuid('c', 2), alias = 's2-replica' },
-            },
-        }
-    },
-}
-
 pgroup.before_all(function(g)
-    helpers.start_cluster(g, cartridge_cfg_template, vshard_cfg_template)
+    helpers.start_default_cluster(g, 'srv_say_hi')
 
     g.clear_vshard_calls = function()
         g.router:call('clear_vshard_calls')

--- a/test/unit/not_initialized_test.lua
+++ b/test/unit/not_initialized_test.lua
@@ -76,7 +76,6 @@ local tarantool3_cluster_cfg_template = {
     },
     bucket_count = 20,
     storage_entrypoint = helpers.entrypoint_vshard_storage('srv_not_initialized'),
-    crud_init = false,
 }
 
 pgroup.before_all(function(g)

--- a/test/unit/not_initialized_test.lua
+++ b/test/unit/not_initialized_test.lua
@@ -45,10 +45,47 @@ local cartridge_cfg_template = {
     },
 }
 
+local tarantool3_cluster_cfg_template = {
+    groups = {
+        routers = {
+            sharding = {
+                roles = {'router'},
+            },
+            replicasets = {
+                ['router'] = {
+                    leader = 'router',
+                    instances = {
+                        ['router'] = {},
+                    },
+                },
+            },
+        },
+        storages = {
+            sharding = {
+                roles = {'storage'},
+            },
+            replicasets = {
+                ['s-1'] = {
+                    leader = 's1-master',
+                    instances = {
+                        ['s1-master'] = {},
+                    },
+                },
+            },
+        },
+    },
+    bucket_count = 20,
+    storage_entrypoint = helpers.entrypoint_vshard_storage('srv_not_initialized'),
+    crud_init = false,
+}
+
 pgroup.before_all(function(g)
-    helpers.start_cluster(g, cartridge_cfg_template, vshard_cfg_template, {
-        wait_crud_is_ready = false,
-    })
+    helpers.start_cluster(g,
+        cartridge_cfg_template,
+        vshard_cfg_template,
+        tarantool3_cluster_cfg_template,
+        {wait_crud_is_ready = false}
+    )
 
     g.router = g.cluster:server('router')
 end)

--- a/test/unit/utils_test.lua
+++ b/test/unit/utils_test.lua
@@ -27,7 +27,7 @@ end
 
 
 g.test_get_tarantool_version = function()
-    local major, minor, patch, suffix = utils.get_tarantool_version()
+    local major, minor, patch, suffix, commits_since = utils.get_tarantool_version()
 
     t.assert_gt(major, 0, 'Tarantool version major is a positive number')
     t.assert_ge(minor, 0, 'Tarantool version minor is a non-negative number')
@@ -35,6 +35,10 @@ g.test_get_tarantool_version = function()
 
     if suffix ~= nil then
         t.assert_type(suffix, 'string')
+    end
+
+    if commits_since ~= nil then
+        t.assert_type(commits_since, 'number')
     end
 end
 
@@ -190,90 +194,119 @@ end
 -- Pairwise-like testing cases since there are too many combinations.
 local is_version_ge_cases = {
     case_1 = {
-        args = {2, 10, 5, nil,
-                2, 10, 5, nil},
+        args = {2, 10, 5, nil, nil,
+                2, 10, 5, nil, nil},
         le = true,
     },
     case_2 = {
-        args = {2, 10, 5, 'entrypoint',
-                2, 10, 5, 'entrypoint'},
+        args = {2, 10, 5, 'entrypoint', nil,
+                2, 10, 5, 'entrypoint', nil},
         le = true,
     },
     case_3 = {
-        args = {2, 10, 5, nil,
-                2, 10, 5, 'entrypoint'},
+        args = {2, 10, 5, nil, nil,
+                2, 10, 5, 'entrypoint', nil},
     },
     case_4 = {
-        args = {2, 10, 5, 'alpha3',
-                2, 10, 5, 'alpha1'},
+        args = {2, 10, 5, 'alpha3', nil,
+                2, 10, 5, 'alpha1', nil},
     },
     case_5 = {
-        args = {2, 10, 5, 'rc1',
-                2, 10, 5, 'alpha1'},
+        args = {2, 10, 5, 'rc1', nil,
+                2, 10, 5, 'alpha1', nil},
     },
     case_6 = {
-        args = {2, 10, 5, nil,
-                2, 10, 4, nil},
+        args = {2, 10, 5, nil, nil,
+                2, 10, 4, nil, nil},
     },
     case_7 = {
-        args = {2, 10, 4, nil,
-                2, 9, 5, nil},
+        args = {2, 10, 4, nil, nil,
+                2, 9, 5, nil, nil},
     },
     case_8 = {
-        args = {2, 10, 5, nil,
-                2, 9, 4, nil},
+        args = {2, 10, 5, nil, nil,
+                2, 9, 4, nil, nil},
     },
     case_9 = {
-        args = {2, 10, 5, 'alpha1',
-                2, 9, 4, nil},
+        args = {2, 10, 5, 'alpha1', nil,
+                2, 9, 4, nil, nil},
     },
     case_10 = {
-        args = {2, 10, 5, nil,
-                2, 9, 4, 'alpha1'},
+        args = {2, 10, 5, nil, nil,
+                2, 9, 4, 'alpha1', nil},
     },
     case_11 = {
-        args = {3, 10, 5, nil,
-                2, 10, 5, nil},
+        args = {3, 10, 5, nil, nil,
+                2, 10, 5, nil, nil},
     },
     case_12 = {
-        args = {3, 9, 5, nil,
-                2, 10, 5, nil},
+        args = {3, 9, 5, nil, nil,
+                2, 10, 5, nil, nil},
     },
     case_13 = {
-        args = {3, 10, 5, nil,
-                2, 9, 5, nil},
+        args = {3, 10, 5, nil, nil,
+                2, 9, 5, nil, nil},
     },
     case_14 = {
-        args = {3, 10, 4, nil,
-                2, 10, 5, nil},
+        args = {3, 10, 4, nil, nil,
+                2, 10, 5, nil, nil},
     },
     case_15 = {
-        args = {3, 10, 5, nil,
-                2, 10, 4, nil},
+        args = {3, 10, 5, nil, nil,
+                2, 10, 4, nil, nil},
     },
     case_16 = {
-        args = {3, 10, 5, 'alpha1',
-                2, 10, 5, nil},
+        args = {3, 10, 5, 'alpha1', nil,
+                2, 10, 5, nil, nil},
     },
     case_17 = {
-        args = {3, 10, 5, nil,
-                2, 10, 5, 'alpha1'},
+        args = {3, 10, 5, nil, nil,
+                2, 10, 5, 'alpha1', nil},
     },
     case_18 = {
-        args = {3, 10, 5, 'alpha1',
-                2, 10, 5, nil},
+        args = {3, 10, 5, 'alpha1', nil,
+                2, 10, 5, nil, nil},
     },
     case_19 = {
-        args = {3, 10, 4, nil,
-                2, 10, 5, 'alpha1'},
+        args = {3, 10, 4, nil, nil,
+                2, 10, 5, 'alpha1', nil},
     },
     case_20 = {
-        args = {3, 9, 5, nil,
-                2, 10, 5, 'alpha1'},
+        args = {3, 9, 5, nil, nil,
+                2, 10, 5, 'alpha1', nil},
     },
     case_21 = {
-        args = {3, 9, 5, 'rc1',
-                2, 10, 4, nil},
+        args = {3, 9, 5, 'rc1', nil,
+                2, 10, 4, nil, nil},
+    },
+    case_22 = {
+        args = {2, 10, 5, nil, 0,
+                2, 10, 5, nil, 0},
+        le = true,
+    },
+    case_23 = {
+        args = {2, 10, 5, nil, 10,
+                2, 10, 5, nil, 0},
+    },
+    case_24 = {
+        args = {2, 10, 5, 'beta2', 0,
+                2, 10, 5, 'alpha1', 10},
+    },
+    case_25 = {
+        args = {2, 10, 5, 'beta2', 15,
+                2, 10, 5, 'alpha1', 10},
+    },
+    case_26 = {
+        args = {2, 10, 6, nil, 0,
+                2, 10, 5, nil, 10},
+    },
+    case_27 = {
+        args = {2, 11, 5, nil, 0,
+                2, 10, 5, nil, 10},
+    },
+    case_28 = {
+        args = {3, 10, 5, nil, 0,
+                2, 10, 5, nil, 10},
     },
 }
 
@@ -289,8 +322,8 @@ for name, case in pairs(is_version_ge_cases) do
             le = case.le
         end
 
-        t.assert_equals(utils.is_version_ge(unpack_N(case.args, 8)), ge)
-        t.assert_equals(utils.is_version_ge(unpack_N_swap_halves(case.args, 8)), le)
+        t.assert_equals(utils.is_version_ge(unpack_N(case.args, 10)), ge)
+        t.assert_equals(utils.is_version_ge(unpack_N_swap_halves(case.args, 10)), le)
     end
 end
 
@@ -298,21 +331,27 @@ end
 -- Even more cases here, rely on utils.is_version_ge tests.
 local is_version_in_range_cases = {
     case_1 = {
-        args = {2, 11, 0, 'entrypoint',
-                2, 10, 4, nil,
-                3, 9, 5, 'rc1'},
+        args = {2, 11, 0, 'entrypoint', nil,
+                2, 10, 4, nil, nil,
+                3, 9, 5, 'rc1', nil},
         res = true,
     },
     case_2 = {
-        args = {3, 9, 0, nil,
-                2, 10, 4, nil,
-                3, 4, 5, 'rc1'},
+        args = {3, 9, 0, nil, nil,
+                2, 10, 4, nil, nil,
+                3, 4, 5, 'rc1', nil},
+        res = false,
+    },
+    case_3 = {
+        args = {3, 9, 0, nil, nil,
+                2, 10, 4, nil, nil,
+                3, 4, 5, 'rc1', nil},
         res = false,
     },
 }
 
 for name, case in pairs(is_version_in_range_cases) do
     g['test_is_version_range_' .. name] = function()
-        t.assert_equals(utils.is_version_in_range(unpack_N(case.args, 12)), case.res)
+        t.assert_equals(utils.is_version_in_range(unpack_N(case.args, 15)), case.res)
     end
 end

--- a/test/vshard_helpers/instances/utils.lua
+++ b/test/vshard_helpers/instances/utils.lua
@@ -7,7 +7,6 @@ local function default_cfg()
     return {
         work_dir = os.getenv('TARANTOOL_WORKDIR'),
         listen = os.getenv('TARANTOOL_LISTEN'),
-        log = ('%s/%s.log'):format(os.getenv('TARANTOOL_WORKDIR'), os.getenv('TARANTOOL_ALIAS')),
     }
 end
 

--- a/test/vshard_helpers/server.lua
+++ b/test/vshard_helpers/server.lua
@@ -5,7 +5,6 @@ local fiber = require('fiber')
 local fio = require('fio')
 local fun = require('fun')
 local json = require('json')
-local errno = require('errno')
 
 local checks = require('checks')
 local luatest = require('luatest')
@@ -275,70 +274,6 @@ end
 function Server:drop()
     self:stop()
     self:cleanup()
-end
-
--- A copy of test_run:grep_log.
-function Server:grep_log(what, bytes, opts)
-    local opts = opts or {}
-    local noreset = opts.noreset or false
-    -- if instance has crashed provide filename to use grep_log
-    local filename = opts.filename or self:eval('return box.cfg.log')
-    local file = fio.open(filename, {'O_RDONLY', 'O_NONBLOCK'})
-
-    local function fail(msg)
-        local err = errno.strerror()
-        if file ~= nil then
-            file:close()
-        end
-        error(string.format("%s: %s: %s", msg, filename, err))
-    end
-
-    if file == nil then
-        fail("Failed to open log file")
-    end
-    io.flush() -- attempt to flush stdout == log fd
-    local filesize = file:seek(0, 'SEEK_END')
-    if filesize == nil then
-        fail("Failed to get log file size")
-    end
-    local bytes = bytes or 65536 -- don't read whole log - it can be huge
-    bytes = bytes > filesize and filesize or bytes
-    if file:seek(-bytes, 'SEEK_END') == nil then
-        fail("Failed to seek log file")
-    end
-    local found, buf
-    repeat -- read file in chunks
-        local s = file:read(2048)
-        if s == nil then
-            fail("Failed to read log file")
-        end
-        local pos = 1
-        repeat -- split read string in lines
-            local endpos = string.find(s, '\n', pos)
-            endpos = endpos and endpos - 1 -- strip terminating \n
-            local line = string.sub(s, pos, endpos)
-            if endpos == nil and s ~= '' then
-                -- line doesn't end with \n or eof, append it to buffer
-                -- to be checked on next iteration
-                buf = buf or {}
-                table.insert(buf, line)
-            else
-                if buf ~= nil then -- prepend line with buffered data
-                    table.insert(buf, line)
-                    line = table.concat(buf)
-                    buf = nil
-                end
-                if string.match(line, "Starting instance") and not noreset then
-                    found = nil -- server was restarted, reset search
-                else
-                    found = string.match(line, what) or found
-                end
-            end
-            pos = endpos and endpos + 2 -- jump to char after \n
-        until pos == nil
-    until s == ''
-    file:close()
-    return found
 end
 
 vclock_utils.extend_with_vclock_methods(Server)


### PR DESCRIPTION
This patch introduce Tarantool 3 roles for crud routers and storages, similar to Cartridge ones. It also introduces testing with Tarantool 3 cluster started from configuration. See commits for more info.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #415
