### PR TITLE
ci: do not install metrics for reusable test

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Install requirements
         run: ./deps.sh
 
-      - name: Install metrics
-        run: |
-          tt init
-          tt rocks install metrics 1.0.0
-
       # This server starts and listen on 8084 port that is used for tests
       - name: Stop Mono server
         run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true


### PR DESCRIPTION
metrics 1.0.0 cannot be installed together with Tarantool 3.x: they override built-in ones, but they're too old to work with 3.x default setup which uses [1].

1. https://github.com/tarantool/metrics/commit/4865675c22f1b94248cb6ed5d818a73ea7713270

I didn't forget about

- [x] Tests
