### PR TITLE
ci: install newer vshard for reusable test

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install requirements
         run: ./deps.sh
+        env:
+          VSHARD_VERSION: "0.1.26"
 
       # This server starts and listen on 8084 port that is used for tests
       - name: Stop Mono server


### PR DESCRIPTION
Tarantool 3 config requires vshard 0.1.25 or newer, while tests install older versions by default (since crud is able to work with older vshards).

At the same time, newer vshard can work with old Tarantools.

I didn't forget about

- [x] Tests
