### PR TITLE
test: retry cluster init on fail

### DIFF
--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -13,10 +13,9 @@ end)
 g.before_each(function(cg)
     -- Tests are rather dangerous and may break the cluster,
     -- so it's safer to restart for each case.
-    helpers.start_tarantool3_cluster(cg, cg.template_cfg)
-    cg.router = cg.cluster:server('router')
-
-    helpers.wait_crud_is_ready_on_cluster(cg, {backend = helpers.backend.CONFIG})
+    helpers.start_cluster(cg, nil, nil, cg.template_cfg, {
+        backend = helpers.backend.CONFIG,
+    })
 end)
 
 g.after_each(function(cg)

--- a/test/unit/not_initialized_test.lua
+++ b/test/unit/not_initialized_test.lua
@@ -83,7 +83,7 @@ pgroup.before_all(function(g)
         cartridge_cfg_template,
         vshard_cfg_template,
         tarantool3_cluster_cfg_template,
-        {wait_crud_is_ready = false}
+        {wait_crud_is_ready = false, retries = 1}
     )
 
     g.router = g.cluster:server('router')


### PR DESCRIPTION
Sometimes cluster fails to bootstrap in tests. The reasons are yet unknown and likely unrelated to crud or maybe even crud tests setup.

After this patch, in case cluster preparation had failed for a test, we retry to create a cluster up t three times.

Part of #432

- [x] Tests
