### PR TITLE
module: release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.5.2] - 20-05-24
 
 ### Fixed
 * `insert_many`, `insert_object_many`, `replace_many`, `replace_object_many`,

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.5.1'
+return '1.5.2'


### PR DESCRIPTION
### Overview

This release fixes the bug that was discovered while working with `tt crud export` and `tt crud import` tools.

### Fixed
* `insert_many`, `insert_object_many`, `replace_many`, `replace_object_many`, `upsert_many`, `upsert_object_many` operations no longer fail with `ShardingHashMismatchError` if a space has custom sharding info and every tuple/object in the request has `bucket_id` set (#437).
