### PR TITLE
doc: enable statistics quantiles in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2111,7 +2111,7 @@ issues.
       roles.crud-router:
         stats: true
         stats_driver: metrics
-        stats_quantiles: false
+        stats_quantiles: true
         stats_quantile_tolerated_error: 0.001
         stats_quantile_age_buckets_count: 5
         stats_quantile_max_age_time: 180
@@ -2205,7 +2205,7 @@ scope, so that you can call them via `net.box`.
     crud:
       stats: true
       stats_driver: metrics
-      stats_quantiles: false
+      stats_quantiles: true
       stats_quantile_tolerated_error: 0.001
       stats_quantile_age_buckets_count: 5
       stats_quantile_max_age_time: 180


### PR DESCRIPTION
Even though enabling quantiles decreases performance, it increases observability, so I think that basic example should enable them (since it already configures their parameters).

I didn't forget about

- Tests
- Changelog
- [x] Documentation
