### PR TITLE
coverage: fix dkjson install

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -11,7 +11,7 @@ then
 fi
 
 # Test dependencies:
-$TTCTL rocks install luatest
+$TTCTL rocks install luatest 1.0.1
 $TTCTL rocks install luacheck 0.25.0
 $TTCTL rocks install luacov 0.13.0
 

--- a/deps.sh
+++ b/deps.sh
@@ -17,7 +17,7 @@ $TTCTL rocks install luacov 0.13.0
 
 # cluacov, luacov-coveralls and dependencies
 $TTCTL rocks install https://raw.githubusercontent.com/luarocks/cluacov/master/cluacov-scm-1.rockspec
-$TTCTL rocks install https://raw.githubusercontent.com/LuaDist/dkjson/master/dkjson-2.5-2.rockspec
+$TTCTL rocks install https://luarocks.org/manifests/dhkolf/dkjson-2.8-1.rockspec
 $TTCTL rocks install https://raw.githubusercontent.com/keplerproject/luafilesystem/master/luafilesystem-scm-1.rockspec
 $TTCTL rocks install https://raw.githubusercontent.com/moteus/lua-path/master/rockspecs/lua-path-scm-0.rockspec
 


### PR DESCRIPTION
dkjson rocks are installed by downloading some author-hosted tar.gz source archives. It seems that 2.5-2 version archive has been removed. (It's not available, yet 2.8-1 is ok.) We also change rockspec source to luarocks in the commit since GitHub repository for dkjson is archived since 2020 [1] while luarocks page is alive and receives new updates [2].

1. https://github.com/LuaDist/dkjson
2. https://luarocks.org/modules/dhkolf/dkjson