### PR TITLE
schema: add new system space _gc_consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* `crud.schema` no longer returns system space `_gc_consumers` with Tarantool 3.2+.
+* Tests of `schema` with Tarantool 3.2+.
+
 ## [1.5.2] - 20-05-24
 
 ### Fixed

--- a/crud/schema.lua
+++ b/crud/schema.lua
@@ -36,6 +36,7 @@ schema.system_spaces = {
     ['_ck_constraint'] = true,
     ['_func_index'] = true,
     ['_session_settings'] = true,
+    ['_gc_consumers'] = true,
     -- https://github.com/tarantool/vshard/blob/b3c27b32637863e9a03503e641bb7c8c69779a00/vshard/storage/init.lua#L752
     ['_bucket'] = true,
     -- https://github.com/tarantool/ddl/blob/b55d0ff7409f32e4d527e2d25444d883bce4163b/test/set_sharding_metadata_test.lua#L92-L98


### PR DESCRIPTION
Tarantool is being populated with new system space, so we need to add it to the list of all system spaces in `crud.schema`.

Closes #443
