### PR TITLE
release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.0] - 09-09-25
 
 ### Changed
 * bumped: vshard version in rockspec.
-* Role model support in CRUD is provided ([commit](https://github.com/tarantool/crud/pull/453/commits/379f7e0a133b3ad8763885b51626e7d30b2920ee)).
 
 ### Added
+* Role model support in CRUD is provided ([commit](https://github.com/tarantool/crud/pull/453/commits/379f7e0a133b3ad8763885b51626e7d30b2920ee)).
 * Validation of `bucket_id`. Invalid values now raise `BucketIDError`
   before routing ([commit](https://github.com/tarantool/crud/pull/453/commits/3019e76a09200b0c12523b0b5221350ae8a0a8b4)).
 

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.5.2'
+return '1.6.0'


### PR DESCRIPTION
Added
* Role model support in CRUD is provided ([commit](https://github.com/tarantool/crud/pull/453/commits/379f7e0a133b3ad8763885b51626e7d30b2920ee)).
* Validation of `bucket_id`. Invalid values now raise `BucketIDError` before routing ([commit](https://github.com/tarantool/crud/pull/453/commits/3019e76a09200b0c12523b0b5221350ae8a0a8b4)).

Changed
* Bumped vshard version in rockspec.

Fixed
* Fixed compatibility with cartridge `2.16.0`.
* `crud.schema` no longer returns TCF system space `_cdc_state`.
* `crud.schema` no longer returns system space `_gc_consumers` with Tarantool 3.2+.
* `crud.schema` no longer returns `tt` system space `_tt_migrations`.
* Tests of `schema` with Tarantool 3.2+.
* Fixed bad error handling for method `call.single`
* Added support for working in 3.1 with data from 2.11, previously there was an error
due to the inability to find the replicasets by name ([commit](https://github.com/tarantool/crud/pull/453/commits/fdce364254a234fb8db9ed1bab9bbe0d3c9d3e17)).
