### PR TITLE
sharding: fail fast on invalid bucket_id in data or opts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ sdk: sdk-2 sdk-3
 	chmod 644 sdk-3/rocks/* && \
 	tt rocks make_manifest sdk-3/rocks
 
-lint: .rocks
+lint:
 	source sdk-2/env.sh && .rocks/bin/luacheck .
 
 .PHONY: test

--- a/test/integration/count_test.lua
+++ b/test/integration/count_test.lua
@@ -925,7 +925,7 @@ pgroup.test_invalid_bucket_id_in_opts = function(g)
 
     for _, bucket_id in ipairs(invalid_values) do
         local expected_err = string.format(
-            "Invalid bucket_id: expected unsigned, got %s",
+            "Invalid bucket_id in opts: expected unsigned, got %s",
             type(bucket_id)
         )
 

--- a/test/integration/pairs_readview_test.lua
+++ b/test/integration/pairs_readview_test.lua
@@ -957,7 +957,7 @@ pgroup.test_invalid_bucket_id_in_readview_pairs = function(g)
 
     for _, opts in ipairs(invalid_opts_list) do
         local expected_err = string.format(
-            "Invalid bucket_id: expected unsigned, got %s",
+            "Invalid bucket_id in opts: expected unsigned, got %s",
             type(opts.bucket_id)
         )
         local _, err = g.router:eval([[

--- a/test/integration/pairs_test.lua
+++ b/test/integration/pairs_test.lua
@@ -964,7 +964,7 @@ pgroup.test_invalid_bucket_id_pairs = function(g)
 
     for _, opts in ipairs(invalid_opts_list) do
         local expected_err = string.format(
-            "Invalid bucket_id: expected unsigned, got %s",
+            "Invalid bucket_id in opts: expected unsigned, got %s",
             type(opts.bucket_id)
         )
         t.assert_error_msg_contains(expected_err, function()

--- a/test/integration/select_readview_test.lua
+++ b/test/integration/select_readview_test.lua
@@ -2575,7 +2575,7 @@ pgroup.test_invalid_bucket_id_in_readview = function(g)
 
     for _, opts in ipairs(invalid_opts_list) do
         local expected_err = string.format(
-            "Invalid bucket_id: expected unsigned, got %s",
+            "Invalid bucket_id in opts: expected unsigned, got %s",
             type(opts.bucket_id)
         )
         local _, err = g.router:eval([[

--- a/test/integration/select_test.lua
+++ b/test/integration/select_test.lua
@@ -2339,7 +2339,7 @@ pgroup.test_select_invalid_bucket_id = function(g)
         opts.fullscan = true
 
         local expected_err = string.format(
-            "Invalid bucket_id: expected unsigned, got %s",
+            "Invalid bucket_id in opts: expected unsigned, got %s",
             type(opts.bucket_id)
         )
 


### PR DESCRIPTION
- Added early validation of bucket_id in tuple/object and in opts inside tuple_set_and_return_bucket_id().
- Error messages now specify where the invalid value was provided:
  * "Invalid bucket_id in data: expected unsigned, got %s"
  * "Invalid bucket_id in opts: expected unsigned, got %s"
- Extended integration tests for insert/replace/upsert to cover these cases.

I didn't forget about

- [x] Tests
- [ ] Changelog
- [ ] Documentation