### PR TITLE
sharding: auto-fill bucket_id when PK is sharding index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Support for `vshard`'s `request_timeout` parameter for calls with `mode = 'read'`
 
 ### Changed
+* Auto-fill `bucket_id` for primary-key CRUD requests (get/update/delete) when the sharding index is the primary index and `bucket_id` is passed as `box.NULL`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ require any actions from user side. However, for operations that accepts
 tuple/object bucket ID can be specified as tuple/object field as well as
 `opts.bucket_id` value.
 
+**Primary key requests without explicit `bucket_id`**
+
+If the sharding index (with `bucket_id` as the first field) also acts as the
+primary index, CRUD can populate the missing `bucket_id` automatically. You may
+pass `box.NULL` instead of the first key part, and the router will compute the
+`bucket_id` from the remaining primary key fields:
+
+```lua
+local res, err = crud.get('customers', {box.NULL, customer_id})
+local res, err = crud.update('customers', {box.NULL, customer_id}, {{'=', 'name', 'Jane'}})
+local res, err = crud.delete('customers', {box.NULL, customer_id})
+```
+
+The behaviour works as long as the router has up-to-date sharding metadata and
+the primary index layout is `(bucket_id, ...)`.
+
 Starting from 0.10.0 users who don't want to use primary key as a sharding key
 may set custom sharding key definition as a part of [DDL
 schema](https://github.com/tarantool/ddl#input-data-format) or insert manually

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -112,6 +112,9 @@ local function call_delete_on_router(vshard_router, space_name, key, opts)
         return nil, err
     end
 
+    -- When the sharding index (bucket_id) is the primary index, bucket_id can be passed as box.NULL.
+    sharding.fill_bucket_id_pk(space, key, bucket_id_data.bucket_id)
+
     local delete_on_storage_opts = {
         sharding_func_hash = bucket_id_data.sharding_func_hash,
         sharding_key_hash = sharding_key_hash,

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -110,6 +110,9 @@ local function call_get_on_router(vshard_router, space_name, key, opts)
         return nil, err
     end
 
+    -- When the sharding index (bucket_id) is the primary index, bucket_id can be passed as box.NULL.
+    sharding.fill_bucket_id_pk(space, key, bucket_id_data.bucket_id)
+
     local get_on_storage_opts = {
         sharding_func_hash = bucket_id_data.sharding_func_hash,
         sharding_key_hash = sharding_key_hash,

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -144,6 +144,9 @@ local function call_update_on_router(vshard_router, space_name, key, user_operat
         return nil, err
     end
 
+    -- When the sharding index (bucket_id) is the primary index, bucket_id can be passed as box.NULL.
+    sharding.fill_bucket_id_pk(space, key, bucket_id_data.bucket_id)
+
     local update_on_storage_opts = {
         sharding_func_hash = bucket_id_data.sharding_func_hash,
         sharding_key_hash = sharding_key_hash,

--- a/test/entrypoint/srv_bucket_id_pk/cartridge_init.lua
+++ b/test/entrypoint/srv_bucket_id_pk/cartridge_init.lua
@@ -1,0 +1,43 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+_G.is_initialized = function() return false end
+
+local fio = require('fio')
+local log = require('log')
+local errors = require('errors')
+local cartridge = require('cartridge')
+
+if package.setsearchroot ~= nil then
+    package.setsearchroot()
+else
+    package.path = package.path .. debug.sourcedir() .. "/?.lua;"
+end
+
+local root = fio.dirname(fio.dirname(fio.dirname(debug.sourcedir())))
+package.path = package.path .. root .. "/?.lua;"
+
+package.preload['customers-storage'] = function()
+    return {
+        role_name = 'customers-storage',
+        init = require('storage').init,
+    }
+end
+
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+    advertise_uri = 'localhost:3301',
+    http_port = 8081,
+    bucket_count = 3000,
+    roles = {
+        'customers-storage',
+        'cartridge.roles.crud-router',
+        'cartridge.roles.crud-storage',
+    },
+})
+
+if not ok then
+    log.error('%s', err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy

--- a/test/entrypoint/srv_bucket_id_pk/storage.lua
+++ b/test/entrypoint/srv_bucket_id_pk/storage.lua
@@ -1,0 +1,42 @@
+local helper = require('test.helper')
+
+return {
+    init = helper.wrap_schema_init(function()
+        local engine = os.getenv('ENGINE') or 'memtx'
+        local customers_space = box.schema.space.create('customers', {
+            format = {
+                {name = 'id', type = 'unsigned'},
+                {name = 'bucket_id', type = 'unsigned'},
+                {name = 'name', type = 'string'},
+                {name = 'age', type = 'number'},
+            },
+            if_not_exists = true,
+            engine = engine,
+        })
+        customers_space:create_index('bucket_id', {
+            parts = { {field = 'bucket_id'}, {field = 'id'} },
+            if_not_exists = true,
+        })
+
+        -- https://github.com/tarantool/migrations/blob/a7c31a17f6ac02d4498b4203c23e495856861444/migrator/utils.lua#L35-L53
+        if box.space._ddl_sharding_key == nil then
+            local sharding_space = box.schema.space.create('_ddl_sharding_key', {
+                format = {
+                    {name = 'space_name', type = 'string', is_nullable = false},
+                    {name = 'sharding_key', type = 'array', is_nullable = false}
+                },
+                if_not_exists = true,
+            })
+            sharding_space:create_index(
+                'space_name', {
+                    type = 'TREE',
+                    unique = true,
+                    parts = {{'space_name', 'string', is_nullable = false}},
+                    if_not_exists = true,
+                }
+            )
+        end
+        box.space._ddl_sharding_key:replace{'customers', {'id'}}
+    end),
+    wait_until_ready = helper.wait_schema_init,
+}

--- a/test/integration/bucket_id_pk_test.lua
+++ b/test/integration/bucket_id_pk_test.lua
@@ -1,0 +1,244 @@
+local t = require('luatest')
+local crud = require('crud')
+
+--- Integration checks for spaces where the sharding index (bucket_id + id)
+--- is the primary index and bucket_id can be passed as box.NULL.
+local helpers = require('test.helper')
+
+local pgroup = t.group('bucket_id_pk', helpers.backend_matrix({
+    {engine = 'memtx'},
+    {engine = 'vinyl'},
+}))
+
+pgroup.before_all(function(g)
+    helpers.start_default_cluster(g, 'srv_bucket_id_pk')
+end)
+
+pgroup.after_all(function(g)
+    helpers.stop_cluster(g.cluster, g.params.backend)
+end)
+
+pgroup.before_each(function(g)
+    helpers.truncate_space_on_cluster(g.cluster, 'customers')
+end)
+
+local function insert_customer(g, id)
+    local result, err = g.router:call(
+        'crud.insert_object', {'customers', {id = id, name = 'Fedor', age = 59}})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(result.metadata, {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    })
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects[1].id, id)
+end
+
+--- test where box.NULL passed in primary key
+pgroup.test_get = function(g)
+    insert_customer(g, 1)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+end
+
+pgroup.test_delete = function(g)
+    insert_customer(g, 1)
+
+    local result, err = g.router:call('crud.delete', {
+        'customers', {box.NULL, 1}
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert_equals(#result.rows, 0)
+end
+
+pgroup.test_update = function(g)
+    insert_customer(g, 1)
+
+    local result, err = g.router:call('crud.update', {'customers', {box.NULL, 1}, {
+        {'+', 'age', 10},
+        {'=', 'name', 'Leo Tolstoy'},
+    }})
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+end
+
+--- test where box.NULL passed in tuple
+pgroup.test_insert_object = function(g)
+    local result, err = g.router:call('crud.insert_object', {
+        'customers', {id = 1, name = 'Fedor', age = 59},
+    })
+
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+end
+
+pgroup.test_insert = function(g)
+    local tuple = {1, box.NULL, 'Fedor', 59}
+
+    local result, err = g.router:call('crud.insert', {'customers', tuple})
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+end
+
+pgroup.test_replace_object = function(g)
+    insert_customer(g, 1)
+
+    local result, err = g.router:call('crud.replace_object', {
+        'customers', {id = 1, name = 'Leo Tolstoy', age = 69},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+end
+
+pgroup.test_replace = function(g)
+    insert_customer(g, 1)
+
+    local tuple = {1, box.NULL, 'Leo Tolstoy', 69}
+
+    local result, err = g.router:call('crud.replace', {'customers', tuple})
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+end
+
+pgroup.test_upsert_object = function(g)
+    local operations = {
+        {'=', 'name', 'Leo Tolstoy'},
+        {'+', 'age', 10},
+    }
+
+    --- replace part
+    local result, err = g.router:call('crud.upsert_object', {
+        'customers', {id = 1, name = 'Fedor', age = 59}, operations,
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    t.assert_equals(#result.rows, 0)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+
+    --- update part
+    local result, err = g.router:call('crud.upsert_object', {
+        'customers', {id = 1, name = 'Fedor', age = 59}, operations,
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    t.assert_equals(#result.rows, 0)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+end
+
+pgroup.test_upsert = function(g)
+    local tuple = {1, box.NULL, 'Fedor', 59}
+    local operations = {
+        {'=', 'name', 'Leo Tolstoy'},
+        {'+', 'age', 10},
+    }
+
+    --- replace part
+    local result, err = g.router:call('crud.upsert', {
+        'customers', tuple, operations,
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    t.assert_equals(#result.rows, 0)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Fedor', age = 59, bucket_id = 477}})
+
+    --- update part
+    local result, err = g.router:call('crud.upsert', {
+        'customers', tuple, operations,
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    t.assert_equals(#result.rows, 0)
+
+    local result, err = g.router:call('crud.get', {
+        'customers', {box.NULL, 1}, {mode = 'write'},
+    })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(result, nil)
+    local objects = crud.unflatten_rows(result.rows, result.metadata)
+    t.assert_equals(objects, {{id = 1, name = 'Leo Tolstoy', age = 69, bucket_id = 477}})
+end


### PR DESCRIPTION
Vinyl deployments often live with a single index (bucket_id, …), so CRUD can derive bucket_id from the rest of the key. Primary-key calls still demanded an explicit bucket_id though: the router sent box.NULL and storage rejected the key type.

Introduce sharding.fill_bucket_id_pk(), which checks that the sharding index is the primary index and patches the first key part when bucket_id arrives as box.NULL.


I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #457
