### PR TITLE
release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.1] - 19-09-25
+
 ### Added
 * Support for `vshard`'s `request_timeout` parameter for calls with `mode = 'read'`
 

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.6.0'
+return '1.6.1'


### PR DESCRIPTION
Added
* Support for `vshard`'s `request_timeout` parameter for calls with `mode = 'read'`

Changed
* Auto-fill `bucket_id` for primary-key CRUD requests (get/update/delete) when the sharding index is the primary index and `bucket_id` is passed as `box.NULL`.

