### PR TITLE
test: remove skip for vshard config support

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -12,18 +12,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        tarantool-version: [ "2.10", "2.11" ]
+        metrics-version: [ "" ]
+        cartridge-version: [ "2.16.3" ]
+        external-tuple-merger-version: [ "" ]
+        external-tuple-keydef-version: [ "" ]
         include:
-          - tarantool-version: "2.10"
           - tarantool-version: "2.11"
             coveralls: true
+            metrics-version: "1.1.0"
+            cartridge-version: "2.16.3"
+          - tarantool-version: "2.11"
+            metrics-version: "1.1.0"
+            vshard-version: "0.1.36"
           - tarantool-version: "2.11"
             external-tuple-merger-version: "0.0.5"
             external-tuple-keydef-version: "0.0.4"
           - tarantool-version: "3.0"
+            vshard-version: "0.1.36"
           - tarantool-version: "3.1"
+            vshard-version: "0.1.36"
           - tarantool-version: "3.2"
+            vshard-version: "0.1.36"
           - tarantool-version: "3.3"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.4"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.5"
+            vshard-version: "0.1.36"
           - tarantool-version: "master"
+            vshard-version: "0.1.36"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -83,6 +101,9 @@ jobs:
         run: |
           tarantool --version
           ./deps.sh
+        env:
+          CARTRIDGE_VERSION: ${{ matrix.cartridge-version }}
+          VSHARD_VERSION: ${{ matrix.vshard-version }}
 
       - name: Install metrics
         if: matrix.metrics-version != ''
@@ -106,47 +127,38 @@ jobs:
 
       - name: Run tests
         if: matrix.coveralls != true # See https://github.com/actions/runner/issues/1173
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 10
-          timeout_minutes: 40
-          command: |
-            make -C build luatest-no-coverage
+        run: make -C build luatest-no-coverage
 
       - name: Run tests with coverage and send results to coveralls.io
         if: ${{ matrix.coveralls }}
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 10
-          timeout_minutes: 40
-          command: |
-            make -C build coveralls
+        run: make -C build coveralls
 
   run-tests-ee:
     if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
+        tarantool-version:
+          - tarantool-version:
+            folder: "2.10"
+            bundle: "tarantool-enterprise-sdk-gc64-2.10.8-0-r691.linux.x86_64"
+          - folder: "2.11"
+            bundle: "tarantool-enterprise-sdk-gc64-2.11.7-0-r691.linux.x86_64"
+        metrics-version: [ "", "1.5.0" ]
+        cartridge-version: [ "2.16.3" ]
         include:
-          - tarantool-version:
-              folder: "2.10"
-              bundle: "tarantool-enterprise-sdk-gc64-2.10.8-0-r691.linux.x86_64"
-          - tarantool-version:
-              folder: "2.11"
-              bundle: "tarantool-enterprise-sdk-gc64-2.11.7-0-r691.linux.x86_64"
           - tarantool-version:
               folder: "3.2"
               bundle: "tarantool-enterprise-sdk-gc64-3.2.0-0-r40.linux.x86_64"
           - tarantool-version:
               folder: "3.3"
-              bundle: "tarantool-enterprise-sdk-gc64-3.3.2-0-r62.linux.x86_64"
+              bundle: "tarantool-enterprise-sdk-gc64-3.3.3-0-r70.linux.x86_64"
           - tarantool-version:
               folder: "3.4"
-              bundle: "tarantool-enterprise-sdk-gc64-3.4.0-0-r62.linux.x86_64"
+              bundle: "tarantool-enterprise-sdk-gc64-3.4.1-0-r70.linux.x86_64"
+          - tarantool-version:
+              folder: "3.5"
+              bundle: "tarantool-enterprise-sdk-gc64-3.5.0-0-r70.linux.x86_64"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -160,6 +172,9 @@ jobs:
           source tarantool-enterprise/env.sh
           tarantool --version
           ./deps.sh
+        env:
+          CARTRIDGE_VERSION: ${{ matrix.cartridge-version }}
+          VSHARD_VERSION: ${{ matrix.vshard-version }}
 
       - name: Install metrics
         if: matrix.metrics-version != ''
@@ -175,23 +190,33 @@ jobs:
       - run: cmake -S . -B build
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 10
-          timeout_minutes: 40
-          command: |
-            make -C build luatest-no-coverage
+        run: make -C build luatest-no-coverage
 
   run-perf-tests-ce:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
-      fail-fast: false
       matrix:
-        tarantool-version: [ "2.10", "2.11", "3.0", "3.1", "3.2", "3.3", "master" ]
+        tarantool-version: [ "2.10", "2.11" ]
+        metrics-version: [ "1.1.0" ]
+        cartridge-version: [ "2.16.3" ]
+        include:
+          - tarantool-version: "3.0"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.1"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.2"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.3"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.4"
+            vshard-version: "0.1.36"
+          - tarantool-version: "3.5"
+            vshard-version: "0.1.36"
+          - tarantool-version: "master"
+            vshard-version: "0.1.36"
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -251,6 +276,9 @@ jobs:
         run: |
           tarantool --version
           ./deps.sh
+        env:
+          CARTRIDGE_VERSION: ${{ matrix.cartridge-version }}
+          VSHARD_VERSION: ${{ matrix.vshard-version }}
 
       - name: Install metrics
         if: matrix.metrics-version != ''
@@ -263,11 +291,4 @@ jobs:
       - run: cmake -S . -B build
 
       - name: Run performance tests
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 10
-          timeout_minutes: 60
-          command: |
-            make -C build performance
+        run: make -C build performance

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-S3_TARANTOOL_SDK_3_PATH := s3://packages/enterprise/release/linux/x86_64/3.3/tarantool-enterprise-sdk-gc64-3.3.2-0-r62.linux.x86_64.tar.gz
+S3_TARANTOOL_SDK_3_PATH := s3://packages/enterprise/release/linux/x86_64/3.5/tarantool-enterprise-sdk-gc64-3.5.0-0-r70.linux.x86_64.tar.gz
 S3_TARANTOOL_SDK_2_PATH := s3://packages/enterprise/release/linux/x86_64/2.11/tarantool-enterprise-sdk-gc64-2.11.7-0-r691.linux.x86_64.tar.gz
 S3_ENDPOINT_URL := $(if $(S3_ENDPOINT_URL),$(S3_ENDPOINT_URL),https://hb.vkcs.cloud)
 

--- a/deps.sh
+++ b/deps.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Call this script to install test dependencies
+# Usage examples:
+#   CARTRIDGE_VERSION=2.16.3 ./deps.sh
+#   VSHARD_VERSION=0.1.36 ./deps.sh
 
 set -e
 
@@ -13,37 +16,21 @@ fi
 # Test dependencies:
 ${TTCTL} rocks install luatest 1.0.1
 ${TTCTL} rocks install luacheck 0.26.0
-${TTCTL} rocks install luacov 0.13.0
-${TTCTL} rocks install luacov-reporters 0.1.0
 
-# cluacov, luacov-coveralls and dependencies
-$TTCTL rocks install https://raw.githubusercontent.com/luarocks/cluacov/master/cluacov-dev-1.rockspec
-$TTCTL rocks install https://luarocks.org/manifests/dhkolf/dkjson-2.8-1.rockspec
-$TTCTL rocks install https://raw.githubusercontent.com/keplerproject/luafilesystem/master/luafilesystem-scm-1.rockspec
-$TTCTL rocks install https://raw.githubusercontent.com/moteus/lua-path/master/rockspecs/lua-path-scm-0.rockspec
+if [[ -n "${CARTRIDGE_VERSION}" ]]
+then
+    ${TTCTL} rocks install https://raw.githubusercontent.com/luarocks/cluacov/master/cluacov-dev-1.rockspec
+    ${TTCTL} rocks install https://luarocks.org/manifests/dhkolf/dkjson-2.8-1.rockspec
+    ${TTCTL} rocks install https://raw.githubusercontent.com/keplerproject/luafilesystem/master/luafilesystem-scm-1.rockspec
+    ${TTCTL} rocks install https://raw.githubusercontent.com/moteus/lua-path/master/rockspecs/lua-path-scm-0.rockspec
+    ${TTCTL} rocks install luacov-coveralls --only-server=https://luarocks.org/
 
-# Most of this code is the workaround for
-# https://github.com/moteus/luacov-coveralls/pull/30
-# Remove it, when the pull request will be merged.
-TMPDIR="$(mktemp -d)"
-LUACOV_COVERALLS_ROCKSPEC_URL="https://raw.githubusercontent.com/moteus/luacov-coveralls/master/rockspecs/luacov-coveralls-scm-0.rockspec"
-LUACOV_COVERALLS_ROCKSPEC_FILE="${TMPDIR}/luacov-coveralls-scm-0.rockspec"
-curl -fsSL "${LUACOV_COVERALLS_ROCKSPEC_URL}" > "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
-sed -i -e 's@git://@git+https://@' "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
-$TTCTL rocks install "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
-rm "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
-rmdir "${TMPDIR}"
+    ${TTCTL} rocks install cartridge "${CARTRIDGE_VERSION}"
+    ${TTCTL} rocks install migrations 1.1.0
+else
+    ${TTCTL} rocks install vshard "${VSHARD_VERSION:-0.1.36}"
+fi
 
-CARTRIDGE_VERSION="${CARTRIDGE_VERSION:-2.16.3}"
-VSHARD_VERSION="${VSHARD_VERSION:-0.1.36}"
-METRICS_VERSION="${METRICS_VERSION:-1.5.0}"
-DDL_VERSION="${METRICS_VERSION:-1.7.1}"
-MIGRATIONS_VERSION="${MIGRATIONS_VERSION:-1.1.0}"
-
-${TTCTL} rocks install cartridge "${CARTRIDGE_VERSION}"
-${TTCTL} rocks install vshard "${VSHARD_VERSION}"
-${TTCTL} rocks install metrics "${METRICS_VERSION}"
-${TTCTL} rocks install ddl "${DDL_VERSION}"
-${TTCTL} rocks install migrations "${MIGRATIONS_VERSION}"
+${TTCTL} rocks install ddl 1.7.1
 
 ${TTCTL} rocks make

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -957,7 +957,6 @@ function helpers.start_cluster(g, cartridge_cfg, vshard_cfg, tarantool3_cluster_
             helpers.start_vshard_cluster(g, vshard_cfg)
         elseif opts.backend == helpers.backend.CONFIG then
             helpers.skip_if_tarantool3_crud_roles_unsupported()
-            helpers.skip_tarantool3_vshard_unsupported()
 
             helpers.start_tarantool3_cluster(g, tarantool3_cluster_cfg)
         end
@@ -1521,11 +1520,6 @@ function helpers.skip_if_tarantool3_crud_roles_unsupported()
     local version = rawget(_G, '_TARANTOOL')
     t.skip_if(not helpers.is_tarantool3_crud_roles_supported(),
               ("Tarantool %s does not support crud roles"):format(version))
-end
-
-function helpers.skip_tarantool3_vshard_unsupported()
-    t.skip("vshard is not supported in config yet: " ..
-           "https://github.com/tarantool/tarantool-ee/issues/815")
 end
 
 function helpers.skip_if_not_config_backend(backend)

--- a/test/tarantool3_helpers/cluster_test.lua
+++ b/test/tarantool3_helpers/cluster_test.lua
@@ -7,7 +7,6 @@ local g = t.group()
 
 g.before_all(function(cg)
     helpers.skip_if_tarantool3_crud_roles_unsupported()
-    helpers.skip_tarantool3_vshard_unsupported()
 
     local config = {
         credentials = {


### PR DESCRIPTION
Removed obsolete helper `skip_tarantool3_vshard_unsupported` and all its usages in tests.  
The skip was introduced due to https://github.com/tarantool/tarantool-ee/issues/815,  
but the issue has been closed long ago. Tests should now run without skipping.  

I didn't forget about
- [x] Tests
- [ ] Changelog
- [ ] Documentation