### PR TITLE
perf: drop wrap_box_space_func_result to cut allocations and speed storage calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+* drop wrap_box_space_func_result to cut allocations and speed up storage calls.
+
 ## [1.6.1] - 19-09-25
 
 ### Added

--- a/crud/borders.lua
+++ b/crud/borders.lua
@@ -32,15 +32,11 @@ local function get_border_on_storage(border_name, space_name, index_id, field_na
         return nil, BorderError:new("Index %q of space doesn't exist", index_id, space_name)
     end
 
-    local function get_index_border(index)
-        return index[border_name](index)
-    end
-
-    return schema.wrap_func_result(space, get_index_border, {index}, {
+    return schema.wrap_func_result(space, index[border_name], {
         add_space_schema_hash = true,
         field_names = field_names,
         fetch_latest_metadata = fetch_latest_metadata,
-    })
+    }, index)
 end
 
 borders.storage_api = {[STAT_FUNC_NAME] = get_border_on_storage}

--- a/crud/common/schema.lua
+++ b/crud/common/schema.lua
@@ -209,14 +209,16 @@ function schema.truncate_row_trailing_fields(tuple, field_names)
     return tuple
 end
 
-function schema.wrap_func_result(space, func, args, opts)
-    dev_checks('table', 'function', 'table', 'table')
-
+-- schema.wrap_func_result pcalls function
+-- and returns its result as a table
+-- `{res = ..., err = ..., space_schema_hash = ...}`
+-- space_schema_hash is computed if function failed and
+-- `add_space_schema_hash` is true
+function schema.wrap_func_result(space, func, opts, ...)
+    dev_checks('table', 'function', 'table')
     local result = {}
 
-    opts = opts or {}
-
-    local ok, func_res = pcall(func, unpack(args))
+    local ok, func_res = pcall(func, ...)
     if ok then
         if opts.noreturn ~= true then
             result.res = filter_tuple_fields(func_res, opts.field_names)
@@ -244,20 +246,6 @@ function schema.wrap_func_result(space, func, args, opts)
     end
 
     return result
-end
-
--- schema.wrap_box_space_func_result pcalls some box.space function
--- and returns its result as a table
--- `{res = ..., err = ..., space_schema_hash = ...}`
--- space_schema_hash is computed if function failed and
--- `add_space_schema_hash` is true
-function schema.wrap_box_space_func_result(space, box_space_func_name, box_space_func_args, opts)
-    dev_checks('table', 'string', 'table', 'table')
-    local function func(space, box_space_func_name, box_space_func_args)
-        return space[box_space_func_name](space, unpack(box_space_func_args))
-    end
-
-    return schema.wrap_func_result(space, func, {space, box_space_func_name, box_space_func_args}, opts)
 end
 
 -- schema.result_needs_reload checks that schema reload can

--- a/crud/delete.lua
+++ b/crud/delete.lua
@@ -44,12 +44,12 @@ local function delete_on_storage(space_name, key, field_names, opts)
 
     -- add_space_schema_hash is false because
     -- reloading space format on router can't avoid delete error on storage
-    return schema.wrap_box_space_func_result(space, 'delete', {key}, {
+    return schema.wrap_func_result(space, space.delete, {
         add_space_schema_hash = false,
         field_names = field_names,
         noreturn = opts.noreturn,
         fetch_latest_metadata = opts.fetch_latest_metadata,
-    })
+    }, space, key)
 end
 
 delete.storage_api = {[DELETE_FUNC_NAME] = delete_on_storage}

--- a/crud/get.lua
+++ b/crud/get.lua
@@ -43,11 +43,11 @@ local function get_on_storage(space_name, key, field_names, opts)
 
     -- add_space_schema_hash is false because
     -- reloading space format on router can't avoid get error on storage
-    return schema.wrap_box_space_func_result(space, 'get', {key}, {
+    return schema.wrap_func_result(space, space.get, {
         add_space_schema_hash = false,
         field_names = field_names,
         fetch_latest_metadata = opts.fetch_latest_metadata,
-    })
+    }, space, key)
 end
 
 get.storage_api = {[GET_FUNC_NAME] = get_on_storage}

--- a/crud/insert.lua
+++ b/crud/insert.lua
@@ -45,12 +45,12 @@ local function insert_on_storage(space_name, tuple, opts)
     -- add_space_schema_hash is true only in case of insert_object
     -- the only one case when reloading schema can avoid insert error
     -- is flattening object on router
-    return schema.wrap_box_space_func_result(space, 'insert', {tuple}, {
+    return schema.wrap_func_result(space, space.insert, {
         add_space_schema_hash = opts.add_space_schema_hash,
         field_names = opts.fields,
         noreturn = opts.noreturn,
         fetch_latest_metadata = opts.fetch_latest_metadata,
-    })
+    }, space, tuple)
 end
 
 insert.storage_api = {[INSERT_FUNC_NAME] = insert_on_storage}

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -52,17 +52,22 @@ local function insert_many_on_storage(space_name, tuples, opts)
     local errs = {}
     local replica_schema_version = nil
 
+    local insert_opts = {
+        add_space_schema_hash = opts.add_space_schema_hash,
+        field_names = opts.fields,
+        noreturn = opts.noreturn,
+        fetch_latest_metadata = opts.fetch_latest_metadata,
+    }
+
     box.begin()
     for i, tuple in ipairs(tuples) do
         -- add_space_schema_hash is true only in case of insert_object_many
         -- the only one case when reloading schema can avoid insert error
         -- is flattening object on router
-        local insert_result = schema.wrap_box_space_func_result(space, 'insert', {tuple}, {
-            add_space_schema_hash = opts.add_space_schema_hash,
-            field_names = opts.fields,
-            noreturn = opts.noreturn,
-            fetch_latest_metadata = opts.fetch_latest_metadata,
-        })
+        local insert_result = schema.wrap_func_result(
+            space, space.insert, insert_opts,
+            space, tuple
+        )
         if opts.fetch_latest_metadata then
             replica_schema_version = insert_result.storage_info.replica_schema_version
         end

--- a/crud/replace.lua
+++ b/crud/replace.lua
@@ -45,12 +45,14 @@ local function replace_on_storage(space_name, tuple, opts)
     -- add_space_schema_hash is true only in case of replace_object
     -- the only one case when reloading schema can avoid insert error
     -- is flattening object on router
-    return schema.wrap_box_space_func_result(space, 'replace', {tuple}, {
+
+    local result = schema.wrap_func_result(space, space.replace, {
         add_space_schema_hash = opts.add_space_schema_hash,
         field_names = opts.fields,
         noreturn = opts.noreturn,
         fetch_latest_metadata = opts.fetch_latest_metadata,
-    })
+    }, space, tuple)
+    return result
 end
 
 replace.storage_api = {[REPLACE_FUNC_NAME] = replace_on_storage}

--- a/crud/update.lua
+++ b/crud/update.lua
@@ -44,12 +44,12 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
 
     -- add_space_schema_hash is false because
     -- reloading space format on router can't avoid update error on storage
-    local res, err = schema.wrap_box_space_func_result(space, 'update', {key, operations}, {
+    local res, err = schema.wrap_func_result(space, space.update, {
         add_space_schema_hash = false,
         field_names = field_names,
         noreturn = opts.noreturn,
         fetch_latest_metadata = opts.fetch_latest_metadata,
-    })
+    }, space, key, operations)
 
     if err ~= nil then
         return nil, err
@@ -66,12 +66,12 @@ local function update_on_storage(space_name, key, operations, field_names, opts)
     -- More details: https://github.com/tarantool/tarantool/issues/3378
     if utils.is_field_not_found(res.err.code) then
         operations = utils.add_intermediate_nullable_fields(operations, space:format(), space:get(key))
-        res, err = schema.wrap_box_space_func_result(space, 'update', {key, operations}, {
+        res, err = schema.wrap_func_result(space, space.update, {
             add_space_schema_hash = false,
             field_names = field_names,
             noreturn = opts.noreturn,
             fetch_latest_metadata = opts.fetch_latest_metadata,
-        })
+        }, space, key, operations)
     end
 
     return res, err

--- a/crud/upsert.lua
+++ b/crud/upsert.lua
@@ -44,10 +44,10 @@ local function upsert_on_storage(space_name, tuple, operations, opts)
     -- add_space_schema_hash is true only in case of upsert_object
     -- the only one case when reloading schema can avoid insert error
     -- is flattening object on router
-    return schema.wrap_box_space_func_result(space, 'upsert', {tuple, operations}, {
+    return schema.wrap_func_result(space, space.upsert, {
         add_space_schema_hash = opts.add_space_schema_hash,
         fetch_latest_metadata = opts.fetch_latest_metadata,
-    })
+    }, space, tuple, operations)
 end
 
 upsert.storage_api = {[UPSERT_FUNC_NAME] = upsert_on_storage}


### PR DESCRIPTION
- remove the extra wrapper around box.space methods to avoid per-call closures and arg tables
- call wrap_func_result directly so storage paths allocate less and return handling stays centralized
- reduce storage-side overhead on replace/insert/delete/get/update/upsert(+_many) for better call latency

crud.replace on master:
![replace on master](https://github.com/user-attachments/assets/5b70db26-baca-4c3a-99b9-f8130b0b3a85)

A lot of work in lj_BC_FNEW, lj_BC_TDUP, lj_bc_TNEW

crud.replace  after drop wrap_box_space_func_result:
![replace after drop wrap_box_space_func_result](https://github.com/user-attachments/assets/eaa957bc-3ed7-4d5c-bdd8-6631482efdaa)




Benchmark (CRUD) | ns/op (branch) | ns/op (master) | Δ ns/op | op/s (branch) | op/s (master) | Δ op/s | B/op (branch) | B/op (master) | Δ B/op
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
delete_bench::bench_delete_crud | 746.5 | 1108 | -32.6% | 1,339,649 | 902,645 | +48.4% | 360 | 904 | -60.2%
get_bench::bench_get_crud | 1080 | 1273 | -15.2% | 926,138 | 785,517 | +17.9% | 592 | 816 | -27.5%
get_bench::bench_get_crud_empty | 1269 | 1384 | -8.3% | 787,892 | 722,747 | +9.0% | 616 | 840 | -26.7%
insert_bench::bench_insert_crud | 1684 | 2167 | -22.3% | 593,904 | 461,438 | +28.7% | 464 | 979 | -52.6%
multiple_bench::bench_multiple_crud | 4075 | 5431 | -25.0% | 245,405 | 184,123 | +33.3% | 1098 | 2600 | -57.8%
replace_bench::bench_replace_crud | 1291 | 1725 | -25.2% | 774,312 | 579,560 | +33.6% | 374 | 860 | -56.5%
update_bench::bench_update_crud | 1693 | 2151 | -21.3% | 590,826 | 464,809 | +27.1% | 570 | 1041 | -45.2%
upsert_bench::bench_upsert_crud | 1240 | 1645 | -24.6% | 806,177 | 607,733 | +32.7% | 224 | 704 | -68.2%




<details><summary>Details</summary>
<p>
BRANCH

Tarantool version: Tarantool 3.5.0-0-g81b5335e96
Tarantool build: Linux-x86_64-RelWithDebInfo (static)
Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -static-libstdc++ -fno-common -msse2  -fmacro-prefix-map=/tarantool=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -fno-gnu89-inline -Wno-cast-function-type -O2 -g -DNDEBUG -ggdb -O2 
CPU: 12th Gen Intel(R) Core(TM) i7-12700F @ 2112.004MHz
JIT: Enabled
JIT: SSE3 SSE4.1 BMI2 fold cse dce fwd dse narrow loop abc sink fuse
Duration: 3s
Global timeout: 60

--- BENCH: delete_bench::bench_delete_crud
 4843811               746.5 ns/op         1339649 op/s      360 B/op   +1663.03MB

--- BENCH: delete_bench::bench_delete_raw
10264413               348.2 ns/op         2872126 op/s       88 B/op   +861.43MB

--- BENCH: get_bench::bench_get_crud
 3370714              1080 ns/op            926138 op/s      592 B/op   +1903.03MB

--- BENCH: get_bench::bench_get_crud_empty
 2853994              1269 ns/op            787892 op/s      616 B/op   +1676.62MB

--- BENCH: get_bench::bench_get_raw
 6907857               520.6 ns/op         1920814 op/s       96 B/op   +632.44MB

--- BENCH: get_bench::bench_get_raw_empty
 5477172               648.9 ns/op         1541154 op/s      120 B/op   +626.81MB

--- BENCH: insert_bench::bench_insert_crud
 2206256              1684 ns/op            593904 op/s      464 B/op   +976.63MB

--- BENCH: insert_bench::bench_insert_raw
 3084187              1251 ns/op            799553 op/s      209 B/op   +617.62MB

--- BENCH: multiple_bench::bench_multiple_crud
 1000000              4075 ns/op            245405 op/s     1098 B/op   +1047.50MB

--- BENCH: replace_bench::bench_replace_crud
 2878729              1291 ns/op            774312 op/s      374 B/op   +1028.88MB

--- BENCH: replace_bench::bench_replace_raw
 5123957               719.4 ns/op         1390055 op/s       94 B/op   +459.66MB

--- BENCH: update_bench::bench_update_crud
 2072387              1693 ns/op            590826 op/s      570 B/op   +1128.17MB

--- BENCH: update_bench::bench_update_raw
 3292275              1110 ns/op            901292 op/s      185 B/op   +582.57MB

--- BENCH: upsert_bench::bench_upsert_crud
 2897877              1240 ns/op            806177 op/s      224 B/op   +619.08MB

--- BENCH: upsert_bench::bench_upsert_raw
 4090589               857.8 ns/op         1165802 op/s        0 B/op   +11.70KB

MASTER

Tarantool version: Tarantool 3.5.0-0-g81b5335e96
Tarantool build: Linux-x86_64-RelWithDebInfo (static)
Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -static-libstdc++ -fno-common -msse2  -fmacro-prefix-map=/tarantool=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -fno-gnu89-inline -Wno-cast-function-type -O2 -g -DNDEBUG -ggdb -O2 
CPU: 12th Gen Intel(R) Core(TM) i7-12700F @ 2112.004MHz
JIT: Enabled
JIT: SSE3 SSE4.1 BMI2 fold cse dce fwd dse narrow loop abc sink fuse
Duration: 3s
Global timeout: 60


--- BENCH: delete_bench::bench_delete_crud
 3286533              1108 ns/op            902645 op/s      904 B/op   +2833.39MB

--- BENCH: delete_bench::bench_delete_raw
10515327               347.1 ns/op         2880666 op/s       88 B/op   +882.49MB

--- BENCH: get_bench::bench_get_crud
 2853490              1273 ns/op            785517 op/s      816 B/op   +2220.59MB

--- BENCH: get_bench::bench_get_crud_empty
 2643043              1384 ns/op            722747 op/s      840 B/op   +2117.31MB

--- BENCH: get_bench::bench_get_raw
 6799610               521.1 ns/op         1919176 op/s       96 B/op   +622.53MB

--- BENCH: get_bench::bench_get_raw_empty
 5647241               650.2 ns/op         1538060 op/s      120 B/op   +646.28MB

--- BENCH: insert_bench::bench_insert_crud
 1695861              2167 ns/op            461438 op/s      979 B/op   +1583.78MB

--- BENCH: insert_bench::bench_insert_raw
 3121376              1252 ns/op            798698 op/s      211 B/op   +630.78MB

--- BENCH: multiple_bench::bench_multiple_crud
  850754              5431 ns/op            184123 op/s     2600 B/op   +2110.08MB

--- BENCH: replace_bench::bench_replace_crud
 2129221              1725 ns/op            579560 op/s      860 B/op   +1747.67MB

--- BENCH: replace_bench::bench_replace_raw
 4900527               725.9 ns/op         1377672 op/s      102 B/op   +478.07MB

--- BENCH: update_bench::bench_update_crud
 1686617              2151 ns/op            464809 op/s     1041 B/op   +1675.78MB

--- BENCH: update_bench::bench_update_raw
 3320403              1132 ns/op            883052 op/s      185 B/op   +588.62MB

--- BENCH: upsert_bench::bench_upsert_crud
 2186906              1645 ns/op            607733 op/s      704 B/op   +1468.27MB

--- BENCH: upsert_bench::bench_upsert_raw
 4233550               866.5 ns/op         1154011 op/s        0 B/op   +12.46KB
</p>
</details> 

code for benchmarks and profile [here](https://github.com/Satbek/bench_crud)

- [x] Tests
- [x] Changelog
- [ ] Documentation

Closes #470
