### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7.0] - 26-12-25
+
 ### Added
 * Implement "safe" mode to prevent writing data to wrong replicaset when vshard rebalance is in progress (#448).
 * Auto switch to safe mode when rebalance process starts.

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.6.1'
+return '1.7.0'


### PR DESCRIPTION
### Added
 * Implement "safe" mode to prevent writing data to wrong replicaset when vshard rebalance is in progress (#448).
 * Auto switch to safe mode when rebalance process starts.
 * Manual return to fast mode.

### Fixed
 * Drop wrap_box_space_func_result to cut allocations and speed up storage calls.