### PR TITLE
ci: update GitHub Actions runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -9,7 +9,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/push_rockspec.yaml
+++ b/.github/workflows/push_rockspec.yaml
@@ -14,7 +14,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master
@@ -22,7 +22,7 @@ jobs:
           module-name: 'crud'
 
   push-scm-rockspec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
           files: ${{ env.ROCK_NAME }}-scm-1.rockspec
 
   push-tagged-rockspec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags')
     needs: version-check
     steps:

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Clone the crud module

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool-version: [ "2.10", "2.11" ]
+        tarantool-version: [ "2.11" ]
         metrics-version: [ "" ]
         cartridge-version: [ "2.16.3" ]
         external-tuple-merger-version: [ "" ]
@@ -42,7 +42,7 @@ jobs:
             vshard-version: "0.1.36"
           - tarantool-version: "master"
             vshard-version: "0.1.36"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -139,9 +139,6 @@ jobs:
       fail-fast: false
       matrix:
         tarantool-version:
-          - tarantool-version:
-            folder: "2.10"
-            bundle: "tarantool-enterprise-sdk-gc64-2.10.8-0-r691.linux.x86_64"
           - folder: "2.11"
             bundle: "tarantool-enterprise-sdk-gc64-2.11.7-0-r691.linux.x86_64"
         metrics-version: [ "", "1.5.0" ]
@@ -159,7 +156,7 @@ jobs:
           - tarantool-version:
               folder: "3.5"
               bundle: "tarantool-enterprise-sdk-gc64-3.5.0-0-r70.linux.x86_64"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -198,7 +195,7 @@ jobs:
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        tarantool-version: [ "2.10", "2.11" ]
+        tarantool-version: [ "2.11" ]
         metrics-version: [ "1.1.0" ]
         cartridge-version: [ "2.16.3" ]
         include:
@@ -217,7 +214,7 @@ jobs:
           - tarantool-version: "master"
             vshard-version: "0.1.36"
       fail-fast: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Update workflows to use ubuntu-24.04 (noble), including reusable_testing.yml (and other) used in Tarantool integration testing.

Tarantool 2.10 is removed from the CI matrix because it is not available in Ubuntu 24.04 repositories and is not an LTS release.

Closes #446
