### PR TITLE
fix(select): use native after option for pagination on Tarantool 2.10+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+* Optimize `crud.select()` and `crud.pairs()` pagination with `after` cursor
+  by using native `after` option on Tarantool 2.10+ for O(1) cursor positioning.
+  Readview operations use native `after` only on Tarantool 3.x (#488).
+
 ## [1.7.3] - 03-02-26
 
 ### Added

--- a/crud/common/utils.lua
+++ b/crud/common/utils.lua
@@ -729,6 +729,11 @@ local function determine_enabled_features()
     enabled_tarantool_features.box_watch = is_version_ge(major, minor, patch, suffix, commits_since,
                                                          2, 10, 0, 'beta2', nil)
 
+    -- Native `after` option in index:pairs() and index:select() for O(1) cursor positioning
+    -- Available since Tarantool 2.10
+    enabled_tarantool_features.index_pairs_after = is_version_ge(major, minor, patch, suffix, commits_since,
+                                                                 2, 10, 0, nil, nil)
+
     enabled_tarantool_features.tarantool_3 = is_version_ge(major, minor, patch, suffix, commits_since,
                                                            3, 0, 0, nil, nil)
 


### PR DESCRIPTION
Optimize crud.select() and crud.pairs() pagination with after cursor by using native `after` option on Tarantool 2.10+ for O(1) cursor positioning instead of O(N) scroll_to_after_tuple.

The optimization applies to all iterators (GT/GE/LT/LE/EQ/REQ). For EQ/REQ iterators, native after is used only when after_tuple key matches scan_value to avoid 'Iterator position is invalid' error.

Readview operations use native after only on Tarantool 3.x, since the after option for read_view:pairs() is not available in 2.x.

- [x] Tests
- [x] Changelog
- [ ] Documentation

Closes #488