### PR TITLE
release 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7.4] - 12-02-26
+
 ### Fixed
 * Optimize `crud.select()` and `crud.pairs()` pagination with `after` cursor
   by using native `after` option on Tarantool 2.10+ for O(1) cursor positioning.

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.7.3'
+return '1.7.4'


### PR DESCRIPTION
Fixed
* Optimize `crud.select()` and `crud.pairs()` pagination with `after` cursor by using native `after` option on Tarantool 2.10+ for O(1) cursor positioning. Readview operations use native `after` only on Tarantool 3.x (#488).

- [ ] Tests
- [x] Changelog
- [ ] Documentation
