### PR TITLE
Yield every 1000 iterations when fetching sharding keys and funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+* Yield every 1000 iterations when fetching sharding keys and functions
+  so the server stays responsive when there are millions of records.
+
 ## [1.7.4] - 12-02-26
 
 ### Fixed

--- a/crud/common/sharding/sharding_metadata.lua
+++ b/crud/common/sharding/sharding_metadata.lua
@@ -16,6 +16,7 @@ local FetchShardingMetadataError = errors.new_class('FetchShardingMetadataError'
 
 local FETCH_FUNC_NAME = 'fetch_on_storage'
 local CRUD_FETCH_FUNC_NAME = utils.get_storage_call(FETCH_FUNC_NAME)
+local FETCH_BATCH_SIZE = 1000
 
 local sharding_metadata_module = {}
 
@@ -60,7 +61,9 @@ function sharding_metadata_module.fetch_on_storage()
     local metadata_map = {}
 
     if sharding_key_space ~= nil then
+        local i = 0
         for _, tuple in sharding_key_space:pairs() do
+            i = i + 1
             local space_name = tuple[sharding_utils.SPACE_NAME_FIELDNO]
             local sharding_key_def = tuple[sharding_utils.SPACE_SHARDING_KEY_FIELDNO]
             local space = box.space[space_name]
@@ -77,16 +80,26 @@ function sharding_metadata_module.fetch_on_storage()
                          'Ensure that you did a proper cleanup after DDL space drop.',
                          space_name)
             end
+
+            if i % FETCH_BATCH_SIZE == 0 then
+                fiber.yield()
+            end
         end
     end
 
     if sharding_func_space ~= nil then
+        local i = 0
         for _, tuple in sharding_func_space:pairs() do
+            i = i + 1
             local space_name = tuple[sharding_utils.SPACE_NAME_FIELDNO]
             local sharding_func_def = sharding_utils.extract_sharding_func_def(tuple)
             metadata_map[space_name] = metadata_map[space_name] or {}
             metadata_map[space_name].sharding_func_def = sharding_func_def
             metadata_map[space_name].sharding_func_hash = storage_cache.get_sharding_func_hash(space_name)
+
+            if i % FETCH_BATCH_SIZE == 0 then
+                fiber.yield()
+            end
         end
     end
 

--- a/crud/common/sharding/storage_metadata_cache.lua
+++ b/crud/common/sharding/storage_metadata_cache.lua
@@ -1,3 +1,4 @@
+local fiber = require('fiber')
 local stash = require('crud.common.stash')
 local utils = require('crud.common.sharding.utils')
 
@@ -5,6 +6,7 @@ local storage_metadata_cache = {}
 
 local FUNC = 1
 local KEY = 2
+local INIT_CACHE_BATCH_SIZE = 1000
 
 local cache_data = {
     [FUNC] = nil,
@@ -64,7 +66,9 @@ local function init_cache(section)
         end
     )
 
+    local i = 0
     for _, tuple in space:pairs() do
+        i = i + 1
         local space_name = tuple[utils.SPACE_NAME_FIELDNO]
         -- If the cache record for a space is not nil, it means
         -- that it was already set to up-to-date value with trigger.
@@ -72,6 +76,10 @@ local function init_cache(section)
         -- isn't expected to yield, but let it be here.
         if cache_data[section][space_name] == nil then
             update_hash_func(nil, tuple)
+        end
+
+        if i % INIT_CACHE_BATCH_SIZE == 0 then
+            fiber.yield()
         end
     end
 end


### PR DESCRIPTION
Yield every 1000 iterations when fetching sharding keys and functions so the server stays responsive when there are millions of records.