### PR TITLE
Bump migrations to 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ S3_ENDPOINT_URL := $(if $(S3_ENDPOINT_URL),$(S3_ENDPOINT_URL),https://hb.vkcs.cl
 	tt rocks install luacov-reporters 0.1.0 --only-server=sdk-2/rocks && \
 	tt rocks install metrics  1.5.0 && \
 	tt rocks install cartridge 2.16.3 && \
-	tt rocks install migrations 1.1.0 && \
+	tt rocks install migrations 1.2.0 && \
 	tt rocks make
 
 sdk-2:

--- a/deps.sh
+++ b/deps.sh
@@ -26,7 +26,7 @@ then
     ${TTCTL} rocks install luacov-coveralls --only-server=https://luarocks.org/
 
     ${TTCTL} rocks install cartridge "${CARTRIDGE_VERSION}"
-    ${TTCTL} rocks install migrations 1.1.0
+    ${TTCTL} rocks install migrations 1.2.0
 else
     if [[ "${VSHARD_VERSION}" == "master" ]]; then
         echo "Installing vshard from master branch..."


### PR DESCRIPTION
New helper functions added, see https://github.com/tarantool/migrations/releases/tag/1.2.0 for details
