### PR TITLE
feat: add crud.locate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Add `_recovery_point` system space introduced in upcoming Tarantool 3.8
   to crud.schema system spaces.
+* Add `crud.locate()` method to find whether a tuple is in `memtx` or `vinyl` engine.
+  Works for spaces managed by the enterprise `cooler` module.
 
 ### Fixed
 * Allow read-only operations (`get`, `select`, `pairs`, `count`, `min`, `max`)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It also provides the `crud-storage` and `crud-router` roles for
     - [Select conditions](#select-conditions)
   - [Pairs](#pairs)
   - [Min and max](#min-and-max)
+  - [Locate](#locate)
   - [Cut extra rows](#cut-extra-rows)
   - [Cut extra objects](#cut-extra-objects)
   - [Truncate](#truncate)
@@ -1269,6 +1270,55 @@ local result, err = crud.max('customers', 'age')
   - {'name': 'age', 'type': 'number'}
   rows:
   - [5, 1172, 'Jack', 35]
+```
+
+### Locate
+
+Locate the storage engine ('memtx' or 'vinyl') where the tuple is currently stored.
+This method works exclusively for spaces managed by the enterprise 'cooler' module.
+
+```lua
+local result, err = crud.locate(space_name, key, opts)
+```
+
+where:
+
+* `space_name` (`string`) - name of the space
+* `key` (`any`) - primary key value
+* `opts`:
+  * `bucket_id` (`?number|cdata`) - bucket ID
+  * `timeout` (`?number`) - `vshard.call` timeout and vshard master
+    discovery timeout (in seconds), default value is 2
+  * `request_timeout` (`?number`) - `vshard.call` `request_timeout` parameter.
+    Can be specified only with `mode` = `read`, and default value is the same as
+    user-passed `timeout`.
+  * `mode` (`?string`, `read` or `write`) - if `write` is specified then `locate` is
+    performed on master, default value is `read`
+  * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
+    the replicas
+  * `balance` (`?boolean`) - use replica according to vshard load balancing policy
+
+Returns string ('memtx' or 'vinyl') if the tuple is found, nil if the tuple is missing
+on the target storage, or nil with error if something went wrong.
+
+**Example:**
+
+```lua
+crud.locate('customers', 100)
+---
+- memtx
+- null
+...
+crud.locate('customers', 200)
+---
+- vinyl
+- null
+...
+crud.locate('customers', 999) -- tuple doesn't exist
+---
+- null
+- null
+...
 ```
 
 ### Cut extra rows

--- a/crud.lua
+++ b/crud.lua
@@ -17,6 +17,7 @@ local truncate = require('crud.truncate')
 local len = require('crud.len')
 local count = require('crud.count')
 local borders = require('crud.borders')
+local locate = require('crud.locate')
 local utils = require('crud.common.utils')
 local stats = require('crud.stats')
 local readview = require('crud.readview')
@@ -126,6 +127,10 @@ crud.min = stats.wrap(borders.min, stats.op.BORDERS)
 -- @refer borders.max
 -- @function max
 crud.max = stats.wrap(borders.max, stats.op.BORDERS)
+
+-- @refer locate.call
+-- @function locate
+crud.locate = stats.wrap(locate.call, stats.op.LOCATE)
 
 -- @refer utils.cut_rows
 -- @function cut_rows

--- a/crud/locate.lua
+++ b/crud/locate.lua
@@ -1,0 +1,231 @@
+local checks = require('checks')
+local errors = require('errors')
+
+local call = require('crud.common.call')
+local const = require('crud.common.const')
+local utils = require('crud.common.utils')
+local sharding = require('crud.common.sharding')
+local sharding_key_module = require('crud.common.sharding.sharding_key')
+local sharding_metadata_module = require('crud.common.sharding.sharding_metadata')
+local dev_checks = require('crud.common.dev_checks')
+local schema = require('crud.common.schema')
+local bucket_ref_unref = require('crud.common.sharding.bucket_ref_unref')
+
+local LocateError = errors.new_class('LocateError', {capture_stack = false})
+
+local locate = {}
+
+local LOCATE_FUNC_NAME = 'locate_on_storage'
+local CRUD_LOCATE_FUNC_NAME = utils.get_storage_call(LOCATE_FUNC_NAME)
+
+local function locate_on_storage(space_name, key, opts)
+    dev_checks('string', '?', {
+        bucket_id = 'number|cdata',
+        sharding_key_hash = '?number',
+        sharding_func_hash = '?number',
+        skip_sharding_hash_check = '?boolean',
+    })
+
+    opts = opts or {}
+
+    -- Dynamic check for the enterprise 'cooler' module
+    local has_cooler, cooler = pcall(require, 'cooler')
+    if not has_cooler or type(cooler) ~= 'table' or type(cooler.locate) ~= 'function' then
+        return {err = "Module 'cooler' with function 'locate' is not available on this storage"}
+    end
+
+    local space = box.space[space_name]
+    if space == nil then
+        return {err = string.format("Space %q doesn't exist", space_name)}
+    end
+
+    local _, sharding_err = sharding.check_sharding_hash(space_name,
+                                                         opts.sharding_func_hash,
+                                                         opts.sharding_key_hash,
+                                                         opts.skip_sharding_hash_check)
+    if sharding_err ~= nil then
+        return {err = sharding_err}
+    end
+
+    local ref_ok, bucket_ref_err, unref = bucket_ref_unref.bucket_refro(opts.bucket_id, space.engine)
+    if not ref_ok then
+        return {err = bucket_ref_err}
+    end
+
+    local ok, locate_res, locate_err = pcall(cooler.locate, space_name, key, opts.bucket_id)
+
+    local unref_ok, err_unref = unref(opts.bucket_id, space.engine)
+    if not unref_ok then
+        return {err = err_unref}
+    end
+
+    if not ok then
+        return {err = string.format("Cooler locate runtime error: %s", tostring(locate_res))}
+    end
+
+    if locate_err ~= nil then
+        return {err = string.format("Cooler locate failed: %s", tostring(locate_err))}
+    end
+
+    return {res = locate_res}
+end
+
+locate.storage_api = {[LOCATE_FUNC_NAME] = locate_on_storage}
+
+local function call_locate_on_router(vshard_router, space_name, key, opts)
+    dev_checks('table', 'string', '?', {
+        timeout = '?number',
+        request_timeout = '?number',
+        bucket_id = '?',
+        prefer_replica = '?boolean',
+        balance = '?boolean',
+        mode = '?string',
+        vshard_router = '?string|table',
+    })
+
+    local space, err = utils.get_space(space_name, vshard_router, {
+        timeout = opts.timeout,
+        read_only = opts.mode ~= 'write',
+    })
+    if err ~= nil then
+        return nil, LocateError:new("An error occurred during the operation: %s", err), const.NEED_SCHEMA_RELOAD
+    end
+    if space == nil then
+        return nil, LocateError:new("Space %q doesn't exist", space_name), const.NEED_SCHEMA_RELOAD
+    end
+
+    if box.tuple.is(key) then
+        key = key:totable()
+    end
+
+    local sharding_key = key
+    local sharding_key_hash = nil
+    local skip_sharding_hash_check = nil
+
+    if opts.bucket_id == nil then
+        local primary_index_parts = space.index[0].parts
+
+        local sharding_key_data, err = sharding_metadata_module.fetch_sharding_key_on_router(vshard_router, space_name)
+        if err ~= nil then
+            return nil, err
+        end
+
+        sharding_key, err = sharding_key_module.extract_from_pk(vshard_router,
+                                                                space_name,
+                                                                sharding_key_data.value,
+                                                                primary_index_parts, key)
+        if err ~= nil then
+            return nil, err
+        end
+
+        sharding_key_hash = sharding_key_data.hash
+    else
+        skip_sharding_hash_check = true
+    end
+
+    local bucket_id_data, err = sharding.key_get_bucket_id(vshard_router, space_name, sharding_key, opts.bucket_id)
+    if err ~= nil then
+        return nil, err
+    end
+
+    sharding.fill_bucket_id_pk(space, key, bucket_id_data.bucket_id)
+
+    local locate_on_storage_opts = {
+        bucket_id = bucket_id_data.bucket_id,
+        sharding_func_hash = bucket_id_data.sharding_func_hash,
+        sharding_key_hash = sharding_key_hash,
+        skip_sharding_hash_check = skip_sharding_hash_check,
+    }
+
+    local mode = opts.mode or 'read'
+
+    local call_opts = {
+        mode = mode,
+        prefer_replica = opts.prefer_replica,
+        balance = opts.balance,
+        timeout = opts.timeout,
+        request_timeout = mode == 'read' and opts.request_timeout or nil,
+    }
+
+    local storage_result, err = call.single(vshard_router,
+        bucket_id_data.bucket_id, CRUD_LOCATE_FUNC_NAME,
+        {space_name, key, locate_on_storage_opts},
+        call_opts
+    )
+
+    if err ~= nil then
+        local err_wrapped = LocateError:new("Failed to call locate on storage-side: %s", err)
+
+        if sharding.result_needs_sharding_reload(err) then
+            return nil, err_wrapped, const.NEED_SHARDING_RELOAD
+        end
+
+        return nil, err_wrapped
+    end
+
+    if storage_result.err ~= nil then
+        return nil, LocateError:new("Failed to locate: %s", storage_result.err)
+    end
+
+    return storage_result.res
+end
+
+--- Locate tuple location by space name and primary key via cooler module
+--
+-- @function call
+--
+-- @param string space_name
+--  A space name
+--
+-- @param key
+--  Primary key value
+--
+-- @tparam ?number opts.timeout
+--  Function call timeout
+--
+-- @tparam ?number opts.request_timeout
+--  vshard call request_timeout
+--  default is the same as opts.timeout
+--
+-- @tparam ?number opts.bucket_id
+--  Bucket ID
+--  (by default, it's vshard.router.bucket_id_strcrc32 of primary key)
+--
+-- @tparam ?boolean opts.prefer_replica
+--  Call on replica if it's possible
+--
+-- @tparam ?boolean opts.balance
+--  Use replica according to round-robin load balancing
+--
+-- @tparam ?string|table opts.vshard_router
+--  Cartridge vshard group name or vshard router instance.
+--  Set this parameter if your space is not a part of the
+--  default vshard cluster.
+--
+-- @return[1] string 'memtx' or 'vinyl'
+-- @return[2] nil
+-- @treturn[3] table Error description
+--
+function locate.call(space_name, key, opts)
+    checks('string', '?', {
+        timeout = '?number',
+        request_timeout = '?number',
+        bucket_id = '?',
+        prefer_replica = '?boolean',
+        balance = '?boolean',
+        mode = '?string',
+        vshard_router = '?string|table',
+    })
+
+    opts = opts or {}
+
+    local vshard_router, err = utils.get_vshard_router_instance(opts.vshard_router)
+    if err ~= nil then
+        return nil, LocateError:new(err)
+    end
+
+    return schema.wrap_func_reload(vshard_router, sharding.wrap_method, call_locate_on_router,
+                                   space_name, key, opts)
+end
+
+return locate

--- a/crud/stats/operation.lua
+++ b/crud/stats/operation.lua
@@ -26,4 +26,6 @@ return {
     COUNT = 'count',
     -- BORDERS identifies both `min` and `max`.
     BORDERS = 'borders',
+    -- LOCATE identifies `locate` operation via cooler module.
+    LOCATE = 'locate',
 }

--- a/crud/storage.lua
+++ b/crud/storage.lua
@@ -22,6 +22,7 @@ local truncate = require('crud.truncate')
 local len = require('crud.len')
 local count = require('crud.count')
 local borders = require('crud.borders')
+local locate = require('crud.locate')
 local readview = require('crud.readview')
 local storage_info = require('crud.storage_info')
 
@@ -81,6 +82,7 @@ local modules_with_storage_api = {
     len,
     count,
     borders,
+    locate,
     readview,
     -- Must be initialized last: properly working storage info is the flag
     -- of initialization success.

--- a/test/integration/locate_test.lua
+++ b/test/integration/locate_test.lua
@@ -1,0 +1,110 @@
+local t = require('luatest')
+local helpers = require('test.helper')
+
+local pgroup = t.group('locate', helpers.backend_matrix({
+    {engine = 'memtx'},
+}))
+
+pgroup.before_all(function(g)
+    helpers.skip_if_tarantool3_crud_roles_unsupported()
+    helpers.start_default_cluster(g, 'srv_select')
+end)
+
+pgroup.after_all(function(g)
+    helpers.stop_cluster(g.cluster, g.params.backend)
+end)
+
+local function inject_mock_cooler(cluster, mock_script)
+    for _, server in ipairs(cluster.servers) do
+        server:exec(function(script)
+            local mock_cooler = {}
+
+            local func, err = load(script)
+            if func == nil then
+                error("Failed to load mock: " .. tostring(err))
+            end
+
+            mock_cooler.locate = func()
+            package.loaded['cooler'] = mock_cooler
+        end, {mock_script})
+    end
+end
+
+local function unload_mock_cooler(cluster)
+    for _, server in ipairs(cluster.servers) do
+        server:exec(function()
+            package.loaded['cooler'] = nil
+        end)
+    end
+end
+
+pgroup.test_locate_when_cooler_missing = function(g)
+    unload_mock_cooler(g.cluster)
+
+    local result, err = g.router:call('crud.locate', {'customers', 1})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "'locate' is not available")
+end
+
+pgroup.test_locate_non_existent_space = function(g)
+    -- Inject a dummy mock just to bypass the module presence check
+    inject_mock_cooler(g.cluster, [[
+        return function(space_name, key, bucket_id) return 'memtx' end
+    ]])
+
+    local result, err = g.router:call('crud.locate', {'non_existent_space', 1})
+
+    t.assert_equals(result, nil)
+    t.assert_str_contains(err.err, "Space \"non_existent_space\" doesn't exist")
+end
+
+pgroup.test_locate_various_locations = function(g)
+    inject_mock_cooler(g.cluster, [[
+        return function(space_name, key, bucket_id)
+            if key == 100 then
+                return 'memtx'
+            elseif key == 200 then
+                return 'vinyl'
+            elseif key == 300 then
+                return nil
+            elseif key == 400 then
+                return nil, "Internal cooler error occurred"
+            end
+            return nil
+        end
+    ]])
+
+    local res_memtx, err_memtx = g.router:call('crud.locate', {'customers', 100})
+    t.assert_equals(err_memtx, nil)
+    t.assert_equals(res_memtx, 'memtx')
+
+    local res_vinyl, err_vinyl = g.router:call('crud.locate', {'customers', 200})
+    t.assert_equals(err_vinyl, nil)
+    t.assert_equals(res_vinyl, 'vinyl')
+
+    local res_nil, err_nil = g.router:call('crud.locate', {'customers', 300})
+    t.assert_equals(err_nil, nil)
+    t.assert_equals(res_nil, nil)
+
+    local res_err, err_msg = g.router:call('crud.locate', {'customers', 400})
+    t.assert_equals(res_err, nil)
+    t.assert_str_contains(err_msg.err, "Internal cooler error occurred")
+end
+
+pgroup.test_opts_not_damaged = function(g)
+    inject_mock_cooler(g.cluster, [[
+        return function(space_name, key, bucket_id) return 'memtx' end
+    ]])
+
+    local locate_opts = {timeout = 1, mode = 'read'}
+
+    local new_locate_opts, err = g.router:exec(function(opts)
+        local crud = require('crud')
+        local _, err = crud.locate('customers', 100, opts)
+        return opts, err
+    end, {locate_opts})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(new_locate_opts, locate_opts)
+end

--- a/test/integration/stats_test.lua
+++ b/test/integration/stats_test.lua
@@ -985,6 +985,52 @@ pgroup.test_spaces_dropped_in_runtime_supported_with_stats = function(g)
         "Error requests count incremented since space was known to registry before drop")
 end
 
+pgroup.test_locate_stats_error = function(g)
+    local op = 'locate'
+
+    local stats_before = get_stats(g, space_name)
+    local op_before = set_defaults_if_empty(stats_before, op)
+
+    local _, err = g.router:call('crud.locate', { space_name, 999 })
+    t.assert_not_equals(err, nil)
+    t.assert_str_contains(err.err, "Module 'cooler' with function 'locate' is not available")
+
+    local stats_after = get_stats(g, space_name)
+    local op_after = stats_after[op]
+    t.assert_equals(op_after.error.count - op_before.error.count, 1, 'Error count incremented')
+end
+
+pgroup.test_locate_stats_success = function(g)
+    local op = 'locate'
+
+    helpers.call_on_storages(g.cluster, function(server)
+        server:exec(function()
+            package.loaded['cooler'] = {
+                locate = function()
+                    return 'memtx'
+                end
+            }
+        end)
+    end)
+
+    local stats_before = get_stats(g, space_name)
+    local op_before = set_defaults_if_empty(stats_before, op)
+
+    local res, err = g.router:call('crud.locate', { space_name, 12 })
+    t.assert_equals(err, nil)
+    t.assert_equals(res, 'memtx')
+
+    local stats_after = get_stats(g, space_name)
+    local op_after = stats_after[op]
+    t.assert_equals(op_after.ok.count - op_before.ok.count, 1, 'Success count incremented')
+
+    helpers.call_on_storages(g.cluster, function(server)
+        server:exec(function()
+            package.loaded['cooler'] = nil
+        end)
+    end)
+end
+
 -- https://github.com/tarantool/metrics/blob/fc5a67072340b12f983f09b7d383aca9e2f10cf1/test/utils.lua#L22-L31
 local function find_obs(metric_name, label_pairs, observations)
     for _, obs in pairs(observations) do


### PR DESCRIPTION
Introduced `crud.locate(space_name, key, opts)` to detect whether a tuple is located in 'memtx' or 'vinyl' engine.
This works exclusively for spaces managed by the enterprise 'cooler' module.

Closes TNTP-8214
