### PR TITLE
schema: add new system space _recovery_point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+* Add `_recovery_point` system space introduced in upcoming Tarantool 3.8
+  to crud.schema system spaces.
+
 ## [1.7.4] - 12-02-26
 
 ### Fixed

--- a/crud/schema.lua
+++ b/crud/schema.lua
@@ -40,6 +40,7 @@ schema.system_spaces = {
     ['_func_index'] = true,
     ['_session_settings'] = true,
     ['_gc_consumers'] = true,
+    ['_recovery_point'] = true,
     -- https://github.com/tarantool/vshard/blob/b3c27b32637863e9a03503e641bb7c8c69779a00/vshard/storage/init.lua#L752
     ['_bucket'] = true,
     -- https://github.com/tarantool/ddl/blob/b55d0ff7409f32e4d527e2d25444d883bce4163b/test/set_sharding_metadata_test.lua#L92-L98


### PR DESCRIPTION
This is space that is going to be added in Tarantool 3.8.

We need this change to pass integration CI with [Tarantool PR](https://github.com/tarantool/tarantool/pull/12835) introducing this space (currently [this](https://github.com/tarantool/tarantool/actions/runs/28787469868/job/85359515185?pr=12835) workflow fails). 
