### PR TITLE
feat: add read-only options to crud.len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   to crud.schema system spaces.
 * Add `crud.locate()` method to find whether a tuple is in `memtx` or `vinyl` engine.
   Works for spaces managed by the enterprise `cooler` module.
+* Support for `mode`, `balance`, `prefer_replica` and `request_timeout` options in `crud.len`.
 
 ### Fixed
 * Allow read-only operations (`get`, `select`, `pairs`, `count`, `min`, `max`)

--- a/README.md
+++ b/README.md
@@ -1405,6 +1405,14 @@ where:
 * `opts`:
   * `timeout` (`?number`) - `vshard.call` timeout and vshard master
     discovery timeout (in seconds), default value is 2
+  * `request_timeout` (`?number`) - `vshard.call` `request_timeout` parameter.
+    Can be specified only with `mode` = `read`, and default value is the same as
+    user-passed `timeout`.
+  * `mode` (`?string`, `read` or `write`) - if `write` is specified then `len` is
+    performed on master, default value is `write`
+  * `prefer_replica` (`?boolean`) - if `true` then the preferred target is one of
+    the replicas
+  * `balance` (`?boolean`) - use replica according to vshard load balancing policy
   * `vshard_router` (`?string|table`) - Cartridge vshard group name or
     vshard router instance. Set this parameter if your space is not
     a part of the default vshard cluster

--- a/crud/len.lua
+++ b/crud/len.lua
@@ -43,6 +43,10 @@ len.storage_api = {[LEN_FUNC_NAME] = len_on_storage}
 function len.call(space_name, opts)
     checks('string', {
         timeout = '?number',
+        request_timeout = '?number',
+        prefer_replica = '?boolean',
+        balance = '?boolean',
+        mode = '?string',
         vshard_router = '?string|table',
     })
 
@@ -53,7 +57,10 @@ function len.call(space_name, opts)
         return nil, LenError:new(err)
     end
 
-    local space, err = utils.get_space(space_name, vshard_router, {timeout = opts.timeout})
+    local space, err = utils.get_space(space_name, vshard_router, {
+        timeout = opts.timeout,
+        read_only = opts.mode == 'read',
+    })
     if err ~= nil then
         return nil, LenError:new("An error occurred during the operation: %s", err)
     end
@@ -61,10 +68,17 @@ function len.call(space_name, opts)
         return nil, LenError:new("Space %q doesn't exist", space_name)
     end
 
-    local results, err = call.map(vshard_router, CRUD_LEN_FUNC_NAME, {space_name}, {
-        mode = 'write',
+    local mode = opts.mode or 'write'
+
+    local call_opts = {
+        mode = mode,
+        prefer_replica = opts.prefer_replica,
+        balance = opts.balance,
         timeout = opts.timeout,
-    })
+        request_timeout = mode == 'read' and opts.request_timeout or nil,
+    }
+
+    local results, err = call.map(vshard_router, CRUD_LEN_FUNC_NAME, {space_name}, call_opts)
 
     if err ~= nil then
         return nil, LenError:new("Failed to call len on storage-side: %s", err)

--- a/test/integration/len_test.lua
+++ b/test/integration/len_test.lua
@@ -44,6 +44,30 @@ pgroup.test_len = function(g)
 
     t.assert_equals(err, nil)
     t.assert_equals(result, expected_len)
+
+    local result_replica, err_replica = g.router:call('crud.len', {
+        'customers', {
+            mode = 'read',
+            prefer_replica = true,
+            balance = false,
+            timeout = 4,
+            request_timeout = 2,
+        }
+    })
+
+    t.assert_equals(err_replica, nil)
+    t.assert_equals(result_replica, expected_len)
+
+    local result_balance, err_balance = g.router:call('crud.len', {
+        'customers', {
+            mode = 'read',
+            prefer_replica = false,
+            balance = true,
+        }
+    })
+
+    t.assert_equals(err_balance, nil)
+    t.assert_equals(result_balance, expected_len)
 end
 
 pgroup.test_len_empty_space = function(g)
@@ -54,7 +78,13 @@ pgroup.test_len_empty_space = function(g)
 end
 
 pgroup.test_opts_not_damaged = function(g)
-    local len_opts = {timeout = 1}
+    local len_opts = {
+        timeout = 1,
+        request_timeout = 1,
+        mode = 'read',
+        prefer_replica = true,
+        balance = true,
+    }
     local new_len_opts, err = g.router:eval([[
         local crud = require('crud')
 

--- a/test/integration/read_dead_masters_test.lua
+++ b/test/integration/read_dead_masters_test.lua
@@ -40,6 +40,10 @@ pgroup.test_read_operations_when_masters_are_down = function(g)
     end)
     t.assert_equals(#pairs_tuples, 2)
 
+    local len_res, err = g.router:call('crud.len', {'customers', {mode = 'read'}})
+    t.assert_equals(err, nil)
+    t.assert_equals(len_res, 2)
+
     local select_res, err = g.router:call('crud.select', {'customers', {{'<=', 'age', 35}}})
     t.assert_equals(err, nil)
     t.assert_not_equals(select_res, nil)


### PR DESCRIPTION
Added support for `mode`, `balance`, `prefer_replica` and `request_timeout` options in crud.len.

The default `mode` remains `write` to preserve backward compatibility.
