### PR TITLE
[TNTP-8909] fix: stop following the transfer destination on bucket ref error retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+* Fix consistency violation during rebalancing: a request could be retried on a
+  storage that did not own the bucket yet, so a read returned no data and a
+  write went to the wrong replicaset (#509).
+* Stop retrying requests blindly: a request is retried only if the router has
+  recovered from the error, and a retry never runs past the original timeout —
+  before, a request could take up to twice as long as requested.
+
 ## [1.7.5] - 15-07-26
 
 ### Added

--- a/crud/common/call.lua
+++ b/crud/common/call.lua
@@ -73,47 +73,145 @@ local function wrap_vshard_err(err, func_name, replicaset_id)
     ))
 end
 
---- Executes a vshard call and retries once after performing recovery actions
---- like bucket cache reset, destination redirect (for single calls), or master discovery.
-local function call_with_retry_and_recovery(vshard_router,
-    replicaset, method, func_name, func_args, call_opts, is_single_call)
+--- Executes a CRUD function on a vshard replicaset.
+local function call_on_replicaset(replicaset, method, func_name, func_args, call_opts)
     local func_args_ext = utils.append_array({ box.session.effective_user(), func_name }, func_args)
-
-    -- In case cluster was just bootstrapped with auto master discovery,
-    -- replicaset may miss master.
-    local resp, err = replicaset[method](replicaset, CRUD_CALL_FUNC_NAME, func_args_ext, call_opts)
-
-    if err == nil then
-        return resp, err
-    end
-
-    -- This is a partial copy of error handling from vshard.router.router_call_impl()
-    -- It is much simpler mostly because bucket_set() can't be accessed from outside vshard.
-    if err.class_name == bucket_ref_unref.BucketRefError.name then
-        if is_single_call and #err.bucket_ref_errs == 1 then
-            local single_err = err.bucket_ref_errs[1]
-            local destination = single_err.vshard_err.destination
-            if destination and vshard_router.replicasets[destination] then
-                replicaset = vshard_router.replicasets[destination]
-            end
-        end
-
-        for _, bucket_ref_err in pairs(err.bucket_ref_errs) do
-            local bucket_id = bucket_ref_err.bucket_id
-            local vshard_err = bucket_ref_err.vshard_err
-            if vshard_err.name == 'WRONG_BUCKET' or
-               vshard_err.name == 'BUCKET_IS_LOCKED' or
-               vshard_err.name == 'TRANSFER_IS_IN_PROGRESS' then
-                vshard_router:_bucket_reset(bucket_id)
-            end
-        end
-    elseif err.name == 'MISSING_MASTER' and replicaset.locate_master ~= nil then
-        replicaset:locate_master()
-    end
-
-    -- Retry only once: should be enough for initial discovery,
-    -- otherwise force user fix up cluster bootstrap.
     return replicaset[method](replicaset, CRUD_CALL_FUNC_NAME, func_args_ext, call_opts)
+end
+
+--- The bucket is not on the replicaset it is routed to anymore, so its
+--- route is stale and must be dropped from the router cache.
+local BUCKET_MOVED_ERRS = {
+    WRONG_BUCKET = true,
+    BUCKET_IS_LOCKED = true,
+    TRANSFER_IS_IN_PROGRESS = true,
+}
+
+--- Performs a recovery action for a call error:
+--- * MISSING_MASTER - the replicaset master is not discovered yet, so it
+---   is discovered explicitly;
+--- * NON_MASTER - the cached master is stale, but the bucket did not move,
+---   so the master is updated and the same replicaset can be retried;
+--- * WRONG_BUCKET, BUCKET_IS_LOCKED, TRANSFER_IS_IN_PROGRESS - the bucket
+---   route is stale, so the route cache is reset and the bucket is routed
+---   anew.
+---
+--- The routes of all the moved buckets are reset even when the request itself
+--- cannot be retried: the cache is stale regardless of the retry decision.
+---
+--- Returns:
+--- * replicaset - the replicaset to retry the request on;
+--- * nil - the request cannot be retried;
+--- * nil, err - the recovery itself failed, so the request cannot be retried.
+local function recover_from_err(vshard_router, replicaset, err)
+    local vshard_err = err
+
+    if err.class_name == bucket_ref_unref.BucketRefError.name then
+        for _, bucket_ref_err in ipairs(err.bucket_ref_errs) do
+            if BUCKET_MOVED_ERRS[bucket_ref_err.vshard_err.name] then
+                vshard_router:_bucket_reset(bucket_ref_err.bucket_id)
+            end
+        end
+
+        -- A request that failed on several buckets has no single replicaset
+        -- to be retried on, so only a single-bucket one is recovered further.
+        if #err.bucket_ref_errs ~= 1 then
+            return nil
+        end
+
+        vshard_err = err.bucket_ref_errs[1].vshard_err
+
+        if BUCKET_MOVED_ERRS[vshard_err.name] then
+            -- The stale route has been reset above, so the bucket is routed
+            -- anew.
+            local new_replicaset, route_err = vshard_router:route(err.bucket_ref_errs[1].bucket_id)
+            if route_err ~= nil then
+                return nil, CallError:new(
+                    "Failed to get router replicaset: %s, after an error: %s",
+                    tostring(route_err),
+                    tostring(err)
+                )
+            end
+            return new_replicaset
+        end
+    end
+
+    if vshard_err.name == 'MISSING_MASTER' then
+        replicaset:locate_master()
+        -- The master is not found, so the retry would get the same error.
+        if replicaset.master == nil then
+            return nil
+        end
+        return replicaset
+    elseif vshard_err.name == 'NON_MASTER' then
+        -- If the master update failed, the retry would get the same error.
+        if not replicaset:update_master(vshard_err.replica, vshard_err.master) then
+            return nil
+        end
+        return replicaset
+    end
+
+    return nil
+end
+
+local function call_single_with_recovery(vshard_router,
+    replicaset, method, func_name, func_args, call_opts)
+    local deadline = fiber_clock() + call_opts.timeout
+
+    local resp, err = call_on_replicaset(replicaset, method, func_name, func_args, call_opts)
+    if err == nil then
+        return resp, err, replicaset.id
+    end
+
+    local retry_replicaset, recover_err = recover_from_err(vshard_router, replicaset, err)
+    if retry_replicaset == nil then
+        return resp, recover_err or err, replicaset.id
+    end
+
+    local timeout = deadline - fiber_clock()
+    if timeout <= 0 then
+        return resp, err, replicaset.id
+    end
+
+    replicaset = retry_replicaset
+
+    call_opts.timeout = timeout
+    if call_opts.request_timeout ~= nil and call_opts.request_timeout > timeout then
+        call_opts.request_timeout = timeout
+    end
+
+    resp, err = call_on_replicaset(replicaset, method, func_name, func_args, call_opts)
+    return resp, err, replicaset.id
+end
+
+local function call_map_with_recovery(replicaset, method, func_name, func_args,
+    call_opts, deadline)
+    local future, err = call_on_replicaset(replicaset, method, func_name, func_args, call_opts)
+    if err == nil or err.name ~= 'MISSING_MASTER' then
+        return future, err
+    end
+
+    if fiber_clock() >= deadline then
+        return future, err
+    end
+
+    replicaset:locate_master()
+
+    -- The master is not found, so the retry would get the same error.
+    if replicaset.master == nil then
+        return future, err
+    end
+
+    local timeout = deadline - fiber_clock()
+    if timeout <= 0 then
+        return future, err
+    end
+
+    if call_opts.request_timeout ~= nil and call_opts.request_timeout > timeout then
+        call_opts.request_timeout = timeout
+    end
+
+    return call_on_replicaset(replicaset, method, func_name, func_args, call_opts)
 end
 
 function call.map(vshard_router, func_name, func_args, opts)
@@ -158,11 +256,13 @@ function call.map(vshard_router, func_name, func_args, opts)
         is_async = true,
         request_timeout = opts.mode == 'read' and opts.request_timeout or nil,
     }
+
+    local deadline = fiber_clock() + timeout
     while iter:has_next() do
         local args, replicaset, replicaset_id = iter:get()
 
-        local future, err = call_with_retry_and_recovery(vshard_router, replicaset, vshard_call_name,
-            func_name, args, call_opts, false)
+        local future, err = call_map_with_recovery(replicaset, vshard_call_name,
+            func_name, args, call_opts, deadline)
 
         if err ~= nil then
             local result_info = {
@@ -184,7 +284,6 @@ function call.map(vshard_router, func_name, func_args, opts)
         futures_by_replicasets[replicaset_id] = future
     end
 
-    local deadline = fiber_clock() + timeout
     for replicaset_id, future in pairs(futures_by_replicasets) do
         local wait_timeout = deadline - fiber_clock()
         if wait_timeout < 0 then
@@ -235,10 +334,11 @@ function call.single(vshard_router, bucket_id, func_name, func_args, opts)
     local timeout = opts.timeout or const.DEFAULT_VSHARD_CALL_TIMEOUT
     local request_timeout = opts.mode == 'read' and opts.request_timeout or nil
 
-    local res, err = call_with_retry_and_recovery(vshard_router, replicaset, vshard_call_name,
-        func_name, func_args, {timeout = timeout, request_timeout = request_timeout}, true)
+    local res, err, replicaset_id = call_single_with_recovery(vshard_router, replicaset, vshard_call_name,
+        func_name, func_args, {timeout = timeout, request_timeout = request_timeout})
+
     if err ~= nil then
-        return nil, wrap_vshard_err(err, func_name, replicaset.id)
+        return nil, wrap_vshard_err(err, func_name, replicaset_id)
     end
 
     if res == box.NULL then
@@ -265,7 +365,7 @@ function call.any(vshard_router, func_name, func_args, opts)
 
     local deadline = fiber_clock() + timeout
 
-    for replicaset_id, replicaset in pairs(replicasets) do
+    for _, replicaset in pairs(replicasets) do
         local wait_timeout = deadline - fiber_clock()
 
         local is_timeout = wait_timeout < 0
@@ -273,8 +373,8 @@ function call.any(vshard_router, func_name, func_args, opts)
             wait_timeout = 0
         end
 
-        local res, err = call_with_retry_and_recovery(vshard_router, replicaset, 'callro',
-            func_name, func_args, {timeout = wait_timeout}, false)
+        local res, err, replicaset_id = call_single_with_recovery(vshard_router, replicaset, 'callro',
+            func_name, func_args, {timeout = wait_timeout})
 
         if err == nil then
             if res == box.NULL then

--- a/crud/common/call.lua
+++ b/crud/common/call.lua
@@ -53,27 +53,16 @@ function call.get_vshard_call_name(mode, prefer_replica, balance)
     return 'callbre'
 end
 
-local function wrap_vshard_err(vshard_router, err, func_name, replicaset_id, bucket_id)
+local function wrap_vshard_err(err, func_name, replicaset_id)
     -- Do not rewrite ShardingHashMismatchError class.
     if err.class_name == sharding_utils.ShardingHashMismatchError.name then
         return errors.wrap(err)
     end
 
     if replicaset_id == nil then
-        local replicaset, _ = vshard_router:route(bucket_id)
-        if replicaset == nil then
-            return CallError:new(
-                "Function returned an error, but we couldn't figure out the replicaset: %s", err
-            )
-        end
-
-        replicaset_id = utils.get_replicaset_id(vshard_router, replicaset)
-
-        if replicaset_id == nil then
-            return CallError:new(
-                "Function returned an error, but we couldn't figure out the replicaset id: %s", err
-            )
-        end
+        return CallError:new(
+            "Function returned an error, but we couldn't figure out the replicaset id: %s", err
+        )
     end
 
     err = utils.update_storage_call_error_description(err, func_name, replicaset_id)
@@ -249,7 +238,7 @@ function call.single(vshard_router, bucket_id, func_name, func_args, opts)
     local res, err = call_with_retry_and_recovery(vshard_router, replicaset, vshard_call_name,
         func_name, func_args, {timeout = timeout, request_timeout = request_timeout}, true)
     if err ~= nil then
-        return nil, wrap_vshard_err(vshard_router, err, func_name, nil, bucket_id)
+        return nil, wrap_vshard_err(err, func_name, replicaset.id)
     end
 
     if res == box.NULL then
@@ -302,7 +291,7 @@ function call.any(vshard_router, func_name, func_args, opts)
         end
     end
 
-    return nil, wrap_vshard_err(vshard_router, last_err, func_name, last_replicaset_id)
+    return nil, wrap_vshard_err(last_err, func_name, last_replicaset_id)
 end
 
 return call

--- a/crud/common/map_call_cases/base_postprocessor.lua
+++ b/crud/common/map_call_cases/base_postprocessor.lua
@@ -7,12 +7,11 @@ local BasePostprocessor = {}
 -- @function new
 --
 -- @return[1] table postprocessor
-function BasePostprocessor:new(vshard_router)
+function BasePostprocessor:new()
     local postprocessor = {
         results = {},
         early_exit = false,
         errs = nil,
-        vshard_router = vshard_router,
         storage_info = {},
     }
 
@@ -68,7 +67,7 @@ function BasePostprocessor:collect(result_info, err_info)
 
     if err ~= nil then
         self.results = nil
-        self.errs = err_info.err_wrapper(self.vshard_router, err, unpack(err_info.wrapper_args))
+        self.errs = err_info.err_wrapper(err, unpack(err_info.wrapper_args))
         self.early_exit = true
 
         return self.early_exit

--- a/crud/common/map_call_cases/batch_postprocessor.lua
+++ b/crud/common/map_call_cases/batch_postprocessor.lua
@@ -55,7 +55,7 @@ function BatchPostprocessor:collect(result_info, err_info)
                 err_to_wrap = err.err
             end
 
-            local err_obj = err_info.err_wrapper(self.vshard_router, err_to_wrap, unpack(err_info.wrapper_args))
+            local err_obj = err_info.err_wrapper(err_to_wrap, unpack(err_info.wrapper_args))
             err_obj.operation_data = err.operation_data
             err_obj.space_schema_hash = err.space_schema_hash
 

--- a/crud/common/rebalance.lua
+++ b/crud/common/rebalance.lua
@@ -25,10 +25,13 @@ local function safe_mode_bucket_trigger(_, new, space, op)
     if space ~= '_bucket' then
         return
     end
-    -- We are interested only in two operations that indicate the beginning of bucket migration:
-    --  * We are receiving a bucket (new bucket with status RECEIVING)
-    --  * We are sending a bucket to another node (existing bucket status changes to SENDING)
+    -- Rebalancing start markers:
+    --  * INSERT with RECEIVING - the bucket is being received.
+    --  * UPDATE to READONLY - since vshard 0.1.41 a transfer starts in
+    --    READONLY.
+    --  * REPLACE to SENDING - compatibility with older vshard versions.
     if (op == 'INSERT' and new.status == vshard_consts.BUCKET.RECEIVING) or
+       (op == 'UPDATE' and new.status == vshard_consts.BUCKET.READONLY) or
        (op == 'REPLACE' and new.status == vshard_consts.BUCKET.SENDING) then
         local stored_safe_mode = schema.settings_space:get{ SAFE_MODE_STATUS }
         if not stored_safe_mode or not stored_safe_mode.value then

--- a/crud/common/sharding/init.lua
+++ b/crud/common/sharding/init.lua
@@ -18,7 +18,8 @@ function sharding.get_replicasets_by_bucket_id(vshard_router, bucket_id)
         return nil, GetReplicasetsError:new("Failed to get replicaset for bucket_id %s: %s", bucket_id, err.err)
     end
 
-    local replicaset_id = utils.get_replicaset_id(vshard_router, replicaset)
+    local replicaset_id = replicaset.id
+
     if replicaset_id == nil then
         return nil, GetReplicasetsError:new("Failed to get replicaset id for bucket_id %s replicaset", bucket_id)
     end
@@ -314,7 +315,7 @@ function sharding.split_tuples_by_replicaset(vshard_router, tuples, space, opts)
                     sharding_data.bucket_id, err.err)
         end
 
-        local replicaset_id = utils.get_replicaset_id(vshard_router, replicaset)
+        local replicaset_id = replicaset.id
         if replicaset_id == nil then
             return nil, GetReplicasetsError:new(
                     "Failed to get replicaset id for bucket_id %s replicaset",

--- a/crud/common/vshard_utils.lua
+++ b/crud/common/vshard_utils.lua
@@ -100,19 +100,6 @@ function vshard_utils.get_self_vshard_replica_id()
     end
 end
 
-function vshard_utils.get_replicaset_id(vshard_router, replicaset)
-    -- https://github.com/tarantool/vshard/issues/460.
-    local known_replicasets = vshard_router:routeall()
-
-    for known_replicaset_id, known_replicaset in pairs(known_replicasets) do
-        if known_replicaset == replicaset then
-            return known_replicaset_id
-        end
-    end
-
-    return nil
-end
-
 function vshard_utils.get_vshard_identification_mode()
     -- https://github.com/tarantool/vshard/issues/460.
     assert(vshard.storage.internal.current_cfg ~= nil, 'available only on vshard storage')

--- a/crud/insert_many.lua
+++ b/crud/insert_many.lua
@@ -214,7 +214,7 @@ local function call_insert_many_on_router(vshard_router, space_name, original_tu
         return nil, {err}, const.NEED_SCHEMA_RELOAD
     end
 
-    local postprocessor = BatchPostprocessor:new(vshard_router)
+    local postprocessor = BatchPostprocessor:new()
 
     local rows, errs, storages_info = call.map(vshard_router, CRUD_INSERT_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,

--- a/crud/replace_many.lua
+++ b/crud/replace_many.lua
@@ -214,7 +214,7 @@ local function call_replace_many_on_router(vshard_router, space_name, original_t
         return nil, {err}, const.NEED_SCHEMA_RELOAD
     end
 
-    local postprocessor = BatchPostprocessor:new(vshard_router)
+    local postprocessor = BatchPostprocessor:new()
 
     local rows, errs, storages_info = call.map(vshard_router, CRUD_REPLACE_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,

--- a/crud/upsert_many.lua
+++ b/crud/upsert_many.lua
@@ -228,7 +228,7 @@ local function call_upsert_many_on_router(vshard_router, space_name, original_tu
         return nil, {err}, const.NEED_SCHEMA_RELOAD
     end
 
-    local postprocessor = BatchPostprocessor:new(vshard_router)
+    local postprocessor = BatchPostprocessor:new()
 
     local _, errs, storages_info = call.map(vshard_router, CRUD_UPSERT_MANY_FUNC_NAME, nil, {
         timeout = opts.timeout,

--- a/test/entrypoint/srv_say_hi/all.lua
+++ b/test/entrypoint/srv_say_hi/all.lua
@@ -39,18 +39,63 @@ return {
             local _, replicaset = next(replicasets)
             local replicaset_mt = getmetatable(replicaset)
 
-            for _, vshard_call_name in ipairs(vshard_call_names) do
-                local old_func = replicaset_mt.__index[vshard_call_name]
-                assert(old_func ~= nil, vshard_call_name)
+            if rawget(_G, 'vshard_call_originals') == nil then
+                rawset(_G, 'vshard_call_originals', {})
+            end
+            local originals = rawget(_G, 'vshard_call_originals')
 
-                replicaset_mt.__index[vshard_call_name] = function(...)
-                    local func_name = select(2, ...)
-                    if not string.startswith(func_name, 'vshard.') or func_name == 'vshard.storage.call' then
-                        table.insert(_G.vshard_calls, vshard_call_name)
+            for _, vshard_call_name in ipairs(vshard_call_names) do
+                if originals[vshard_call_name] == nil then
+                    local old_func = replicaset_mt.__index[vshard_call_name]
+                    assert(old_func ~= nil, vshard_call_name)
+
+                    originals[vshard_call_name] = old_func
+
+                    replicaset_mt.__index[vshard_call_name] = function(...)
+                        local func_name = select(2, ...)
+                        if func_name == nil
+                            or not string.startswith(func_name, 'vshard.')
+                            or func_name == 'vshard.storage.call' then
+                            table.insert(_G.vshard_calls, vshard_call_name)
+                        end
+                        return old_func(...)
                     end
-                    return old_func(...)
                 end
             end
+        end)
+
+        rawset(_G, 'unpatch_vshard_calls', function(vshard_call_names)
+            local vshard = require('vshard')
+
+            local replicasets = vshard.router.routeall()
+
+            local _, replicaset = next(replicasets)
+            local replicaset_mt = getmetatable(replicaset)
+
+            local originals = rawget(_G, 'vshard_call_originals')
+            if originals == nil then
+                return
+            end
+
+            for _, vshard_call_name in ipairs(vshard_call_names) do
+                local old_func = originals[vshard_call_name]
+                if old_func ~= nil then
+                    replicaset_mt.__index[vshard_call_name] = old_func
+                    originals[vshard_call_name] = nil
+                end
+            end
+        end)
+
+        rawset(_G, 'bucket_ref_rw', function(bucket_id)
+            local bucket_ref_unref = require('crud.common.sharding.bucket_ref_unref')
+
+            local ref_ok, err, unref = bucket_ref_unref.bucket_refrw(bucket_id)
+            if not ref_ok then
+                return nil, err
+            end
+
+            local res, err = unref(bucket_id)
+            return res, err
         end)
 
         if type(box.cfg) ~= 'table' then
@@ -61,7 +106,9 @@ return {
                 add_storage_execute('clear_vshard_calls')
                 add_storage_execute('say_hi_sleepily')
                 add_storage_execute('say_hi_politely')
+                add_storage_execute('bucket_ref_rw')
                 add_storage_execute('patch_vshard_calls')
+                add_storage_execute('unpatch_vshard_calls')
                 add_storage_execute('non_existent_func')
             end)()
         end

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -922,6 +922,32 @@ function helpers.start_tarantool3_cluster(g, cfg)
     g.cluster:start()
 end
 
+function helpers.set_safe_mode(cluster, is_enabled)
+    local safe_mode_func = '_crud.rebalance_safe_mode_disable'
+    if is_enabled then
+        safe_mode_func = '_crud.rebalance_safe_mode_enable'
+    end
+    helpers.call_on_storages(cluster, function(server)
+        server.net_box:eval([[
+            box.schema.space.create('_crud_settings_local', {
+                engine = 'memtx',
+                format = {
+                    { name = 'key', type = 'string' },
+                    { name = 'value', type = 'any' },
+                },
+                is_local = true,
+                if_not_exists = true,
+            })
+            box.space._crud_settings_local:create_index('primary', { parts = { 'key' }, if_not_exists = true })
+        ]])
+        t.helpers.retrying(
+                {timeout = 60, delay = 0.1},
+                server.call,
+                server, safe_mode_func
+        )
+    end)
+end
+
 function helpers.start_cluster(g, cartridge_cfg, vshard_cfg, tarantool3_cluster_cfg, opts)
     checks('table', '?table', '?table', '?table', {
         wait_crud_is_ready = '?boolean',
@@ -983,29 +1009,7 @@ function helpers.start_cluster(g, cartridge_cfg, vshard_cfg, tarantool3_cluster_
     end
 
     if g.params and g.params.safe_mode ~= nil then
-        local safe_mode_func = '_crud.rebalance_safe_mode_disable'
-        if g.params.safe_mode then
-            safe_mode_func = '_crud.rebalance_safe_mode_enable'
-        end
-        helpers.call_on_storages(g.cluster, function(server)
-            server.net_box:eval([[
-                box.schema.space.create('_crud_settings_local', {
-                    engine = 'memtx',
-                    format = {
-                        { name = 'key', type = 'string' },
-                        { name = 'value', type = 'any' },
-                    },
-                    is_local = true,
-                    if_not_exists = true,
-                })
-                box.space._crud_settings_local:create_index('primary', { parts = { 'key' }, if_not_exists = true })
-            ]])
-            t.helpers.retrying(
-                    {timeout = 60, delay = 0.1},
-                    server.call,
-                    server, safe_mode_func
-            )
-        end)
+        helpers.set_safe_mode(g.cluster, g.params.safe_mode)
     end
 end
 
@@ -1312,7 +1316,7 @@ function helpers.schema_compatibility(schema)
 end
 
 function helpers.string_replace(base, old_fragment, new_fragment)
-    local i, j = base:find(old_fragment)
+    local i, j = base:find(old_fragment, 1, true)
 
     if i == nil then
         return base
@@ -1332,20 +1336,15 @@ function helpers.string_replace(base, old_fragment, new_fragment)
 end
 
 function helpers.assert_str_contains_pattern_with_replicaset_id(str, pattern)
-    local uuid_pattern = "%w+%-0000%-0000%-0000%-00000000000%d"
-    local name_pattern = "s%-%d" -- All existing test clusters use this pattern, but it may change in the future.
+    -- A replicaset id is either a UUID or a name, depending on the vshard
+    -- identification mode.
+    local id_pattern = "[%w%-_]+"
 
-    local found = false
-    for _, id_pattern in pairs({uuid_pattern, name_pattern}) do
-        -- pattern is expected to be like "Failed for [replicaset_id]".
-        local full_pattern = helpers.string_replace('[replicaset_id]', id_pattern)
-        if str:find(full_pattern) ~= nil then
-            found = true
-            break
-        end
-    end
+    -- pattern is expected to be like "Failed for [replicaset_id]".
+    local full_pattern = helpers.string_replace(pattern, '[replicaset_id]', id_pattern)
 
-    t.assert(found, ("string %q does not contain pattern %q"):format(str, pattern))
+    t.assert(str:find(full_pattern) ~= nil,
+        ("string %q does not contain pattern %q"):format(str, pattern))
 end
 
 function helpers.prepare_ordered_data(g, space, expected_objects, bucket_id, order_condition)

--- a/test/integration/double_buckets_test.lua
+++ b/test/integration/double_buckets_test.lua
@@ -28,6 +28,18 @@ local function balance_cluster(g)
     end
 end
 
+-- Returns a replicaset name if it is used as a sharding key, otherwise
+-- returns a replicaset UUID.
+local function get_replicaset_id(server)
+    return server:exec(function()
+        local name = box.info.replicaset.name
+        if name == box.NULL then
+            name = box.info.replicaset.uuid
+        end
+        return name
+    end)
+end
+
 local pgroup_duplicates = t.group('double_buckets_duplicates', helpers.backend_matrix({
     {engine = 'memtx', operation = 'replace'},
     {engine = 'memtx', operation = 'insert'},
@@ -321,4 +333,193 @@ pgroup_not_applied.test_not_applied = function(g)
         not_applied_operations[g.params.operation].check_applied(res.rows, applied_ids)
         not_applied_operations[g.params.operation].check_not_applied(not_applied_ids)
     end
+end
+
+local function restart_storage(g, server)
+    server:stop()
+    server:start()
+    server:wait_for_rw()
+
+    if g.params.backend == helpers.backend.VSHARD then
+        local bootstrap_key = 'uuid'
+        if type(g.params.backend_cfg) == 'table'
+            and g.params.backend_cfg.identification_mode == 'name_as_key' then
+            bootstrap_key = 'name'
+        end
+
+        server:exec(function(cfg, bootstrap_key)
+            require('vshard.storage').cfg(cfg, box.info[bootstrap_key])
+            require('crud').init_storage()
+        end, {g.cfg, bootstrap_key})
+    end
+end
+
+local pgroup_transfers = t.group('double_buckets_transfers', helpers.backend_matrix({
+    {engine = 'memtx', safe_mode = false},
+}, {skip_safe_mode = true}))
+
+pgroup_transfers.before_all(function(g)
+    helpers.start_default_cluster(g, 'srv_simple_operations')
+    wait_balance(g, 1500, 1500)
+end)
+
+pgroup_transfers.after_all(function(g)
+    helpers.stop_cluster(g.cluster, g.params.backend)
+end)
+
+pgroup_transfers.after_each(function(g)
+    helpers.truncate_space_on_cluster(g.cluster, 'customers')
+
+    helpers.set_safe_mode(g.cluster, false)
+end)
+
+--
+-- Once the source became SENDING (READONLY since vshard 0.1.41),
+-- bucket_refrw() reported its destination and CRUD retried there directly.
+-- The destination must not accept that retry before bucket_recv() created
+-- the bucket as READONLY/RECEIVING.
+--
+pgroup_transfers.test_delete_before_bucket_receive = function(g)
+    t.skip_if(not utils.tarantool_version_at_least(3, 1),
+        'test implemented only for 3.1 and greater'
+    )
+
+    local source = g.cluster:server('s1-master')
+    local destination = g.cluster:server('s2-master')
+
+    -- Create the tuple.
+    local tuple_id = 8909
+    local bucket_id = source:exec(function(id)
+        local active = require('vshard.consts').BUCKET.ACTIVE
+        local bucket = box.space._bucket.index.status:min({active})
+        assert(bucket ~= nil)
+        box.space.customers:replace({id, bucket.id, 'A', 42})
+        return bucket.id
+    end, {tuple_id})
+
+    -- Populate the router cache with the source replicaset.
+    local get_result, get_err = g.router:call('crud.get', {
+        'customers', {tuple_id}, {bucket_id = bucket_id, mode = 'write'}})
+    t.assert_equals(get_err, nil)
+    t.assert_equals(#get_result.rows, 1)
+
+    -- Start sending the bucket.
+    destination:exec(function()
+        require('vshard').storage.internal.errinj.ERRINJ_RECEIVE_DELAY = true
+    end)
+    local destination_id = get_replicaset_id(destination)
+    -- Since vshard 0.1.41 a transfer starts in READONLY instead of SENDING,
+    -- but the SENDING is kept for compatibility with older versions.
+    local expected_status = require('vshard.consts').BUCKET.SENDING
+
+    source:exec(function(bucket_id, destination_id, expected_status)
+        local t = require('luatest')
+        local fiber = require('fiber')
+        local vshard = require('vshard')
+        rawset(_G, 'send_fiber', fiber.new(function()
+            return vshard.storage.bucket_send(bucket_id, destination_id)
+        end))
+        _G.send_fiber:set_joinable(true)
+        t.helpers.retrying({timeout = 15}, function()
+            t.assert_equals(box.space._bucket:get({bucket_id}).status,
+                expected_status)
+        end)
+        -- Safe mode is enabled.
+        t.assert(rawget(_G, '_crud').rebalance_safe_mode_status())
+    end, {bucket_id, destination_id, expected_status})
+
+    -- But destination doesn't have it yet.
+    destination:exec(function(bucket_id) local t = require('luatest')
+        t.assert_not(box.space._bucket:get({bucket_id}))
+    end, {bucket_id})
+
+    --
+    -- The sender was in safe mode, it redirected the router to the node,
+    -- which was not in safe mode yet: it hadn't received the bucket yet,
+    -- but the request was done anyway, even without the bucket.
+    --
+    local delete_result, delete_err = g.router:call('crud.delete', {
+        'customers', {tuple_id}, {bucket_id = bucket_id, timeout = 1},
+    })
+
+    -- delete should not succeed.
+    t.assert(delete_err ~= nil, ('delete succeeded with result %s, but ' ..
+        'tuple remained on destination'):format(json.encode(delete_result)))
+    t.assert_str_contains(delete_err.err, "TRANSFER_IS_IN_PROGRESS")
+
+    destination:exec(function()
+        require('vshard').storage.internal.errinj.ERRINJ_RECEIVE_DELAY = false
+    end)
+    source:exec(function()
+        local t = require('luatest')
+        local fiber_ok, status, err = _G.send_fiber:join()
+        t.assert(fiber_ok, status)
+        t.assert(status, err)
+    end)
+
+    destination:exec(function(tuple_id)
+        local t = require('luatest')
+        t.assert(box.space.customers:get({tuple_id}))
+    end, {tuple_id})
+end
+
+--
+-- Safe mode is enabled by an on_replace trigger on _bucket. The
+-- SENDING/RECEIVING rows replicate and fire the trigger on replicas too,
+-- so the replica stays in safe mode as well as the master. It is also
+-- persisted in the local settings space, so it stays enabled after a
+-- restart.
+--
+pgroup_transfers.test_safe_mode_replicates_and_persists = function(g)
+    t.skip_if(not utils.tarantool_version_at_least(3, 1),
+        'test implemented only for 3.1 and greater'
+    )
+    local source = g.cluster:server('s1-master')
+    local source_replica = g.cluster:server('s1-replica')
+    local destination = g.cluster:server('s2-master')
+
+    -- bucket_send requires both masters to be synced with their replicas
+    -- (is_bucket_in_sync is set by a background vshard fiber).
+    for _, server in ipairs({source, destination}) do
+        t.helpers.retrying({timeout = TIMEOUT}, function()
+            t.assert(server:exec(function()
+                return require('vshard').storage.internal.is_bucket_in_sync
+            end))
+        end)
+    end
+
+    -- Insert data into a bucket and explicitly send it to the second
+    -- replicaset.
+    local destination_id = get_replicaset_id(destination)
+
+    source:exec(function(destination_id)
+        local vshard = require('vshard')
+        local consts = require('vshard.consts')
+
+        local bucket = box.space._bucket.index.status:min({consts.BUCKET.ACTIVE})
+        assert(bucket ~= nil)
+
+        box.space.customers:replace({1, bucket.id, 'Danila', 40})
+
+        local ok, err = vshard.storage.bucket_send(bucket.id, destination_id)
+        assert(ok, err)
+    end, {destination_id})
+
+    -- Safe mode is enabled on the master and, via replication, on the
+    -- replica.
+    t.assert(source:exec(function()
+        return rawget(_G, '_crud').rebalance_safe_mode_status()
+    end))
+    t.helpers.retrying({timeout = TIMEOUT}, function()
+        t.assert(source_replica:exec(function()
+            return rawget(_G, '_crud').rebalance_safe_mode_status()
+        end))
+    end)
+
+    -- Safe mode is persisted in the local settings space and stays enabled
+    -- after the source is restarted.
+    restart_storage(g, source)
+    t.assert(source:exec(function()
+        return rawget(_G, '_crud').rebalance_safe_mode_status()
+    end))
 end

--- a/test/unit/call_test.lua
+++ b/test/unit/call_test.lua
@@ -16,7 +16,8 @@ pgroup.before_all(function(g)
     end
 
     -- patch vshard.router.call* functions
-    local vshard_call_names = {'callro', 'callbro', 'callre', 'callbre', 'callrw'}
+    local vshard_call_names = {'callro', 'callbro', 'callre', 'callbre', 'callrw',
+                               'update_master'}
     g.router:call('patch_vshard_calls', {vshard_call_names})
 end)
 
@@ -269,7 +270,7 @@ pgroup.test_any_vshard_call_timeout = function(g)
 end
 
 pgroup.before_test('test_any_vshard_call_fallback', function(g)
-    -- Mock callro to fail exactly once per replicaset.
+    -- Mock callro to fail permanently on a single replicaset.
     -- This guarantees that call.any triggers its fallback loop.
     g.router:eval([[
         local vshard = require('vshard')
@@ -280,17 +281,19 @@ pgroup.before_test('test_any_vshard_call_fallback', function(g)
         rawset(_G, '__original_callros', {})
         local originals = rawget(_G, '__original_callros')
 
+        local ids = {}
+        for replicaset_id in pairs(replicasets) do
+            table.insert(ids, replicaset_id)
+        end
+        table.sort(ids)
+        local broken_replicaset_id = ids[1]
+
         for replicaset_id, replicaset in pairs(replicasets) do
             originals[replicaset_id] = replicaset.callro
 
-            local calls_count = 0
-
-            replicaset.callro = function(self, ...)
-                calls_count = calls_count + 1
-                if calls_count == 1 then
+            if replicaset_id == broken_replicaset_id then
+                replicaset.callro = function(self, ...)
                     return nil, errors.new_class('ClientError'):new('Temporary failure')
-                else
-                    return originals[replicaset_id](self, ...)
                 end
             end
         end
@@ -327,4 +330,258 @@ pgroup.test_any_vshard_call_fallback = function(g)
     -- and uses the available fallback.
     t.assert_str_contains(results, 'HI, survivor!')
     t.assert_equals(err, nil)
+end
+
+local function is_vshard_backend(g)
+    return g.params.backend == helpers.backend.VSHARD
+end
+
+local function cfg_router_drop_masters(g)
+    g.router:exec(function(cfg)
+        local vshard = require('vshard')
+
+        for _, rs in pairs(cfg.sharding) do
+            rs.master = nil
+            for _, replica in pairs(rs.replicas) do
+                replica.master = nil
+            end
+        end
+        vshard.router.cfg(cfg)
+    end, {g.cfg})
+end
+
+local function cfg_router_move_masters_to_replicas(g)
+    g.router:exec(function(cfg)
+        local vshard = require('vshard')
+
+        -- The master is marked with 'master' in a static config and with
+        -- 'read_only = false' in the 'master = auto' one (test/vshard_helpers/vtest.lua).
+        for _, rs in pairs(cfg.sharding) do
+            local master_name
+            for replica_name, replica in pairs(rs.replicas) do
+                if replica.master or (replica.read_only ~= nil and not replica.read_only) then
+                    master_name = replica_name
+                    replica.master = nil
+                    break
+                end
+            end
+            for replica_name, replica in pairs(rs.replicas) do
+                if replica_name ~= master_name then
+                    replica.master = true
+                    break
+                end
+            end
+            rs.master = nil
+        end
+        vshard.router.cfg(cfg)
+    end, {g.cfg})
+end
+
+local function cfg_router_restore(g)
+    g.router:exec(function(cfg)
+        local vshard = require('vshard')
+        local fiber = require('fiber')
+
+        vshard.router.cfg(cfg)
+
+        -- The master search is asynchronous, but the next tests need masters.
+        local deadline = fiber.clock() + 10
+        while fiber.clock() < deadline do
+            local is_found = true
+            for _, rs in pairs(vshard.router.routeall()) do
+                if rs.master == nil then
+                    is_found = false
+                end
+            end
+            if is_found then
+                return
+            end
+            vshard.router.master_search_wakeup()
+            fiber.sleep(0.05)
+        end
+        error('masters are not found after the router cfg restore')
+    end, {g.cfg})
+end
+
+
+pgroup.before_test('test_single_retry_on_missing_master', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    -- The router cannot discover a bucket while the masters are gone, so the
+    -- route is cached in advance: router_cfg() keeps the route map.
+    g.router:exec(function()
+        require('vshard').router.static:route(1)
+    end)
+    cfg_router_drop_masters(g)
+    -- locate_master is patched and unpatched for this test only: with the
+    -- master = 'auto' backend config the background master search calls it
+    -- too, which would pollute the calls of other tests.
+    g.router:call('patch_vshard_calls', {{'locate_master'}})
+end)
+
+pgroup.after_test('test_single_retry_on_missing_master', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    g.router:call('unpatch_vshard_calls', {{'locate_master'}})
+    cfg_router_restore(g)
+end)
+
+pgroup.test_single_retry_on_missing_master = function(g)
+    t.skip_if(not is_vshard_backend(g),
+        'the router re-configuration is available on the vshard backend only')
+
+    g.clear_vshard_calls()
+    local results, err = g.router:eval([[
+        local vshard = require('vshard')
+        local call = require('crud.common.call')
+
+        return call.single(vshard.router.static, 1, 'say_hi_politely', {'Jonh'},
+            {mode = 'write'})
+    ]])
+
+    t.assert_equals(results, nil)
+    t.assert(err ~= nil)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
+    t.assert_str_contains(err.err, 'Master is not configured')
+
+    -- The master discovery is performed, but the config has no master at all:
+    -- nothing is found, so the call is not retried.
+    t.assert_equals(g.get_vshard_calls(), {'callrw', 'locate_master'})
+end
+
+pgroup.before_test('test_single_non_master_no_retry', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    -- The router cannot discover a bucket while the masters are gone, so the
+    -- route is cached in advance: router_cfg() keeps the route map.
+    g.router:exec(function()
+        require('vshard').router.static:route(1)
+    end)
+    helpers.set_safe_mode(g.cluster, true)
+    cfg_router_move_masters_to_replicas(g)
+end)
+
+pgroup.after_test('test_single_non_master_no_retry', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    cfg_router_restore(g)
+    helpers.set_safe_mode(g.cluster, g.params.safe_mode)
+end)
+
+pgroup.test_single_non_master_no_retry = function(g)
+    t.skip_if(not is_vshard_backend(g),
+        'the router re-configuration is available on the vshard backend only')
+
+    g.clear_vshard_calls()
+    local results, err = g.router:eval([[
+        local vshard = require('vshard')
+        local call = require('crud.common.call')
+
+        return call.single(vshard.router.static, 1, 'bucket_ref_rw', {1}, {mode = 'write'})
+    ]])
+
+    t.assert_equals(results, nil)
+    t.assert(err ~= nil)
+    helpers.assert_str_contains_pattern_with_replicaset_id(err.err, "Failed for [replicaset_id]")
+    t.assert_str_contains(err.err, 'NON_MASTER')
+
+    -- The master is updated, but the retry makes no sense: the master is
+    -- assigned to a replica until the configuration is changed.
+    t.assert_equals(g.get_vshard_calls(), {'callrw', 'update_master'})
+end
+
+pgroup.before_test('test_single_wrong_bucket_retry_with_reroute', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    helpers.set_safe_mode(g.cluster, true)
+end)
+
+pgroup.after_test('test_single_wrong_bucket_retry_with_reroute', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    helpers.set_safe_mode(g.cluster, g.params.safe_mode)
+end)
+
+pgroup.test_single_wrong_bucket_retry_with_reroute = function(g)
+    t.skip_if(not is_vshard_backend(g),
+        'the router re-configuration is available on the vshard backend only')
+
+    g.clear_vshard_calls()
+    local results, err = g.router:eval([[
+        local vshard = require('vshard')
+        local call = require('crud.common.call')
+
+        local bucket_count = ...
+
+        local router = vshard.router.static
+        local replicaset = router:route(1)
+        local bucket_id
+        for id = 1, bucket_count do
+            if router:route(id) ~= replicaset then
+                bucket_id = id
+                break
+            end
+        end
+        assert(bucket_id ~= nil, 'no bucket on another replicaset')
+
+        -- The call is routed by bucket 1, but the bucket ref is taken for a
+        -- bucket from another replicaset: the route is stale.
+        return call.single(vshard.router.static, 1, 'bucket_ref_rw', {bucket_id},
+            {mode = 'write'})
+    ]], {g.cfg.bucket_count})
+
+    t.assert_equals(err, nil)
+    t.assert_equals(results, true)
+
+    -- The bucket route is reset and the call is retried on the replicaset
+    -- the bucket is routed to now.
+    t.assert_equals(g.get_vshard_calls(), {'callrw', 'callrw'})
+end
+
+pgroup.before_test('test_map_retry_on_missing_master', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    cfg_router_drop_masters(g)
+    -- See the comment in before_test('test_single_retry_on_missing_master').
+    g.router:call('patch_vshard_calls', {{'locate_master'}})
+end)
+
+pgroup.after_test('test_map_retry_on_missing_master', function(g)
+    if not is_vshard_backend(g) then
+        return
+    end
+    g.router:call('unpatch_vshard_calls', {{'locate_master'}})
+    cfg_router_restore(g)
+end)
+
+pgroup.test_map_retry_on_missing_master = function(g)
+    t.skip_if(not is_vshard_backend(g),
+        'the router re-configuration is available on the vshard backend only')
+
+    g.clear_vshard_calls()
+    local results, errs = g.router:eval([[
+        local vshard = require('vshard')
+        local call = require('crud.common.call')
+
+        return call.map(vshard.router.static, 'say_hi_politely', {'Jonh'},
+            {mode = 'write'})
+    ]])
+
+    t.assert_equals(results, nil)
+    t.assert(errs ~= nil)
+    helpers.assert_str_contains_pattern_with_replicaset_id(errs.err, "Failed for [replicaset_id]")
+    t.assert_str_contains(errs.err, 'Master is not configured')
+
+    -- The requests are async, so vshard does not search for a master itself.
+    -- The master discovery is performed by crud, but the config has no master
+    -- at all: the search finds nothing, so the call is not retried.
+    -- The map call exits early on the first failed replicaset.
+    t.assert_equals(g.get_vshard_calls(), {'callrw', 'locate_master'})
 end


### PR DESCRIPTION
During rebalancing the source storage rejects a request with a bucket
ref error (e.g. TRANSFER_IS_IN_PROGRESS) and reports the transfer
destination. The router followed this redirect and retried the request
directly on the destination.

The destination, however, may not have received the bucket yet: it has
neither the _bucket record nor the data, and it is still in fast mode,
so no bucket ownership check is performed. The request was applied
against an empty space and acknowledged to the client. Once
bucket_recv() delivered the data, the cluster state diverged from the
acknowledged result: a deleted tuple reappeared, and the final result
of replace/update/upsert could differ from what was acknowledged.

The router no longer follows the destination reported by the error:
the bucket route cache is reset and the retry target is re-discovered
via vshard discovery, so a request is applied only on the replicaset
that actually holds the bucket.

A failed request is retried at most once and only after a recovery
action: the master is located on MISSING_MASTER, the cached master is
updated on NON_MASTER, the bucket route is reset on bucket ref errors
and the retry is re-routed by the bucket id. Other errors are returned
to the caller without a retry: the old code retried them blindly,
which silently doubled the effective request timeout. The retry is
given only the time left before the request deadline. Map requests are
not recovered at all: they are async, so storage errors arrive later,
in the future payload (see #513).

The rebalance safe mode also missed the start of a transfer on vshard
0.1.41+, where the bucket status is UPDATEd to READONLY instead of
being REPLACEd with SENDING, so safe mode was not enabled during
rebalancing and writes were not protected with bucket refs. Now the
READONLY update enables the safe mode as well.

Closes #509