### PR TITLE
release 1.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7.6] - 31-08-26
+
 ### Changed
 * Update `vshard` dependency to [0.1.42](https://github.com/tarantool/vshard/releases/tag/0.1.42).
 

--- a/crud/version.lua
+++ b/crud/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.7.5'
+return '1.7.6'


### PR DESCRIPTION
Changed
* Update `vshard` dependency to [0.1.42](https://github.com/tarantool/vshard/releases/tag/0.1.42).

Fixed
* Fix consistency violation during rebalancing: a request could be retried on a
  storage that did not own the bucket yet, so a read returned no data and a
  write went to the wrong replicaset (#509).
* Stop retrying requests blindly: a request is retried only if the router has
  recovered from the error, and a retry never runs past the original timeout —
  before, a request could take up to twice as long as requested.
